### PR TITLE
Fix CI: Update iOS Simulator to 18.5

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        lfs: true
       
     - name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1


### PR DESCRIPTION
## Summary
- Update iOS Simulator version from 18.4 to 18.5 in CI workflow
- iOS 18.4 is no longer available on GitHub Actions macOS 15 runners
- iOS 18.5 is the latest stable iOS 18.x version available

## Test plan
- [ ] CI build passes with the new simulator version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the iOS CI workflow to use the latest available simulator and ensure large files are fetched.
> 
> - Bumps simulator destination from `iOS 18.4` to `iOS 18.5` in `Build` and `Test` steps
> - Enables Git LFS during `actions/checkout` to fetch large assets needed for builds
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0554fc1a0c1ea17ce4bd712747f6a48aa667c6f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->