### PR TITLE
Watch countdown fix, type-safe Watch protocol, camera rotation fix

### DIFF
--- a/RemoteCam/CameraViewController.swift
+++ b/RemoteCam/CameraViewController.swift
@@ -388,20 +388,38 @@ public class CameraViewController: UIViewController,
     }
 
     public override func willAnimateRotation(to toInterfaceOrientation: UIInterfaceOrientation, duration: TimeInterval) {
+        // Deprecated and not called on modern iOS; kept for any OS version that
+        // still invokes it. `viewWillTransition` below is the live rotation path —
+        // both funnel into the same idempotent orientation update.
         orientation = getOrientation()
         self.rotateCameraToOrientation(orientation: toInterfaceOrientation)
     }
 
     public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        // iOS can drop the torch when the capture pipeline reconfigures during rotation.
-        // `viewWillTransition` fires reliably on modern iOS (unlike the deprecated
-        // `willAnimateRotation`), so restore the user's torch intent once the rotation
-        // settles and re-sync the Watch, which would otherwise keep a stale torch state.
-        coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+        coordinator.animate(alongsideTransition: { [weak self] _ in
+            guard let self else { return }
+            // Mid-transition the window scene already reports the TARGET
+            // orientation (getOrientation()'s foreground-scene lookup would still
+            // return the old one if read before the animation block).
+            let newOrientation = self.view.window?.windowScene?.interfaceOrientation ?? getOrientation()
+            self.orientation = newOrientation
+            self.rotateCameraToOrientation(orientation: newOrientation)
+        }, completion: { [weak self] _ in
+            // iOS can drop the torch when the capture pipeline reconfigures during
+            // rotation, so restore the user's torch intent once the rotation
+            // settles and re-sync the Watch, which would otherwise keep a stale
+            // torch state.
             self?.applyDesiredTorch()
             self?.syncTorchToWatch()
-        }
+        })
+    }
+
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        // The preview is a bare CALayer — it does not track the view through
+        // rotation or layout changes, so keep it glued to the current bounds.
+        captureVideoPreviewLayer?.frame = view.bounds
     }
 
     func setupCamera() {

--- a/RemoteCam/FlatBufferSchemas.fbs
+++ b/RemoteCam/FlatBufferSchemas.fbs
@@ -247,8 +247,36 @@ table WatchCommand {
     mode: RecordingModeEnum;         // payload for SetMode
 }
 
+// Why the phone can or can't capture right now. Unknown = no signal yet —
+// the Watch treats it as "connecting", never as ready.
+enum WatchReadiness : byte {
+    Unknown = 0,
+    Ready = 1,
+    PhoneBackgrounded = 2,   // app backgrounded / device locked — camera can't run
+    NotInWatchMode = 3       // phone left the Watch Remote screen
+}
+
+// One-shot capture events, piggybacked on a state push. Unknown = no event.
+enum WatchEventType : byte {
+    Unknown = 0,
+    PhotoTaken = 1,
+    PhotoError = 2,
+    RecordingStarted = 3,
+    RecordingStopped = 4,
+    RecordingFailed = 5,
+    MicrophoneDenied = 6,
+    Busy = 7,
+    BusyRecording = 8,
+    SendFailed = 9           // Watch-local (command never reached the phone); not sent on the wire
+}
+
+// Retyped 2026-07-01 (pre-release, no wire compatibility to keep): the old
+// last_event string smuggled events, countdown ticks, and readiness reasons
+// through one field. Each concept now has its own typed field.
 table WatchCameraState {
-    is_ready: bool;
+    readiness: WatchReadiness;
+    event: WatchEventType;
+    countdown_remaining_secs: int;   // > 0 = live self-timer; authoritative in every snapshot
     current_zoom_factor: double;
     min_zoom_factor: double;
     max_zoom_factor: double;
@@ -256,14 +284,11 @@ table WatchCameraState {
     current_mode: RecordingModeEnum;
     current_lens_type: CameraLensType;
     available_lens_types: [CameraLensType];
-    is_flash_enabled: bool;
+    flash_mode: FlashMode;
     is_torch_enabled: bool;
     zoom_stops: [double];
     wide_angle_zoom_factor: double;
-    last_event: string;
-    // Appended fields only below this line (FlatBuffers schema evolution).
     state_epoch_ms: uint64;          // ordering between live messages and applicationContext
-    flash_mode: FlashMode;           // tri-state truth; is_flash_enabled kept for compatibility
 }
 
 // Transport-level acknowledgment for a Watch command: confirms the iPhone

--- a/RemoteCam/FlatBufferSchemas_generated.swift
+++ b/RemoteCam/FlatBufferSchemas_generated.swift
@@ -202,6 +202,40 @@ public enum RemoteShutter_WatchCommandAction: Int8, Enum, Verifiable {
 }
 
 
+public enum RemoteShutter_WatchReadiness: Int8, Enum, Verifiable {
+  public typealias T = Int8
+  public static var byteSize: Int { return MemoryLayout<Int8>.size }
+  public var value: Int8 { return self.rawValue }
+  case unknown = 0
+  case ready = 1
+  case phonebackgrounded = 2
+  case notinwatchmode = 3
+
+  public static var max: RemoteShutter_WatchReadiness { return .notinwatchmode }
+  public static var min: RemoteShutter_WatchReadiness { return .unknown }
+}
+
+
+public enum RemoteShutter_WatchEventType: Int8, Enum, Verifiable {
+  public typealias T = Int8
+  public static var byteSize: Int { return MemoryLayout<Int8>.size }
+  public var value: Int8 { return self.rawValue }
+  case unknown = 0
+  case phototaken = 1
+  case photoerror = 2
+  case recordingstarted = 3
+  case recordingstopped = 4
+  case recordingfailed = 5
+  case microphonedenied = 6
+  case busy = 7
+  case busyrecording = 8
+  case sendfailed = 9
+
+  public static var max: RemoteShutter_WatchEventType { return .sendfailed }
+  public static var min: RemoteShutter_WatchEventType { return .unknown }
+}
+
+
 public enum RemoteShutter_WatchAckStatus: Int8, Enum, Verifiable {
   public typealias T = Int8
   public static var byteSize: Int { return MemoryLayout<Int8>.size }
@@ -1136,26 +1170,28 @@ public struct RemoteShutter_WatchCameraState: FlatBufferObject, Verifiable {
   public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
   private enum VTOFFSET: VOffset {
-    case isReady = 4
-    case currentZoomFactor = 6
-    case minZoomFactor = 8
-    case maxZoomFactor = 10
-    case isRecording = 12
-    case currentMode = 14
-    case currentLensType = 16
-    case availableLensTypes = 18
-    case isFlashEnabled = 20
-    case isTorchEnabled = 22
-    case zoomStops = 24
-    case wideAngleZoomFactor = 26
-    case lastEvent = 28
-    case stateEpochMs = 30
-    case flashMode = 32
+    case readiness = 4
+    case event = 6
+    case countdownRemainingSecs = 8
+    case currentZoomFactor = 10
+    case minZoomFactor = 12
+    case maxZoomFactor = 14
+    case isRecording = 16
+    case currentMode = 18
+    case currentLensType = 20
+    case availableLensTypes = 22
+    case flashMode = 24
+    case isTorchEnabled = 26
+    case zoomStops = 28
+    case wideAngleZoomFactor = 30
+    case stateEpochMs = 32
     var v: Int32 { Int32(self.rawValue) }
     var p: VOffset { self.rawValue }
   }
 
-  public var isReady: Bool { let o = _accessor.offset(VTOFFSET.isReady.v); return o == 0 ? false : _accessor.readBuffer(of: Bool.self, at: o) }
+  public var readiness: RemoteShutter_WatchReadiness { let o = _accessor.offset(VTOFFSET.readiness.v); return o == 0 ? .unknown : RemoteShutter_WatchReadiness(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .unknown }
+  public var event: RemoteShutter_WatchEventType { let o = _accessor.offset(VTOFFSET.event.v); return o == 0 ? .unknown : RemoteShutter_WatchEventType(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .unknown }
+  public var countdownRemainingSecs: Int32 { let o = _accessor.offset(VTOFFSET.countdownRemainingSecs.v); return o == 0 ? 0 : _accessor.readBuffer(of: Int32.self, at: o) }
   public var currentZoomFactor: Double { let o = _accessor.offset(VTOFFSET.currentZoomFactor.v); return o == 0 ? 0.0 : _accessor.readBuffer(of: Double.self, at: o) }
   public var minZoomFactor: Double { let o = _accessor.offset(VTOFFSET.minZoomFactor.v); return o == 0 ? 0.0 : _accessor.readBuffer(of: Double.self, at: o) }
   public var maxZoomFactor: Double { let o = _accessor.offset(VTOFFSET.maxZoomFactor.v); return o == 0 ? 0.0 : _accessor.readBuffer(of: Double.self, at: o) }
@@ -1165,20 +1201,18 @@ public struct RemoteShutter_WatchCameraState: FlatBufferObject, Verifiable {
   public var hasAvailableLensTypes: Bool { let o = _accessor.offset(VTOFFSET.availableLensTypes.v); return o == 0 ? false : true }
   public var availableLensTypesCount: Int32 { let o = _accessor.offset(VTOFFSET.availableLensTypes.v); return o == 0 ? 0 : _accessor.vector(count: o) }
   public func availableLensTypes(at index: Int32) -> RemoteShutter_CameraLensType? { let o = _accessor.offset(VTOFFSET.availableLensTypes.v); return o == 0 ? RemoteShutter_CameraLensType.wideangle : RemoteShutter_CameraLensType(rawValue: _accessor.directRead(of: Int8.self, offset: _accessor.vector(at: o) + index * 1)) }
-  public var isFlashEnabled: Bool { let o = _accessor.offset(VTOFFSET.isFlashEnabled.v); return o == 0 ? false : _accessor.readBuffer(of: Bool.self, at: o) }
+  public var flashMode: RemoteShutter_FlashMode { let o = _accessor.offset(VTOFFSET.flashMode.v); return o == 0 ? .off : RemoteShutter_FlashMode(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .off }
   public var isTorchEnabled: Bool { let o = _accessor.offset(VTOFFSET.isTorchEnabled.v); return o == 0 ? false : _accessor.readBuffer(of: Bool.self, at: o) }
   public var hasZoomStops: Bool { let o = _accessor.offset(VTOFFSET.zoomStops.v); return o == 0 ? false : true }
   public var zoomStopsCount: Int32 { let o = _accessor.offset(VTOFFSET.zoomStops.v); return o == 0 ? 0 : _accessor.vector(count: o) }
   public func zoomStops(at index: Int32) -> Double { let o = _accessor.offset(VTOFFSET.zoomStops.v); return o == 0 ? 0 : _accessor.directRead(of: Double.self, offset: _accessor.vector(at: o) + index * 8) }
   public var zoomStops: [Double] { return _accessor.getVector(at: VTOFFSET.zoomStops.v) ?? [] }
   public var wideAngleZoomFactor: Double { let o = _accessor.offset(VTOFFSET.wideAngleZoomFactor.v); return o == 0 ? 0.0 : _accessor.readBuffer(of: Double.self, at: o) }
-  public var lastEvent: String? { let o = _accessor.offset(VTOFFSET.lastEvent.v); return o == 0 ? nil : _accessor.string(at: o) }
-  public var lastEventSegmentArray: [UInt8]? { return _accessor.getVector(at: VTOFFSET.lastEvent.v) }
   public var stateEpochMs: UInt64 { let o = _accessor.offset(VTOFFSET.stateEpochMs.v); return o == 0 ? 0 : _accessor.readBuffer(of: UInt64.self, at: o) }
-  public var flashMode: RemoteShutter_FlashMode { let o = _accessor.offset(VTOFFSET.flashMode.v); return o == 0 ? .off : RemoteShutter_FlashMode(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .off }
   public static func startWatchCameraState(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 15) }
-  public static func add(isReady: Bool, _ fbb: inout FlatBufferBuilder) { fbb.add(element: isReady, def: false,
-   at: VTOFFSET.isReady.p) }
+  public static func add(readiness: RemoteShutter_WatchReadiness, _ fbb: inout FlatBufferBuilder) { fbb.add(element: readiness.rawValue, def: 0, at: VTOFFSET.readiness.p) }
+  public static func add(event: RemoteShutter_WatchEventType, _ fbb: inout FlatBufferBuilder) { fbb.add(element: event.rawValue, def: 0, at: VTOFFSET.event.p) }
+  public static func add(countdownRemainingSecs: Int32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: countdownRemainingSecs, def: 0, at: VTOFFSET.countdownRemainingSecs.p) }
   public static func add(currentZoomFactor: Double, _ fbb: inout FlatBufferBuilder) { fbb.add(element: currentZoomFactor, def: 0.0, at: VTOFFSET.currentZoomFactor.p) }
   public static func add(minZoomFactor: Double, _ fbb: inout FlatBufferBuilder) { fbb.add(element: minZoomFactor, def: 0.0, at: VTOFFSET.minZoomFactor.p) }
   public static func add(maxZoomFactor: Double, _ fbb: inout FlatBufferBuilder) { fbb.add(element: maxZoomFactor, def: 0.0, at: VTOFFSET.maxZoomFactor.p) }
@@ -1187,19 +1221,18 @@ public struct RemoteShutter_WatchCameraState: FlatBufferObject, Verifiable {
   public static func add(currentMode: RemoteShutter_RecordingModeEnum, _ fbb: inout FlatBufferBuilder) { fbb.add(element: currentMode.rawValue, def: 0, at: VTOFFSET.currentMode.p) }
   public static func add(currentLensType: RemoteShutter_CameraLensType, _ fbb: inout FlatBufferBuilder) { fbb.add(element: currentLensType.rawValue, def: 0, at: VTOFFSET.currentLensType.p) }
   public static func addVectorOf(availableLensTypes: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: availableLensTypes, at: VTOFFSET.availableLensTypes.p) }
-  public static func add(isFlashEnabled: Bool, _ fbb: inout FlatBufferBuilder) { fbb.add(element: isFlashEnabled, def: false,
-   at: VTOFFSET.isFlashEnabled.p) }
+  public static func add(flashMode: RemoteShutter_FlashMode, _ fbb: inout FlatBufferBuilder) { fbb.add(element: flashMode.rawValue, def: 0, at: VTOFFSET.flashMode.p) }
   public static func add(isTorchEnabled: Bool, _ fbb: inout FlatBufferBuilder) { fbb.add(element: isTorchEnabled, def: false,
    at: VTOFFSET.isTorchEnabled.p) }
   public static func addVectorOf(zoomStops: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: zoomStops, at: VTOFFSET.zoomStops.p) }
   public static func add(wideAngleZoomFactor: Double, _ fbb: inout FlatBufferBuilder) { fbb.add(element: wideAngleZoomFactor, def: 0.0, at: VTOFFSET.wideAngleZoomFactor.p) }
-  public static func add(lastEvent: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: lastEvent, at: VTOFFSET.lastEvent.p) }
   public static func add(stateEpochMs: UInt64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: stateEpochMs, def: 0, at: VTOFFSET.stateEpochMs.p) }
-  public static func add(flashMode: RemoteShutter_FlashMode, _ fbb: inout FlatBufferBuilder) { fbb.add(element: flashMode.rawValue, def: 0, at: VTOFFSET.flashMode.p) }
   public static func endWatchCameraState(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createWatchCameraState(
     _ fbb: inout FlatBufferBuilder,
-    isReady: Bool = false,
+    readiness: RemoteShutter_WatchReadiness = .unknown,
+    event: RemoteShutter_WatchEventType = .unknown,
+    countdownRemainingSecs: Int32 = 0,
     currentZoomFactor: Double = 0.0,
     minZoomFactor: Double = 0.0,
     maxZoomFactor: Double = 0.0,
@@ -1207,16 +1240,16 @@ public struct RemoteShutter_WatchCameraState: FlatBufferObject, Verifiable {
     currentMode: RemoteShutter_RecordingModeEnum = .unknown,
     currentLensType: RemoteShutter_CameraLensType = .wideangle,
     availableLensTypesVectorOffset availableLensTypes: Offset = Offset(),
-    isFlashEnabled: Bool = false,
+    flashMode: RemoteShutter_FlashMode = .off,
     isTorchEnabled: Bool = false,
     zoomStopsVectorOffset zoomStops: Offset = Offset(),
     wideAngleZoomFactor: Double = 0.0,
-    lastEventOffset lastEvent: Offset = Offset(),
-    stateEpochMs: UInt64 = 0,
-    flashMode: RemoteShutter_FlashMode = .off
+    stateEpochMs: UInt64 = 0
   ) -> Offset {
     let __start = RemoteShutter_WatchCameraState.startWatchCameraState(&fbb)
-    RemoteShutter_WatchCameraState.add(isReady: isReady, &fbb)
+    RemoteShutter_WatchCameraState.add(readiness: readiness, &fbb)
+    RemoteShutter_WatchCameraState.add(event: event, &fbb)
+    RemoteShutter_WatchCameraState.add(countdownRemainingSecs: countdownRemainingSecs, &fbb)
     RemoteShutter_WatchCameraState.add(currentZoomFactor: currentZoomFactor, &fbb)
     RemoteShutter_WatchCameraState.add(minZoomFactor: minZoomFactor, &fbb)
     RemoteShutter_WatchCameraState.add(maxZoomFactor: maxZoomFactor, &fbb)
@@ -1224,19 +1257,19 @@ public struct RemoteShutter_WatchCameraState: FlatBufferObject, Verifiable {
     RemoteShutter_WatchCameraState.add(currentMode: currentMode, &fbb)
     RemoteShutter_WatchCameraState.add(currentLensType: currentLensType, &fbb)
     RemoteShutter_WatchCameraState.addVectorOf(availableLensTypes: availableLensTypes, &fbb)
-    RemoteShutter_WatchCameraState.add(isFlashEnabled: isFlashEnabled, &fbb)
+    RemoteShutter_WatchCameraState.add(flashMode: flashMode, &fbb)
     RemoteShutter_WatchCameraState.add(isTorchEnabled: isTorchEnabled, &fbb)
     RemoteShutter_WatchCameraState.addVectorOf(zoomStops: zoomStops, &fbb)
     RemoteShutter_WatchCameraState.add(wideAngleZoomFactor: wideAngleZoomFactor, &fbb)
-    RemoteShutter_WatchCameraState.add(lastEvent: lastEvent, &fbb)
     RemoteShutter_WatchCameraState.add(stateEpochMs: stateEpochMs, &fbb)
-    RemoteShutter_WatchCameraState.add(flashMode: flashMode, &fbb)
     return RemoteShutter_WatchCameraState.endWatchCameraState(&fbb, start: __start)
   }
 
   public static func verify<T>(_ verifier: inout Verifier, at position: Int, of type: T.Type) throws where T: Verifiable {
     var _v = try verifier.visitTable(at: position)
-    try _v.visit(field: VTOFFSET.isReady.p, fieldName: "isReady", required: false, type: Bool.self)
+    try _v.visit(field: VTOFFSET.readiness.p, fieldName: "readiness", required: false, type: RemoteShutter_WatchReadiness.self)
+    try _v.visit(field: VTOFFSET.event.p, fieldName: "event", required: false, type: RemoteShutter_WatchEventType.self)
+    try _v.visit(field: VTOFFSET.countdownRemainingSecs.p, fieldName: "countdownRemainingSecs", required: false, type: Int32.self)
     try _v.visit(field: VTOFFSET.currentZoomFactor.p, fieldName: "currentZoomFactor", required: false, type: Double.self)
     try _v.visit(field: VTOFFSET.minZoomFactor.p, fieldName: "minZoomFactor", required: false, type: Double.self)
     try _v.visit(field: VTOFFSET.maxZoomFactor.p, fieldName: "maxZoomFactor", required: false, type: Double.self)
@@ -1244,13 +1277,11 @@ public struct RemoteShutter_WatchCameraState: FlatBufferObject, Verifiable {
     try _v.visit(field: VTOFFSET.currentMode.p, fieldName: "currentMode", required: false, type: RemoteShutter_RecordingModeEnum.self)
     try _v.visit(field: VTOFFSET.currentLensType.p, fieldName: "currentLensType", required: false, type: RemoteShutter_CameraLensType.self)
     try _v.visit(field: VTOFFSET.availableLensTypes.p, fieldName: "availableLensTypes", required: false, type: ForwardOffset<Vector<RemoteShutter_CameraLensType, RemoteShutter_CameraLensType>>.self)
-    try _v.visit(field: VTOFFSET.isFlashEnabled.p, fieldName: "isFlashEnabled", required: false, type: Bool.self)
+    try _v.visit(field: VTOFFSET.flashMode.p, fieldName: "flashMode", required: false, type: RemoteShutter_FlashMode.self)
     try _v.visit(field: VTOFFSET.isTorchEnabled.p, fieldName: "isTorchEnabled", required: false, type: Bool.self)
     try _v.visit(field: VTOFFSET.zoomStops.p, fieldName: "zoomStops", required: false, type: ForwardOffset<Vector<Double, Double>>.self)
     try _v.visit(field: VTOFFSET.wideAngleZoomFactor.p, fieldName: "wideAngleZoomFactor", required: false, type: Double.self)
-    try _v.visit(field: VTOFFSET.lastEvent.p, fieldName: "lastEvent", required: false, type: ForwardOffset<String>.self)
     try _v.visit(field: VTOFFSET.stateEpochMs.p, fieldName: "stateEpochMs", required: false, type: UInt64.self)
-    try _v.visit(field: VTOFFSET.flashMode.p, fieldName: "flashMode", required: false, type: RemoteShutter_FlashMode.self)
     _v.finish()
   }
 }

--- a/RemoteCam/RemoteCamSession.swift
+++ b/RemoteCam/RemoteCamSession.swift
@@ -53,8 +53,14 @@ public class RemoteCamSession: ViewCtrlActor<DeviceScannerViewController> {
 
     /// Whether the phone is backgrounded/locked (camera can't capture). Injected so
     /// tests can force either state; production reads the shared lifecycle monitor.
-    /// This is the sole input that decides `WatchCameraStateSnapshot.isReady`.
+    /// This is the sole input that decides `WatchCameraStateSnapshot.readiness`.
     var isPhoneBackgrounded: () -> Bool = { AppActivityMonitor.shared.isBackgrounded }
+
+    /// Seconds left on a Watch-initiated self-timer (0 = none). Mirrored from the
+    /// `TimerCountdown` ticks so EVERY watch state push carries the live countdown —
+    /// countdown is snapshot state, never a transient event a Watch could miss.
+    /// Actor-confined: only touched inside message handlers.
+    var watchCountdownRemaining: Int32 = 0
 
     /// Photo-library write seam — tests record the data instead of hitting
     /// PHPhotoLibrary. Production routes to `savePicture` (CamStates.swift).

--- a/RemoteCam/WatchRemoteCamStates.swift
+++ b/RemoteCam/WatchRemoteCamStates.swift
@@ -105,6 +105,7 @@ extension RemoteCamSession {
             switch msg {
             case is OnEnter:
                 debugLog("Watch Remote: Camera state entered")
+                self.watchCountdownRemaining = 0
                 self.pushWatchState(ctrl: ctrl)
 
             // MARK: - Photo Capture
@@ -131,7 +132,7 @@ extension RemoteCamSession {
 
             case let micError as UICmd.MicrophoneAccessDenied:
                 debugLog("Watch Remote: Microphone access denied: \(micError.error)")
-                self.pushWatchState(ctrl: ctrl, event: "microphoneDenied")
+                self.pushWatchState(ctrl: ctrl, event: .microphonedenied)
 
             // MARK: - Photo/Video Mode Switch (Watch-initiated)
 
@@ -144,14 +145,13 @@ extension RemoteCamSession {
 
             case let countdown as RemoteCmd.TimerCountdown:
                 ctrl.updateTimerCountdown(value: countdown.value)
-                if countdown.value > 0 {
-                    self.pushWatchState(ctrl: ctrl, event: "countdown:\(countdown.value)")
-                } else {
-                    // Fire/cancel: sync a countdown-free snapshot so neither the
-                    // Watch nor the durable context mirror keeps a countdown that
-                    // is no longer running.
-                    self.pushWatchState(ctrl: ctrl)
-                }
+                // The countdown is snapshot state, not an event: mirror the tick
+                // (fire/cancel zero it) and push — every subsequent push of any
+                // kind carries the live value, so neither the Watch nor the
+                // durable context mirror can ever hold a countdown that isn't
+                // actually running.
+                self.watchCountdownRemaining = Int32(max(0, countdown.value))
+                self.pushWatchState(ctrl: ctrl)
 
             // MARK: - Late Arrivals (sub-state timed out before the callback landed)
 
@@ -161,9 +161,9 @@ extension RemoteCamSession {
                 debugLog("Watch Remote: late OnPicture (error: \(String(describing: t.error)))")
                 if let imageData = t.pic, t.error == nil {
                     self.photoLibrarySaver(imageData)
-                    self.pushWatchState(ctrl: ctrl, event: "photoTaken")
+                    self.pushWatchState(ctrl: ctrl, event: .phototaken)
                 } else {
-                    self.pushWatchState(ctrl: ctrl, event: "photoError")
+                    self.pushWatchState(ctrl: ctrl, event: .photoerror)
                 }
 
             case is RemoteCmd.StartRecordingVideoAck,
@@ -244,17 +244,17 @@ extension RemoteCamSession {
                 if let imageData = t.pic, t.error == nil {
                     debugLog("Watch Remote: Photo captured, saving to library")
                     self.photoLibrarySaver(imageData)
-                    self.pushWatchState(ctrl: ctrl, event: "photoTaken")
+                    self.pushWatchState(ctrl: ctrl, event: .phototaken)
                 } else {
                     debugLog("Watch Remote: Photo capture error: \(String(describing: t.error))")
-                    self.pushWatchState(ctrl: ctrl, event: "photoError")
+                    self.pushWatchState(ctrl: ctrl, event: .photoerror)
                 }
                 self.unbecome()
 
             case let timeout as UICmd.StateTimeout:
                 if timeout.stateName == .watchRemoteCameraTakingPic && timeout.generation == gen {
                     debugLog("Watch Remote: photo capture timed out")
-                    self.pushWatchState(ctrl: ctrl, event: "photoError")
+                    self.pushWatchState(ctrl: ctrl, event: .photoerror)
                     self.unbecome()
                 }
                 // Stale generations are dropped silently.
@@ -263,7 +263,7 @@ extension RemoteCamSession {
                 debugLog("Watch Remote: capture already in flight, ignoring duplicate TakePic")
 
             case is RemoteCmd.StartRecordingVideo, is UICmd.SetWatchCameraMode:
-                self.pushWatchState(ctrl: ctrl, event: "busy")
+                self.pushWatchState(ctrl: ctrl, event: .busy)
 
             // Zoom keeps working while a capture is in flight (crown turns mid-shot).
             case let zoomCmd as RemoteCmd.SetZoom:
@@ -300,11 +300,11 @@ extension RemoteCamSession {
             case let ack as RemoteCmd.StartRecordingVideoAck:
                 if let error = ack.error {
                     debugLog("Watch Remote: recording failed to start: \(error)")
-                    self.pushWatchState(ctrl: ctrl, event: "recordingFailed")
+                    self.pushWatchState(ctrl: ctrl, event: .recordingfailed)
                     self.unbecome()
                 } else {
                     debugLog("Watch Remote: Recording started at \(ack.recordingStartTime?.description ?? "unknown")")
-                    self.pushWatchState(ctrl: ctrl, event: "recordingStarted")
+                    self.pushWatchState(ctrl: ctrl, event: .recordingstarted)
                     self.become(
                         name: .watchRemoteCameraRecordingVideo,
                         state: self.watchRemoteCameraRecordingVideo(ctrl: ctrl),
@@ -314,25 +314,25 @@ extension RemoteCamSession {
 
             case let micError as UICmd.MicrophoneAccessDenied:
                 debugLog("Watch Remote: Microphone access denied: \(micError.error)")
-                self.pushWatchState(ctrl: ctrl, event: "microphoneDenied")
+                self.pushWatchState(ctrl: ctrl, event: .microphonedenied)
                 self.unbecome()
 
             case let timeout as UICmd.StateTimeout:
                 if timeout.stateName == .watchRemoteCameraStartingVideo && timeout.generation == gen {
                     debugLog("Watch Remote: recording never started, cleaning up")
                     ctrl.stopRecordingVideo(false)
-                    self.pushWatchState(ctrl: ctrl, event: "recordingFailed")
+                    self.pushWatchState(ctrl: ctrl, event: .recordingfailed)
                     self.unbecome()
                 }
 
             // User can abort a start that hasn't been confirmed yet.
             case is RemoteCmd.StopRecordingVideo:
                 ctrl.stopRecordingVideo(false)
-                self.pushWatchState(ctrl: ctrl, event: "recordingStopped")
+                self.pushWatchState(ctrl: ctrl, event: .recordingstopped)
                 self.unbecome()
 
             case is RemoteCmd.TakePic, is RemoteCmd.StartRecordingVideo, is UICmd.SetWatchCameraMode:
-                self.pushWatchState(ctrl: ctrl, event: "busy")
+                self.pushWatchState(ctrl: ctrl, event: .busy)
 
             case let zoomCmd as RemoteCmd.SetZoom:
                 _ = ctrl.setZoom(zoomFactor: zoomCmd.zoomFactor)
@@ -370,24 +370,24 @@ extension RemoteCamSession {
 
             case is RemoteCmd.StopRecordingVideoResp:
                 debugLog("Watch Remote: Recording stopped")
-                self.pushWatchState(ctrl: ctrl, event: "recordingStopped")
+                self.pushWatchState(ctrl: ctrl, event: .recordingstopped)
                 self.unbecome()
 
             case let sendVideo as UICmd.SendVideoResource:
                 // In Watch mode, video is saved locally only
                 debugLog("Watch Remote: Video saved at \(sendVideo.videoURL)")
-                self.pushWatchState(ctrl: ctrl, event: "recordingStopped")
+                self.pushWatchState(ctrl: ctrl, event: .recordingstopped)
                 self.unbecome()
 
             case let timeout as UICmd.StateTimeout:
                 if timeout.stateName == .watchRemoteCameraRecordingVideo && timeout.generation == stopGeneration {
                     debugLog("Watch Remote: stop recording never completed")
-                    self.pushWatchState(ctrl: ctrl, event: "recordingFailed")
+                    self.pushWatchState(ctrl: ctrl, event: .recordingfailed)
                     self.unbecome()
                 }
 
             case is RemoteCmd.TakePic, is RemoteCmd.StartRecordingVideo, is UICmd.SetWatchCameraMode:
-                self.pushWatchState(ctrl: ctrl, event: "busyRecording")
+                self.pushWatchState(ctrl: ctrl, event: .busyrecording)
 
             // Allow zoom/lens/flash/torch during recording
             case let zoomCmd as RemoteCmd.SetZoom:
@@ -420,22 +420,27 @@ extension RemoteCamSession {
 
     // MARK: - Watch State Push Helper (FlatBuffer-encoded)
 
-    func pushWatchState(ctrl: WatchCameraControlling, event: String? = nil) {
+    func pushWatchState(ctrl: WatchCameraControlling,
+                        event: RemoteShutter_WatchEventType = .unknown) {
         watchStatePusher.pushCameraState(
-            Self.watchStateSnapshot(ctrl: ctrl, event: event, isBackgrounded: isPhoneBackgrounded())
+            Self.watchStateSnapshot(ctrl: ctrl, event: event,
+                                    isBackgrounded: isPhoneBackgrounded(),
+                                    countdownRemaining: watchCountdownRemaining)
         )
     }
 
     static func watchStateSnapshot(ctrl: WatchCameraControlling,
-                                   event: String? = nil,
-                                   isBackgrounded: Bool = false) -> WatchCameraStateSnapshot {
+                                   event: RemoteShutter_WatchEventType = .unknown,
+                                   isBackgrounded: Bool = false,
+                                   countdownRemaining: Int32 = 0) -> WatchCameraStateSnapshot {
         var snapshot = WatchCameraStateSnapshot()
         // Readiness is decided here and nowhere else: the phone can only capture while
-        // foregrounded. When backgrounded/locked, report not-ready with the reason the
-        // Watch routes to its "app closed" screen — it takes precedence over any
-        // transient capture event (e.g. a late "photoTaken") that was in flight.
-        snapshot.isReady = !isBackgrounded
-        snapshot.lastEvent = isBackgrounded ? WatchNotReadyReason.phoneBackgrounded : event
+        // foregrounded. A backgrounded/locked phone reports not-ready (routed to the
+        // Watch's "app closed" screen), suppressing any transient capture event or
+        // countdown that was in flight — the timer is suspended with the app anyway.
+        snapshot.readiness = isBackgrounded ? .phonebackgrounded : .ready
+        snapshot.event = isBackgrounded ? .unknown : event
+        snapshot.countdownRemainingSecs = isBackgrounded ? 0 : countdownRemaining
         snapshot.currentZoomFactor = Double(ctrl.getCurrentZoomFactor())
         snapshot.minZoomFactor = Double(ctrl.getMinZoomFactor())
         snapshot.maxZoomFactor = Double(ctrl.getMaxZoomFactor())
@@ -445,7 +450,6 @@ extension RemoteCamSession {
         snapshot.availableLensTypes = ctrl.getAvailableLensTypes().compactMap {
             RemoteShutter_CameraLensType(rawValue: Int8($0.rawValue))
         }
-        snapshot.isFlashEnabled = ctrl.currentFlashMode != .off
         snapshot.flashMode = RemoteShutter_FlashMode(rawValue: Int8(ctrl.currentFlashMode.rawValue)) ?? .off
         snapshot.isTorchEnabled = ctrl.isTorchActive
         snapshot.zoomStops = ctrl.getZoomStops().map { Double($0) }

--- a/RemoteCam/WatchRemoteCamStates.swift
+++ b/RemoteCam/WatchRemoteCamStates.swift
@@ -146,6 +146,11 @@ extension RemoteCamSession {
                 ctrl.updateTimerCountdown(value: countdown.value)
                 if countdown.value > 0 {
                     self.pushWatchState(ctrl: ctrl, event: "countdown:\(countdown.value)")
+                } else {
+                    // Fire/cancel: sync a countdown-free snapshot so neither the
+                    // Watch nor the durable context mirror keeps a countdown that
+                    // is no longer running.
+                    self.pushWatchState(ctrl: ctrl)
                 }
 
             // MARK: - Late Arrivals (sub-state timed out before the callback landed)

--- a/RemoteCam/WatchRemoteCameraController.swift
+++ b/RemoteCam/WatchRemoteCameraController.swift
@@ -250,10 +250,12 @@ public class WatchRemoteCameraController: UIViewController {
             session ! RemoteCmd.RequestCameraCapabilities()
 
         case .canceltimer:
-            // Stop the pending capture and tear down the on-phone countdown overlay
-            // and strobe torch (value < 0 == cancelled).
+            // Stop the pending capture, then let the actor tear down the on-phone
+            // countdown overlay/strobe torch (value < 0 == cancelled) AND push a
+            // countdown-free snapshot — a direct overlay call would leave the
+            // Watch's durable context mirror holding a countdown that isn't running.
             cancelCountdown()
-            cameraVC.updateTimerCountdown(value: -1)
+            session ! RemoteCmd.TimerCountdown(value: -1)
 
         case .requestpreviewframe:
             // The Watch consumed a preview frame and wants the next — release the gate.

--- a/RemoteCam/WatchSessionManager.swift
+++ b/RemoteCam/WatchSessionManager.swift
@@ -103,7 +103,7 @@ class WatchSessionManager: NSObject, ObservableObject, WCSessionDelegate {
 
     func pushDisconnectedState() {
         var snapshot = WatchCameraStateSnapshot()
-        snapshot.isReady = false
+        snapshot.readiness = .notinwatchmode
         pushCameraState(snapshot)
     }
 

--- a/RemoteCamTests/WatchRemoteCamStateTests.swift
+++ b/RemoteCamTests/WatchRemoteCamStateTests.swift
@@ -73,8 +73,8 @@ final class FakeWatchStatePusher: WatchStatePushing {
     var pushedSnapshots: [WatchCameraStateSnapshot] = []
     var disconnectedPushes = 0
 
-    var lastEvent: String? { pushedSnapshots.last(where: { $0.lastEvent != nil })?.lastEvent }
-    var allEvents: [String] { pushedSnapshots.compactMap { $0.lastEvent } }
+    var lastEvent: RemoteShutter_WatchEventType? { pushedSnapshots.last(where: { $0.event != .unknown })?.event }
+    var allEvents: [RemoteShutter_WatchEventType] { pushedSnapshots.map(\.event).filter { $0 != .unknown } }
 
     func pushCameraState(_ snapshot: WatchCameraStateSnapshot) { pushedSnapshots.append(snapshot) }
     func pushDisconnectedState() { disconnectedPushes += 1 }
@@ -179,7 +179,7 @@ class WatchRemoteCamStateTests: XCTestCase {
         waitForMailbox(session, test: self)
 
         XCTAssertEqual(session.currentStateName(), .watchRemoteCamera)
-        XCTAssertEqual(pusher.lastEvent, "photoTaken")
+        XCTAssertEqual(pusher.lastEvent, .phototaken)
         XCTAssertEqual(savedPhotos, [photoBytes],
                        "the captured photo must be written to the photo library")
     }
@@ -190,7 +190,7 @@ class WatchRemoteCamStateTests: XCTestCase {
         waitForMailbox(session, test: self)
 
         XCTAssertEqual(session.currentStateName(), .watchRemoteCamera)
-        XCTAssertEqual(pusher.lastEvent, "photoError")
+        XCTAssertEqual(pusher.lastEvent, .photoerror)
         XCTAssertTrue(savedPhotos.isEmpty)
     }
 
@@ -202,7 +202,7 @@ class WatchRemoteCamStateTests: XCTestCase {
         waitForMailbox(session, test: self)
 
         XCTAssertEqual(session.currentStateName(), .watchRemoteCamera)
-        XCTAssertEqual(pusher.lastEvent, "photoError")
+        XCTAssertEqual(pusher.lastEvent, .photoerror)
     }
 
     func testTakingPicStaleTimeoutIsIgnored() {
@@ -239,7 +239,7 @@ class WatchRemoteCamStateTests: XCTestCase {
         ref ! RemoteCmd.StartRecordingVideo(sender: nil)
         waitForMailbox(session, test: self)
 
-        XCTAssertEqual(pusher.lastEvent, "busy")
+        XCTAssertEqual(pusher.lastEvent, .busy)
         XCTAssertEqual(ctrl.startRecordingCalls, 0)
     }
 
@@ -250,7 +250,7 @@ class WatchRemoteCamStateTests: XCTestCase {
         waitForMailbox(session, test: self)
 
         XCTAssertEqual(session.currentStateName(), .watchRemoteCamera)
-        XCTAssertEqual(pusher.lastEvent, "photoTaken")
+        XCTAssertEqual(pusher.lastEvent, .phototaken)
         XCTAssertEqual(savedPhotos, [photoBytes], "a late capture must still be saved")
     }
 
@@ -265,7 +265,7 @@ class WatchRemoteCamStateTests: XCTestCase {
     func testStartAckTransitionsToRecording() {
         enterRecording()
         XCTAssertEqual(session.currentStateName(), .watchRemoteCameraRecordingVideo)
-        XCTAssertEqual(pusher.lastEvent, "recordingStarted")
+        XCTAssertEqual(pusher.lastEvent, .recordingstarted)
     }
 
     func testStartAckWithErrorReturnsToCameraWithRecordingFailed() {
@@ -275,7 +275,7 @@ class WatchRemoteCamStateTests: XCTestCase {
         waitForMailbox(session, test: self)
 
         XCTAssertEqual(session.currentStateName(), .watchRemoteCamera)
-        XCTAssertEqual(pusher.lastEvent, "recordingFailed")
+        XCTAssertEqual(pusher.lastEvent, .recordingfailed)
     }
 
     func testMicrophoneDeniedDuringStartReturnsToCamera() {
@@ -284,7 +284,7 @@ class WatchRemoteCamStateTests: XCTestCase {
         waitForMailbox(session, test: self)
 
         XCTAssertEqual(session.currentStateName(), .watchRemoteCamera)
-        XCTAssertEqual(pusher.lastEvent, "microphoneDenied")
+        XCTAssertEqual(pusher.lastEvent, .microphonedenied)
     }
 
     func testStartingVideoTimeoutCleansUpAndReturnsToCamera() {
@@ -295,7 +295,7 @@ class WatchRemoteCamStateTests: XCTestCase {
         waitForMailbox(session, test: self)
 
         XCTAssertEqual(session.currentStateName(), .watchRemoteCamera)
-        XCTAssertEqual(pusher.lastEvent, "recordingFailed")
+        XCTAssertEqual(pusher.lastEvent, .recordingfailed)
         XCTAssertEqual(ctrl.stopRecordingCalls, [false], "timeout must attempt recorder cleanup")
     }
 
@@ -319,7 +319,7 @@ class WatchRemoteCamStateTests: XCTestCase {
         waitForMailbox(session, test: self)
 
         XCTAssertEqual(session.currentStateName(), .watchRemoteCamera)
-        XCTAssertEqual(pusher.lastEvent, "recordingStopped")
+        XCTAssertEqual(pusher.lastEvent, .recordingstopped)
     }
 
     func testStopRecordingTimeoutUnwedgesState() {
@@ -332,7 +332,7 @@ class WatchRemoteCamStateTests: XCTestCase {
         waitForMailbox(session, test: self)
 
         XCTAssertEqual(session.currentStateName(), .watchRemoteCamera)
-        XCTAssertEqual(pusher.lastEvent, "recordingFailed")
+        XCTAssertEqual(pusher.lastEvent, .recordingfailed)
     }
 
     func testRecordingHasNoBlanketTimeout() {
@@ -350,7 +350,7 @@ class WatchRemoteCamStateTests: XCTestCase {
         ref ! RemoteCmd.TakePic(sender: nil, sendMediaToPeer: false)
         waitForMailbox(session, test: self)
 
-        XCTAssertEqual(pusher.lastEvent, "busyRecording")
+        XCTAssertEqual(pusher.lastEvent, .busyrecording)
         XCTAssertTrue(ctrl.takePictureCalls.isEmpty)
         XCTAssertEqual(session.currentStateName(), .watchRemoteCameraRecordingVideo)
     }
@@ -411,7 +411,7 @@ class WatchRemoteCamStateTests: XCTestCase {
         waitForMailbox(session, test: self)
 
         XCTAssertEqual(ctrl.currentCameraMode, .Photo, "mode must not change mid-capture")
-        XCTAssertEqual(pusher.lastEvent, "busy")
+        XCTAssertEqual(pusher.lastEvent, .busy)
         XCTAssertEqual(session.currentStateName(), .watchRemoteCameraTakingPic)
     }
 
@@ -421,13 +421,13 @@ class WatchRemoteCamStateTests: XCTestCase {
         waitForMailbox(session, test: self)
 
         XCTAssertEqual(ctrl.currentCameraMode, .Video, "mode must not change while recording")
-        XCTAssertEqual(pusher.lastEvent, "busyRecording")
+        XCTAssertEqual(pusher.lastEvent, .busyrecording)
         XCTAssertEqual(session.currentStateName(), .watchRemoteCameraRecordingVideo)
     }
 
     // MARK: - Timer countdown plumbing
 
-    func testTimerCountdownDrivesPhoneUIAndWatchEvents() {
+    func testTimerCountdownIsCarriedAsSnapshotState() {
         enterWatchCamera()
         ref ! RemoteCmd.TimerCountdown(value: 3)
         ref ! RemoteCmd.TimerCountdown(value: 2)
@@ -435,16 +435,17 @@ class WatchRemoteCamStateTests: XCTestCase {
         waitForMailbox(session, test: self)
 
         XCTAssertEqual(ctrl.countdownTicks, [3, 2, 0])
-        XCTAssertTrue(pusher.allEvents.contains("countdown:3"))
-        XCTAssertTrue(pusher.allEvents.contains("countdown:2"))
-        XCTAssertFalse(pusher.allEvents.contains("countdown:0"),
-                       "the fire tick is not an event — the capture event follows")
+        // Ticks travel as snapshot state, never as events.
+        XCTAssertTrue(pusher.allEvents.isEmpty)
+        let countdowns = pusher.pushedSnapshots.map(\.countdownRemainingSecs)
+        XCTAssertTrue(countdowns.contains(3))
+        XCTAssertTrue(countdowns.contains(2))
         XCTAssertEqual(session.currentStateName(), .watchRemoteCamera)
 
-        // The fire tick must still push a countdown-free snapshot: without it the
+        // The fire tick must push a countdown-free snapshot: without it the
         // Watch (and the latest-wins context mirror) keeps showing the last tick.
         let last = pusher.pushedSnapshots.last
-        XCTAssertNil(last?.lastEvent)
+        XCTAssertEqual(last?.countdownRemainingSecs, 0)
         XCTAssertNil(last?.activeCountdownSeconds)
     }
 
@@ -458,9 +459,26 @@ class WatchRemoteCamStateTests: XCTestCase {
                        "cancel must tear down the on-phone countdown overlay")
         let last = pusher.pushedSnapshots.last
         XCTAssertNotNil(last, "cancel must push state so the context mirror can't hold a dead countdown")
-        XCTAssertNil(last?.lastEvent)
+        XCTAssertEqual(last?.countdownRemainingSecs, 0)
         XCTAssertNil(last?.activeCountdownSeconds)
         XCTAssertEqual(session.currentStateName(), .watchRemoteCamera)
+    }
+
+    /// Any push that interleaves with a live countdown (zoom, toggles, capability
+    /// refresh) must carry the countdown — it's snapshot state, so no push can
+    /// accidentally "clear" it on the Watch.
+    func testPushesDuringCountdownCarryTheCountdown() {
+        enterWatchCamera()
+        ref ! RemoteCmd.TimerCountdown(value: 5)
+        ref ! RemoteCmd.SetZoom(zoomFactor: 2.0)
+        ref ! RemoteCmd.RequestCameraCapabilities()
+        waitForMailbox(session, test: self)
+
+        let afterTick = pusher.pushedSnapshots.suffix(2)
+        XCTAssertEqual(afterTick.count, 2)
+        XCTAssertTrue(afterTick.allSatisfy { $0.countdownRemainingSecs == 5 },
+                      "interleaved pushes must not drop a live countdown")
+        XCTAssertTrue(afterTick.allSatisfy { $0.activeCountdownSeconds == 5 })
     }
 
     // MARK: - Snapshot truthfulness
@@ -478,26 +496,30 @@ class WatchRemoteCamStateTests: XCTestCase {
         ctrl.isTorchActive = true
         ctrl.isRecording = true
         ctrl.currentCameraMode = .Video
-        let snapshot = RemoteCamSession.watchStateSnapshot(ctrl: ctrl, event: "x")
+        let snapshot = RemoteCamSession.watchStateSnapshot(ctrl: ctrl, event: .recordingstarted)
         XCTAssertTrue(snapshot.isTorchEnabled)
         XCTAssertTrue(snapshot.isRecording)
         XCTAssertEqual(snapshot.currentMode, .video)
-        XCTAssertEqual(snapshot.lastEvent, "x")
+        XCTAssertEqual(snapshot.event, .recordingstarted)
     }
 
     // MARK: - Readiness (backgrounded / locked phone)
 
     func testSnapshotReadyWhenForegrounded() {
-        let snapshot = RemoteCamSession.watchStateSnapshot(ctrl: ctrl, event: "photoTaken", isBackgrounded: false)
-        XCTAssertTrue(snapshot.isReady)
-        XCTAssertEqual(snapshot.lastEvent, "photoTaken", "transient event passes through while foregrounded")
+        let snapshot = RemoteCamSession.watchStateSnapshot(ctrl: ctrl, event: .phototaken, isBackgrounded: false)
+        XCTAssertEqual(snapshot.readiness, .ready)
+        XCTAssertEqual(snapshot.event, .phototaken, "transient event passes through while foregrounded")
     }
 
     func testSnapshotNotReadyWhenBackgrounded() {
-        let snapshot = RemoteCamSession.watchStateSnapshot(ctrl: ctrl, event: "photoTaken", isBackgrounded: true)
-        XCTAssertFalse(snapshot.isReady, "a backgrounded/locked phone can't capture")
-        XCTAssertEqual(snapshot.lastEvent, WatchNotReadyReason.phoneBackgrounded,
-                       "the not-ready reason takes precedence over any in-flight transient event")
+        let snapshot = RemoteCamSession.watchStateSnapshot(ctrl: ctrl, event: .phototaken,
+                                                           isBackgrounded: true, countdownRemaining: 3)
+        XCTAssertEqual(snapshot.readiness, .phonebackgrounded,
+                       "a backgrounded/locked phone can't capture")
+        XCTAssertEqual(snapshot.event, .unknown,
+                       "the not-ready verdict suppresses any in-flight transient event")
+        XCTAssertEqual(snapshot.countdownRemainingSecs, 0,
+                       "the countdown timer is suspended with the app — don't report it live")
     }
 
     /// The regression this whole change targets: whichever push path runs while the
@@ -515,7 +537,7 @@ class WatchRemoteCamStateTests: XCTestCase {
         XCTAssertFalse(pushes.isEmpty)
         XCTAssertTrue(pushes.allSatisfy { !$0.isReady },
                       "no push may claim ready while the phone is backgrounded")
-        XCTAssertEqual(pushes.last?.lastEvent, WatchNotReadyReason.phoneBackgrounded)
+        XCTAssertEqual(pushes.last?.readiness, .phonebackgrounded)
     }
 }
 

--- a/RemoteCamTests/WatchRemoteCamStateTests.swift
+++ b/RemoteCamTests/WatchRemoteCamStateTests.swift
@@ -440,6 +440,27 @@ class WatchRemoteCamStateTests: XCTestCase {
         XCTAssertFalse(pusher.allEvents.contains("countdown:0"),
                        "the fire tick is not an event — the capture event follows")
         XCTAssertEqual(session.currentStateName(), .watchRemoteCamera)
+
+        // The fire tick must still push a countdown-free snapshot: without it the
+        // Watch (and the latest-wins context mirror) keeps showing the last tick.
+        let last = pusher.pushedSnapshots.last
+        XCTAssertNil(last?.lastEvent)
+        XCTAssertNil(last?.activeCountdownSeconds)
+    }
+
+    func testTimerCancelDrivesPhoneUIAndPushesCountdownFreeSnapshot() {
+        enterWatchCamera()
+        ref ! RemoteCmd.TimerCountdown(value: 2)
+        ref ! RemoteCmd.TimerCountdown(value: -1)
+        waitForMailbox(session, test: self)
+
+        XCTAssertEqual(ctrl.countdownTicks, [2, -1],
+                       "cancel must tear down the on-phone countdown overlay")
+        let last = pusher.pushedSnapshots.last
+        XCTAssertNotNil(last, "cancel must push state so the context mirror can't hold a dead countdown")
+        XCTAssertNil(last?.lastEvent)
+        XCTAssertNil(last?.activeCountdownSeconds)
+        XCTAssertEqual(session.currentStateName(), .watchRemoteCamera)
     }
 
     // MARK: - Snapshot truthfulness

--- a/RemoteCamTests/WatchSerializationTests.swift
+++ b/RemoteCamTests/WatchSerializationTests.swift
@@ -224,6 +224,41 @@ final class WatchSerializationTests: XCTestCase {
             isSessionActive: true, isPhoneReachable: true, isReady: false,
             phoneNotInWatchMode: false, phoneNotReadyReason: nil), .connecting)
     }
+
+    // MARK: - Active Countdown Derivation
+
+    private func snapshot(isReady: Bool = true, lastEvent: String?) -> WatchCameraStateSnapshot {
+        var snapshot = WatchCameraStateSnapshot()
+        snapshot.isReady = isReady
+        snapshot.lastEvent = lastEvent
+        return snapshot
+    }
+
+    func testActiveCountdownParsesTicks() {
+        XCTAssertEqual(snapshot(lastEvent: "countdown:3").activeCountdownSeconds, 3)
+        XCTAssertEqual(snapshot(lastEvent: "countdown:1").activeCountdownSeconds, 1)
+    }
+
+    /// The stuck-overlay regression: a snapshot without a countdown event is
+    /// authoritative — the Watch must treat it as "no countdown running".
+    func testSnapshotWithoutCountdownEventCarriesNoCountdown() {
+        XCTAssertNil(snapshot(lastEvent: nil).activeCountdownSeconds)
+        XCTAssertNil(snapshot(lastEvent: "photoTaken").activeCountdownSeconds)
+    }
+
+    func testFireTickIsNotAnActiveCountdown() {
+        XCTAssertNil(snapshot(lastEvent: "countdown:0").activeCountdownSeconds)
+    }
+
+    func testMalformedCountdownEventsAreIgnored() {
+        XCTAssertNil(snapshot(lastEvent: "countdown:-2").activeCountdownSeconds)
+        XCTAssertNil(snapshot(lastEvent: "countdown:abc").activeCountdownSeconds)
+        XCTAssertNil(snapshot(lastEvent: "countdown:").activeCountdownSeconds)
+    }
+
+    func testNotReadySnapshotCarriesNoCountdown() {
+        XCTAssertNil(snapshot(isReady: false, lastEvent: "countdown:2").activeCountdownSeconds)
+    }
 }
 
 // MARK: - Zoom Throttle

--- a/RemoteCamTests/WatchSerializationTests.swift
+++ b/RemoteCamTests/WatchSerializationTests.swift
@@ -61,7 +61,9 @@ final class WatchSerializationTests: XCTestCase {
 
     func testStateRoundTripPreservesAllFields() throws {
         let data = WatchStateEncoder.encode(WatchCameraStateSnapshot(
-            isReady: true,
+            readiness: .ready,
+            event: .phototaken,
+            countdownRemainingSecs: 4,
             currentZoomFactor: 3.0,
             minZoomFactor: 1.0,
             maxZoomFactor: 12.0,
@@ -69,14 +71,15 @@ final class WatchSerializationTests: XCTestCase {
             currentMode: .video,
             currentLensType: .ultrawide,
             availableLensTypes: [.ultrawide, .wideangle, .telephoto],
-            isFlashEnabled: false,
+            flashMode: .auto,
             isTorchEnabled: true,
             zoomStops: [0.5, 1.0, 2.0],
-            wideAngleZoomFactor: 2.0,
-            lastEvent: "photoTaken"
+            wideAngleZoomFactor: 2.0
         ))
         let decoded = try XCTUnwrap(WatchStateEncoder.decode(data), "state should decode")
-        XCTAssertTrue(decoded.isReady)
+        XCTAssertEqual(decoded.readiness, .ready)
+        XCTAssertEqual(decoded.event, .phototaken)
+        XCTAssertEqual(decoded.countdownRemainingSecs, 4)
         XCTAssertEqual(decoded.currentZoomFactor, 3.0, accuracy: 0.0001)
         XCTAssertEqual(decoded.minZoomFactor, 1.0, accuracy: 0.0001)
         XCTAssertEqual(decoded.maxZoomFactor, 12.0, accuracy: 0.0001)
@@ -84,19 +87,39 @@ final class WatchSerializationTests: XCTestCase {
         XCTAssertEqual(decoded.currentMode, .video)
         XCTAssertEqual(decoded.currentLensType, .ultrawide)
         XCTAssertEqual(decoded.availableLensTypes, [.ultrawide, .wideangle, .telephoto])
-        XCTAssertFalse(decoded.isFlashEnabled)
+        XCTAssertEqual(decoded.flashMode, .auto)
+        XCTAssertTrue(decoded.isFlashEnabled, "auto flash surfaces as enabled")
         XCTAssertTrue(decoded.isTorchEnabled)
         XCTAssertEqual(decoded.zoomStops, [0.5, 1.0, 2.0])
         XCTAssertEqual(decoded.wideAngleZoomFactor, 2.0, accuracy: 0.0001)
-        XCTAssertEqual(decoded.lastEvent, "photoTaken")
     }
 
-    /// A nil `lastEvent` decodes back as nil (or empty) — i.e. no spurious event is fired.
-    func testStateRoundTripWithNilEvent() throws {
-        let data = WatchStateEncoder.encode(WatchCameraStateSnapshot(lastEvent: nil))
+    /// An event-free state decodes back as `.unknown` — no spurious event is fired.
+    func testStateRoundTripWithNoEvent() throws {
+        let data = WatchStateEncoder.encode(WatchCameraStateSnapshot(event: .unknown))
         let decoded = try XCTUnwrap(WatchStateEncoder.decode(data))
-        XCTAssertTrue(decoded.lastEvent == nil || decoded.lastEvent?.isEmpty == true,
-                      "Expected no event, got \(String(describing: decoded.lastEvent))")
+        XCTAssertEqual(decoded.event, .unknown)
+    }
+
+    func testAllEventTypesRoundTrip() throws {
+        let events: [RemoteShutter_WatchEventType] = [
+            .phototaken, .photoerror, .recordingstarted, .recordingstopped,
+            .recordingfailed, .microphonedenied, .busy, .busyrecording, .sendfailed
+        ]
+        for event in events {
+            let data = WatchStateEncoder.encode(WatchCameraStateSnapshot(event: event))
+            let decoded = try XCTUnwrap(WatchStateEncoder.decode(data), "\(event) should decode")
+            XCTAssertEqual(decoded.event, event)
+        }
+    }
+
+    func testAllReadinessValuesRoundTrip() throws {
+        let values: [RemoteShutter_WatchReadiness] = [.unknown, .ready, .phonebackgrounded, .notinwatchmode]
+        for readiness in values {
+            let data = WatchStateEncoder.encode(WatchCameraStateSnapshot(readiness: readiness))
+            let decoded = try XCTUnwrap(WatchStateEncoder.decode(data), "\(readiness) should decode")
+            XCTAssertEqual(decoded.readiness, readiness)
+        }
     }
 
     // MARK: - Negative cases (the "ignore undecodable" guard)
@@ -113,7 +136,7 @@ final class WatchSerializationTests: XCTestCase {
         XCTAssertNil(WatchCommandEncoder.decode(stateData))
     }
 
-    // MARK: - New appended state fields
+    // MARK: - Field defaults
 
     func testStateRoundTripPreservesEpochAndFlashMode() throws {
         var snapshot = WatchCameraStateSnapshot()
@@ -124,19 +147,22 @@ final class WatchSerializationTests: XCTestCase {
         XCTAssertEqual(decoded.flashMode, .auto)
     }
 
-    /// Bytes from a build that predates the appended fields still decode, with
-    /// the new fields falling back to their FlatBuffer defaults.
-    func testLegacyStateWithoutAppendedFieldsDecodes() throws {
+    /// A state built entirely from FlatBuffer defaults decodes to the safe
+    /// zero-values: unknown readiness (never treated as ready), no event, no
+    /// countdown.
+    func testDefaultStateDecodesToSafeValues() throws {
         var fbb = FlatBufferBuilder()
         let start = RemoteShutter_WatchCameraState.startWatchCameraState(&fbb)
-        RemoteShutter_WatchCameraState.add(isReady: true, &fbb)
         RemoteShutter_WatchCameraState.add(currentZoomFactor: 2.0, &fbb)
         let state = RemoteShutter_WatchCameraState.endWatchCameraState(&fbb, start: start)
         let msg = RemoteShutter_WatchMessage.createWatchMessage(&fbb, type: .watchstatemsg, stateOffset: state)
         fbb.finish(offset: msg)
 
         let decoded = try XCTUnwrap(WatchStateEncoder.decode(fbb.data))
-        XCTAssertTrue(decoded.isReady)
+        XCTAssertEqual(decoded.readiness, .unknown)
+        XCTAssertFalse(decoded.isReady, "unknown readiness must never present as ready")
+        XCTAssertEqual(decoded.event, .unknown)
+        XCTAssertEqual(decoded.countdownRemainingSecs, 0)
         XCTAssertEqual(decoded.currentZoomFactor, 2.0, accuracy: 0.0001)
         XCTAssertEqual(decoded.stateEpochMs, 0)
         XCTAssertEqual(decoded.flashMode, .off)
@@ -196,68 +222,55 @@ final class WatchSerializationTests: XCTestCase {
     func testPhaseDerivation() {
         // Session not activated → inactive regardless of anything else.
         XCTAssertEqual(WatchConnectionPhase.derive(
-            isSessionActive: false, isPhoneReachable: true, isReady: true,
-            phoneNotInWatchMode: false, phoneNotReadyReason: nil), .inactive)
+            isSessionActive: false, isPhoneReachable: true, readiness: .ready), .inactive)
 
-        // Activated but unreachable → connecting.
+        // Activated but unreachable → connecting, whatever the last verdict was.
         XCTAssertEqual(WatchConnectionPhase.derive(
-            isSessionActive: true, isPhoneReachable: false, isReady: false,
-            phoneNotInWatchMode: true, phoneNotReadyReason: nil), .connecting)
+            isSessionActive: true, isPhoneReachable: false, readiness: .notinwatchmode), .connecting)
 
-        // Ready wins.
+        // Ready → controls.
         XCTAssertEqual(WatchConnectionPhase.derive(
-            isSessionActive: true, isPhoneReachable: true, isReady: true,
-            phoneNotInWatchMode: false, phoneNotReadyReason: nil), .ready)
+            isSessionActive: true, isPhoneReachable: true, readiness: .ready), .ready)
 
-        // Reachable, not ready, phone said NotInWatchMode → instruction screen.
+        // Phone left the Watch Remote screen → instruction screen.
         XCTAssertEqual(WatchConnectionPhase.derive(
-            isSessionActive: true, isPhoneReachable: true, isReady: false,
-            phoneNotInWatchMode: true, phoneNotReadyReason: nil), .phoneNotInWatchMode)
+            isSessionActive: true, isPhoneReachable: true, readiness: .notinwatchmode), .phoneNotInWatchMode)
 
-        // Phone backgrounded beats NotInWatchMode messaging.
+        // Phone backgrounded/locked → "app closed" screen.
         XCTAssertEqual(WatchConnectionPhase.derive(
-            isSessionActive: true, isPhoneReachable: true, isReady: false,
-            phoneNotInWatchMode: false, phoneNotReadyReason: WatchNotReadyReason.phoneBackgrounded), .phoneNotReady)
+            isSessionActive: true, isPhoneReachable: true, readiness: .phonebackgrounded), .phoneNotReady)
 
         // Reachable, no signal yet → still connecting (syncing).
         XCTAssertEqual(WatchConnectionPhase.derive(
-            isSessionActive: true, isPhoneReachable: true, isReady: false,
-            phoneNotInWatchMode: false, phoneNotReadyReason: nil), .connecting)
+            isSessionActive: true, isPhoneReachable: true, readiness: .unknown), .connecting)
     }
 
     // MARK: - Active Countdown Derivation
 
-    private func snapshot(isReady: Bool = true, lastEvent: String?) -> WatchCameraStateSnapshot {
+    private func snapshot(readiness: RemoteShutter_WatchReadiness = .ready,
+                          countdown: Int32 = 0) -> WatchCameraStateSnapshot {
         var snapshot = WatchCameraStateSnapshot()
-        snapshot.isReady = isReady
-        snapshot.lastEvent = lastEvent
+        snapshot.readiness = readiness
+        snapshot.countdownRemainingSecs = countdown
         return snapshot
     }
 
-    func testActiveCountdownParsesTicks() {
-        XCTAssertEqual(snapshot(lastEvent: "countdown:3").activeCountdownSeconds, 3)
-        XCTAssertEqual(snapshot(lastEvent: "countdown:1").activeCountdownSeconds, 1)
+    func testActiveCountdownReadsPositiveSeconds() {
+        XCTAssertEqual(snapshot(countdown: 3).activeCountdownSeconds, 3)
+        XCTAssertEqual(snapshot(countdown: 1).activeCountdownSeconds, 1)
     }
 
-    /// The stuck-overlay regression: a snapshot without a countdown event is
-    /// authoritative — the Watch must treat it as "no countdown running".
-    func testSnapshotWithoutCountdownEventCarriesNoCountdown() {
-        XCTAssertNil(snapshot(lastEvent: nil).activeCountdownSeconds)
-        XCTAssertNil(snapshot(lastEvent: "photoTaken").activeCountdownSeconds)
+    /// The stuck-overlay regression: a snapshot is authoritative — zero (or
+    /// negative) countdown means "no countdown running".
+    func testSnapshotWithoutCountdownCarriesNoCountdown() {
+        XCTAssertNil(snapshot(countdown: 0).activeCountdownSeconds)
+        XCTAssertNil(snapshot(countdown: -2).activeCountdownSeconds)
     }
 
-    func testFireTickIsNotAnActiveCountdown() {
-        XCTAssertNil(snapshot(lastEvent: "countdown:0").activeCountdownSeconds)
-    }
-
-    func testMalformedCountdownEventsAreIgnored() {
-        XCTAssertNil(snapshot(lastEvent: "countdown:-2").activeCountdownSeconds)
-        XCTAssertNil(snapshot(lastEvent: "countdown:abc").activeCountdownSeconds)
-        XCTAssertNil(snapshot(lastEvent: "countdown:").activeCountdownSeconds)
-    }
-
-    func testNotReadySnapshotCarriesNoCountdown() {
-        XCTAssertNil(snapshot(isReady: false, lastEvent: "countdown:2").activeCountdownSeconds)
+    func testCountdownOnlyCountsWhilePhoneCanCapture() {
+        XCTAssertNil(snapshot(readiness: .phonebackgrounded, countdown: 2).activeCountdownSeconds)
+        XCTAssertNil(snapshot(readiness: .notinwatchmode, countdown: 2).activeCountdownSeconds)
+        XCTAssertNil(snapshot(readiness: .unknown, countdown: 2).activeCountdownSeconds)
     }
 }
 

--- a/RemoteShutterWatch/Localizable.xcstrings
+++ b/RemoteShutterWatch/Localizable.xcstrings
@@ -1,6 +1,9 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "" : {
+
+    },
     "%@ lens" : {
       "localizations" : {
         "da" : {

--- a/RemoteShutterWatch/RemoteShutterWatchApp.swift
+++ b/RemoteShutterWatch/RemoteShutterWatchApp.swift
@@ -12,12 +12,21 @@ import WatchKit
 @main
 struct RemoteShutterWatchApp: App {
     @WKApplicationDelegateAdaptor(WatchAppDelegate.self) var appDelegate
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environmentObject(appDelegate.viewModel)
                 .environmentObject(appDelegate.sessionDelegate)
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            // Reopening the app must re-sync: activation/reachability callbacks
+            // don't fire when the app resumes while the phone stayed reachable,
+            // and whatever state we last showed may be long stale.
+            if newPhase == .active {
+                appDelegate.sessionDelegate.requestState()
+            }
         }
     }
 }

--- a/RemoteShutterWatch/WatchCameraViewModel.swift
+++ b/RemoteShutterWatch/WatchCameraViewModel.swift
@@ -18,10 +18,9 @@ class WatchCameraViewModel: ObservableObject {
 
     @Published var isSessionActive = false
     @Published var isPhoneReachable = false
-    /// Set when the phone acks NotInWatchMode or pushes a disconnected state.
-    @Published var phoneNotInWatchMode = false
-    /// Set when the phone reports it can't capture (e.g. "phoneBackgrounded").
-    @Published var phoneNotReadyReason: String?
+    /// Latest readiness signal. Snapshot pushes set it; a NotInWatchMode ack
+    /// overrides it (the phone answered but left the Watch Remote screen).
+    @Published var readiness: RemoteShutter_WatchReadiness = .unknown
 
     var isConnected: Bool {
         isSessionActive && isPhoneReachable && isReady
@@ -34,15 +33,13 @@ class WatchCameraViewModel: ObservableObject {
         WatchConnectionPhase.derive(
             isSessionActive: isSessionActive,
             isPhoneReachable: isPhoneReachable,
-            isReady: isReady,
-            phoneNotInWatchMode: phoneNotInWatchMode,
-            phoneNotReadyReason: phoneNotReadyReason
+            readiness: readiness
         )
     }
 
     // MARK: - Camera State
 
-    @Published var isReady = false
+    var isReady: Bool { readiness == .ready }
     @Published var currentZoomFactor: Double = 1.0
     @Published var minZoomFactor: Double = 1.0
     @Published var maxZoomFactor: Double = 10.0
@@ -86,7 +83,7 @@ class WatchCameraViewModel: ObservableObject {
 
     // MARK: - Events
 
-    @Published var lastEvent: String?
+    @Published var lastEvent: RemoteShutter_WatchEventType?
     @Published var showEventConfirmation = false
 
     /// Seconds left on an active self-timer, or `nil` when none is counting. Shown
@@ -187,18 +184,7 @@ class WatchCameraViewModel: ObservableObject {
         }
         lastStateEpochMs = max(lastStateEpochMs, state.stateEpochMs)
 
-        if state.isReady {
-            phoneNotInWatchMode = false
-            phoneNotReadyReason = nil
-        } else if state.lastEvent == WatchNotReadyReason.phoneBackgrounded {
-            phoneNotReadyReason = state.lastEvent
-        } else {
-            // Disconnected push: the phone left Watch Remote mode.
-            phoneNotInWatchMode = true
-            phoneNotReadyReason = nil
-        }
-
-        isReady = state.isReady
+        readiness = state.readiness
         if !state.isReady {
             clearPreview()
         }
@@ -214,20 +200,20 @@ class WatchCameraViewModel: ObservableObject {
         zoomStops = state.zoomStops
         wideAngleZoomFactor = state.wideAngleZoomFactor
 
-        // The snapshot is authoritative for the self-timer: no positive countdown
-        // event means no countdown is running. Applying this on every state is what
-        // unsticks a stale overlay after missed pushes (locked phone/watch races).
+        // The snapshot is authoritative for the self-timer: no countdown in the
+        // snapshot means no countdown is running. Applying this on every state is
+        // what unsticks a stale overlay after missed pushes (locked phone/watch
+        // races) — and any interleaved push carries the live value too.
         countdownRemaining = state.activeCountdownSeconds
 
-        // Handle events with haptic feedback. A live countdown gets a steady,
-        // cancelable overlay; every other user-facing event flashes a 2s
-        // confirmation. `countdown:*` strings are protocol plumbing, never flashed.
+        // A live countdown gets a steady, cancelable overlay with a per-tick
+        // click; a one-shot event flashes a 2s confirmation with its haptic.
         if countdownRemaining != nil {
             WKInterfaceDevice.current().play(.click)
-        } else if let event = state.lastEvent, !event.hasPrefix("countdown:") {
-            lastEvent = event
+        } else if state.event != .unknown {
+            lastEvent = state.event
             showEventConfirmation = true
-            playHaptic(for: event)
+            playHaptic(for: state.event)
             DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
                 self?.showEventConfirmation = false
             }
@@ -258,7 +244,7 @@ class WatchCameraViewModel: ObservableObject {
     /// A command failed to reach the phone (or the phone refused it) — make the
     /// failure tangible instead of silently doing nothing.
     func noteSendFailure() {
-        lastEvent = "sendFailed"
+        lastEvent = .sendfailed
         showEventConfirmation = true
         WKInterfaceDevice.current().play(.failure)
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
@@ -267,26 +253,26 @@ class WatchCameraViewModel: ObservableObject {
     }
 
     func notePhoneNotInWatchMode() {
-        phoneNotInWatchMode = true
+        readiness = .notinwatchmode
         WKInterfaceDevice.current().play(.failure)
     }
 
     // MARK: - Haptic Feedback
 
-    private func playHaptic(for event: String) {
+    private func playHaptic(for event: RemoteShutter_WatchEventType) {
         let type: WKHapticType
         switch event {
-        case "photoTaken":
+        case .phototaken:
             type = .success
-        case "recordingStarted":
+        case .recordingstarted:
             type = .start
-        case "recordingStopped":
+        case .recordingstopped:
             type = .stop
-        case "photoError", "microphoneDenied", "recordingFailed":
+        case .photoerror, .microphonedenied, .recordingfailed, .sendfailed:
             type = .failure
-        case "busy", "busyRecording":
+        case .busy, .busyrecording:
             type = .retry
-        default:
+        case .unknown:
             type = .notification
         }
         WKInterfaceDevice.current().play(type)

--- a/RemoteShutterWatch/WatchCameraViewModel.swift
+++ b/RemoteShutterWatch/WatchCameraViewModel.swift
@@ -93,12 +93,6 @@ class WatchCameraViewModel: ObservableObject {
     /// as a steady, cancelable overlay rather than flashing per-tick confirmations.
     @Published var countdownRemaining: Int?
 
-    /// Parses a `"countdown:N"` event into its remaining seconds.
-    private static func countdownValue(from event: String) -> Int? {
-        guard event.hasPrefix("countdown:") else { return nil }
-        return Int(event.dropFirst("countdown:".count))
-    }
-
     /// User tapped Cancel: drop the countdown immediately (optimistic) and tell the
     /// phone to abort the pending capture.
     func cancelTimer(send: () -> Void) {
@@ -207,7 +201,6 @@ class WatchCameraViewModel: ObservableObject {
         isReady = state.isReady
         if !state.isReady {
             clearPreview()
-            countdownRemaining = nil
         }
         currentZoomFactor = state.currentZoomFactor
         minZoomFactor = state.minZoomFactor
@@ -221,20 +214,22 @@ class WatchCameraViewModel: ObservableObject {
         zoomStops = state.zoomStops
         wideAngleZoomFactor = state.wideAngleZoomFactor
 
+        // The snapshot is authoritative for the self-timer: no positive countdown
+        // event means no countdown is running. Applying this on every state is what
+        // unsticks a stale overlay after missed pushes (locked phone/watch races).
+        countdownRemaining = state.activeCountdownSeconds
+
         // Handle events with haptic feedback. A live countdown gets a steady,
-        // cancelable overlay; every other event flashes a 2s confirmation.
-        if let event = state.lastEvent {
-            if let remaining = Self.countdownValue(from: event) {
-                countdownRemaining = remaining
-                WKInterfaceDevice.current().play(.click)
-            } else {
-                countdownRemaining = nil
-                lastEvent = event
-                showEventConfirmation = true
-                playHaptic(for: event)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
-                    self?.showEventConfirmation = false
-                }
+        // cancelable overlay; every other user-facing event flashes a 2s
+        // confirmation. `countdown:*` strings are protocol plumbing, never flashed.
+        if countdownRemaining != nil {
+            WKInterfaceDevice.current().play(.click)
+        } else if let event = state.lastEvent, !event.hasPrefix("countdown:") {
+            lastEvent = event
+            showEventConfirmation = true
+            playHaptic(for: event)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+                self?.showEventConfirmation = false
             }
         }
 

--- a/RemoteShutterWatch/WatchControlView.swift
+++ b/RemoteShutterWatch/WatchControlView.swift
@@ -388,7 +388,7 @@ struct WatchControlView: View {
     // MARK: - Event Confirmation
 
     @ViewBuilder
-    private func eventConfirmationView(event: String) -> some View {
+    private func eventConfirmationView(event: RemoteShutter_WatchEventType) -> some View {
         VStack {
             Image(systemName: iconForEvent(event))
                 .font(.title)
@@ -405,39 +405,39 @@ struct WatchControlView: View {
         .accessibilityLabel(textForEvent(event))
     }
 
-    private func iconForEvent(_ event: String) -> String {
+    private func iconForEvent(_ event: RemoteShutter_WatchEventType) -> String {
         switch event {
-        case "photoTaken": return "checkmark.circle.fill"
-        case "recordingStarted": return "record.circle"
-        case "recordingStopped": return "stop.circle.fill"
-        case "photoError", "recordingFailed", "sendFailed": return "xmark.circle.fill"
-        case "microphoneDenied": return "mic.slash.fill"
-        case "busy", "busyRecording": return "hourglass"
-        default: return "info.circle"
+        case .phototaken: return "checkmark.circle.fill"
+        case .recordingstarted: return "record.circle"
+        case .recordingstopped: return "stop.circle.fill"
+        case .photoerror, .recordingfailed, .sendfailed: return "xmark.circle.fill"
+        case .microphonedenied: return "mic.slash.fill"
+        case .busy, .busyrecording: return "hourglass"
+        case .unknown: return "info.circle"
         }
     }
 
-    private func colorForEvent(_ event: String) -> Color {
+    private func colorForEvent(_ event: RemoteShutter_WatchEventType) -> Color {
         switch event {
-        case "photoError", "microphoneDenied", "recordingFailed", "sendFailed": return .red
-        case "recordingStarted": return .red
-        case "busy", "busyRecording": return .orange
-        default: return .green
+        case .photoerror, .microphonedenied, .recordingfailed, .sendfailed: return .red
+        case .recordingstarted: return .red
+        case .busy, .busyrecording: return .orange
+        case .phototaken, .recordingstopped, .unknown: return .green
         }
     }
 
-    private func textForEvent(_ event: String) -> LocalizedStringKey {
+    private func textForEvent(_ event: RemoteShutter_WatchEventType) -> LocalizedStringKey {
         switch event {
-        case "photoTaken": return "Photo Saved"
-        case "recordingStarted": return "Recording"
-        case "recordingStopped": return "Video Saved"
-        case "photoError": return "Photo Failed"
-        case "recordingFailed": return "Recording Failed"
-        case "sendFailed": return "Not Delivered"
-        case "microphoneDenied": return "Mic Denied"
-        case "busy": return "Busy"
-        case "busyRecording": return "Recording…"
-        default: return LocalizedStringKey(event)
+        case .phototaken: return "Photo Saved"
+        case .recordingstarted: return "Recording"
+        case .recordingstopped: return "Video Saved"
+        case .photoerror: return "Photo Failed"
+        case .recordingfailed: return "Recording Failed"
+        case .sendfailed: return "Not Delivered"
+        case .microphonedenied: return "Mic Denied"
+        case .busy: return "Busy"
+        case .busyrecording: return "Recording…"
+        case .unknown: return ""
         }
     }
 }

--- a/RemoteShutterWatch/WatchSessionDelegate.swift
+++ b/RemoteShutterWatch/WatchSessionDelegate.swift
@@ -104,7 +104,9 @@ class WatchSessionDelegate: NSObject, ObservableObject, WCSessionDelegate {
     func manualRetry() {
         DispatchQueue.main.async { [weak self] in
             self?.retryCount = 0
-            self?.viewModel.phoneNotInWatchMode = false
+            // Drop any stale readiness verdict — back to "connecting" until the
+            // phone answers.
+            self?.viewModel.readiness = .unknown
             self?.retryRequestState()
         }
     }
@@ -176,7 +178,11 @@ class WatchSessionDelegate: NSObject, ObservableObject, WCSessionDelegate {
             guard let self else { return }
             switch ack.status {
             case .ok:
-                self.viewModel.phoneNotInWatchMode = false
+                // An Ok ack contradicts a "not in watch mode" verdict — the phone
+                // answered from the Watch Remote screen; its state push follows.
+                if self.viewModel.readiness == .notinwatchmode {
+                    self.viewModel.readiness = .unknown
+                }
                 if action == .requeststate {
                     self.armStateArrivalCheck()
                 }

--- a/Shared/WatchSharedTypes.swift
+++ b/Shared/WatchSharedTypes.swift
@@ -77,6 +77,25 @@ struct WatchCameraStateSnapshot {
     var flashMode: RemoteShutter_FlashMode = .off
 }
 
+extension WatchCameraStateSnapshot {
+    /// Seconds left on an active self-timer, parsed from a `"countdown:N"` event,
+    /// or `nil` when this snapshot carries no live countdown.
+    ///
+    /// A snapshot is authoritative: any push without a positive countdown event
+    /// means no countdown is running. The Watch must apply this on *every* state —
+    /// treating countdown as a sticky event left the overlay stuck when the push
+    /// that would have cleared it (fire, cancel, photoTaken) was coalesced away by
+    /// the latest-wins applicationContext mirror.
+    var activeCountdownSeconds: Int? {
+        guard isReady,
+              let event = lastEvent,
+              event.hasPrefix("countdown:"),
+              let remaining = Int(event.dropFirst("countdown:".count)),
+              remaining > 0 else { return nil }
+        return remaining
+    }
+}
+
 // MARK: - iPhone -> Watch State Encoding
 
 struct WatchStateEncoder {

--- a/Shared/WatchSharedTypes.swift
+++ b/Shared/WatchSharedTypes.swift
@@ -57,7 +57,14 @@ struct WatchCommandEncoder {
 /// Built on the iPhone, FlatBuffer-encoded by `WatchStateEncoder`, decoded
 /// back into the same type on the Watch.
 struct WatchCameraStateSnapshot {
-    var isReady: Bool = true
+    /// Why the phone can or can't capture. `.unknown` means "no signal yet" and
+    /// is never treated as ready.
+    var readiness: RemoteShutter_WatchReadiness = .unknown
+    /// One-shot capture event piggybacked on this push; `.unknown` = no event.
+    var event: RemoteShutter_WatchEventType = .unknown
+    /// Live self-timer seconds (> 0), or 0 when none is running. Authoritative
+    /// in every snapshot — a push without a countdown means no countdown.
+    var countdownRemainingSecs: Int32 = 0
     var currentZoomFactor: Double = 1.0
     var minZoomFactor: Double = 1.0
     var maxZoomFactor: Double = 10.0
@@ -65,34 +72,25 @@ struct WatchCameraStateSnapshot {
     var currentMode: RemoteShutter_RecordingModeEnum = .photo
     var currentLensType: RemoteShutter_CameraLensType = .wideangle
     var availableLensTypes: [RemoteShutter_CameraLensType] = [.wideangle]
-    var isFlashEnabled: Bool = false
+    var flashMode: RemoteShutter_FlashMode = .off
     var isTorchEnabled: Bool = false
     var zoomStops: [Double] = [1.0]
     var wideAngleZoomFactor: Double = 1.0
-    var lastEvent: String?
     /// Milliseconds since epoch, stamped at push time. Orders live messages
     /// against (possibly stale) applicationContext deliveries.
     var stateEpochMs: UInt64 = 0
-    /// Tri-state flash truth; `isFlashEnabled` is kept as the simple bool.
-    var flashMode: RemoteShutter_FlashMode = .off
 }
 
 extension WatchCameraStateSnapshot {
-    /// Seconds left on an active self-timer, parsed from a `"countdown:N"` event,
-    /// or `nil` when this snapshot carries no live countdown.
-    ///
-    /// A snapshot is authoritative: any push without a positive countdown event
-    /// means no countdown is running. The Watch must apply this on *every* state —
-    /// treating countdown as a sticky event left the overlay stuck when the push
-    /// that would have cleared it (fire, cancel, photoTaken) was coalesced away by
-    /// the latest-wins applicationContext mirror.
+    var isReady: Bool { readiness == .ready }
+
+    var isFlashEnabled: Bool { flashMode != .off }
+
+    /// Seconds left on an active self-timer, or `nil` when this snapshot carries
+    /// no live countdown. A countdown only counts while the phone can capture.
     var activeCountdownSeconds: Int? {
-        guard isReady,
-              let event = lastEvent,
-              event.hasPrefix("countdown:"),
-              let remaining = Int(event.dropFirst("countdown:".count)),
-              remaining > 0 else { return nil }
-        return remaining
+        guard readiness == .ready, countdownRemainingSecs > 0 else { return nil }
+        return Int(countdownRemainingSecs)
     }
 }
 
@@ -105,11 +103,12 @@ struct WatchStateEncoder {
 
         let lensVec = fbb.createVector(snapshot.availableLensTypes.map { $0.rawValue })
         let stopsVec = fbb.createVector(snapshot.zoomStops)
-        let eventOffset: Offset = snapshot.lastEvent.map { fbb.create(string: $0) } ?? Offset()
 
         let state = RemoteShutter_WatchCameraState.createWatchCameraState(
             &fbb,
-            isReady: snapshot.isReady,
+            readiness: snapshot.readiness,
+            event: snapshot.event,
+            countdownRemainingSecs: snapshot.countdownRemainingSecs,
             currentZoomFactor: snapshot.currentZoomFactor,
             minZoomFactor: snapshot.minZoomFactor,
             maxZoomFactor: snapshot.maxZoomFactor,
@@ -117,13 +116,11 @@ struct WatchStateEncoder {
             currentMode: snapshot.currentMode,
             currentLensType: snapshot.currentLensType,
             availableLensTypesVectorOffset: lensVec,
-            isFlashEnabled: snapshot.isFlashEnabled,
+            flashMode: snapshot.flashMode,
             isTorchEnabled: snapshot.isTorchEnabled,
             zoomStopsVectorOffset: stopsVec,
             wideAngleZoomFactor: snapshot.wideAngleZoomFactor,
-            lastEventOffset: eventOffset,
-            stateEpochMs: snapshot.stateEpochMs,
-            flashMode: snapshot.flashMode
+            stateEpochMs: snapshot.stateEpochMs
         )
         let msg = RemoteShutter_WatchMessage.createWatchMessage(
             &fbb,
@@ -155,7 +152,9 @@ struct WatchStateEncoder {
         }
 
         return WatchCameraStateSnapshot(
-            isReady: state.isReady,
+            readiness: state.readiness,
+            event: state.event,
+            countdownRemainingSecs: state.countdownRemainingSecs,
             currentZoomFactor: state.currentZoomFactor,
             minZoomFactor: state.minZoomFactor,
             maxZoomFactor: state.maxZoomFactor,
@@ -163,13 +162,11 @@ struct WatchStateEncoder {
             currentMode: state.currentMode,
             currentLensType: state.currentLensType,
             availableLensTypes: lenses,
-            isFlashEnabled: state.isFlashEnabled,
+            flashMode: state.flashMode,
             isTorchEnabled: state.isTorchEnabled,
             zoomStops: stops,
             wideAngleZoomFactor: state.wideAngleZoomFactor,
-            lastEvent: state.lastEvent,
-            stateEpochMs: state.stateEpochMs,
-            flashMode: state.flashMode
+            stateEpochMs: state.stateEpochMs
         )
     }
 }
@@ -297,18 +294,6 @@ enum WatchContextKeys {
     static let epoch = "epoch"
 }
 
-// MARK: - Not-Ready Reasons
-
-/// Reasons the iPhone reports it can't capture, carried in
-/// `WatchCameraStateSnapshot.lastEvent` when `isReady == false`. Shared symbol so the
-/// phone (producer) and Watch (consumer) reference one string instead of two literals
-/// that could silently drift apart across the process boundary.
-enum WatchNotReadyReason {
-    /// The iPhone app is backgrounded or the device is locked — the camera can't run.
-    /// The Watch routes this to its "app closed" screen.
-    static let phoneBackgrounded = "phoneBackgrounded"
-}
-
 // MARK: - Watch UI Connection Phase
 
 /// What the Watch UI should show, derived from connectivity + camera state.
@@ -327,15 +312,15 @@ enum WatchConnectionPhase: Equatable {
 
     static func derive(isSessionActive: Bool,
                        isPhoneReachable: Bool,
-                       isReady: Bool,
-                       phoneNotInWatchMode: Bool,
-                       phoneNotReadyReason: String?) -> WatchConnectionPhase {
+                       readiness: RemoteShutter_WatchReadiness) -> WatchConnectionPhase {
         guard isSessionActive else { return .inactive }
         guard isPhoneReachable else { return .connecting }
-        if isReady { return .ready }
-        if phoneNotReadyReason != nil { return .phoneNotReady }
-        if phoneNotInWatchMode { return .phoneNotInWatchMode }
-        return .connecting
+        switch readiness {
+        case .ready: return .ready
+        case .phonebackgrounded: return .phoneNotReady
+        case .notinwatchmode: return .phoneNotInWatchMode
+        case .unknown: return .connecting
+        }
     }
 }
 


### PR DESCRIPTION
Three changes, merged as one per review preference:

## 1. Fix stuck Watch countdown (bug)

Repro: start a Watch self-timer capture → lock the iPhone mid-countdown → lock the Watch → unlock the iPhone (photo fires) → reopen the Watch. The full-screen countdown overlay was stuck at "1" forever, blocking all controls.

**Root cause:** the Watch's countdown was *event-carried* state with no authoritative clear. Ticks arrived as `lastEvent = "countdown:N"` on state pushes, and the overlay was only cleared by a push carrying a *different non-nil* event or `isReady == false`. Nil-event pushes (requestState/reachability/zoom/capabilities) left it untouched; the fire tick pushed nothing; cancel pushed nothing; and the latest-wins applicationContext mirror coalesced away the `photoTaken` push that would have cleared it.

Fixes: snapshot-authoritative countdown, push on fire/cancel, cancel routed through the actor, Watch re-syncs on `scenePhase == .active`.

## 2. Type-safe Watch state protocol (breaking — feature is unreleased)

`last_event: string` smuggled **three concepts** through one stringly-typed field: one-shot events (`"photoTaken"`), continuous state (`"countdown:3"`), and readiness reasons (`"phoneBackgrounded"`). That design flaw is what the bug grew out of, so it's deleted outright (no compat shims — the Watch feature has never shipped):

**Schema** (`FlatBufferSchemas.fbs`):
- `WatchReadiness` enum (`Unknown / Ready / PhoneBackgrounded / NotInWatchMode`) replaces `is_ready` + the magic string; disconnect pushes state their reason explicitly.
- `WatchEventType` enum replaces event strings (`SendFailed` is Watch-local, never sent).
- `countdown_remaining_secs` field replaces `"countdown:N"` parsing. The countdown is **snapshot state**: every push — zoom, toggles, capability refresh — carries the live value, so no push can drop or resurrect a countdown. This kills the bug *class*, not just the repro.
- `is_flash_enabled` dropped (derived from `flash_mode`).

**Phone:** `RemoteCamSession.watchCountdownRemaining` mirrors ticks into every snapshot; `pushWatchState(ctrl:event:)` takes the typed enum at all ~18 call sites.

**Watch:** the view model collapses `isReady`/`phoneNotInWatchMode`/`phoneNotReadyReason` into one `readiness` enum feeding `WatchConnectionPhase.derive`; haptics and confirmation UI switch **exhaustively** on the typed enums — adding an event case is now a compile error, not a silent `default:`.

## 3. Fix camera preview stuck in portrait after rotation

Rotating the phone on the camera screen rotated the interface but the preview stayed portrait (and landscape captures got portrait orientation metadata).

**Root cause:** the only rotation handler updating the capture connections was `willAnimateRotation(to:duration:)` — deprecated in iOS 8 and never called on modern iOS. The preview layer's frame was also only set at setup; a bare `CALayer` doesn't track the view through rotation.

**Fix (additive):** `viewWillTransition` now rotates the connections inside the transition coordinator (target orientation read from `view.window?.windowScene?.interfaceOrientation`); the torch restore moves to the completion block unchanged; `willAnimateRotation` is kept for any OS that still invokes it (idempotent, double-firing harmless); new `viewDidLayoutSubviews` keeps `captureVideoPreviewLayer.frame = view.bounds`. Applies to both camera screens (peer camera and Watch Remote).

## Testing

- 319 unit tests pass, including new coverage: countdown-as-snapshot-state semantics, all event/readiness enum round-trips, interleaved-pushes-carry-the-countdown, backgrounded snapshots suppress event + countdown, phase derivation from the readiness enum.
- iOS app + Watch app both build.
- Manual before merge: (a) the lock/unlock countdown repro on hardware; (b) rotate the camera screen through all four orientations — preview should fill and follow — and take one landscape photo to confirm it saves upright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)