### PR TITLE
Fix camera preview stuck in portrait after rotation

### DIFF
--- a/RemoteCam/CameraViewController.swift
+++ b/RemoteCam/CameraViewController.swift
@@ -388,20 +388,38 @@ public class CameraViewController: UIViewController,
     }
 
     public override func willAnimateRotation(to toInterfaceOrientation: UIInterfaceOrientation, duration: TimeInterval) {
+        // Deprecated and not called on modern iOS; kept for any OS version that
+        // still invokes it. `viewWillTransition` below is the live rotation path —
+        // both funnel into the same idempotent orientation update.
         orientation = getOrientation()
         self.rotateCameraToOrientation(orientation: toInterfaceOrientation)
     }
 
     public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        // iOS can drop the torch when the capture pipeline reconfigures during rotation.
-        // `viewWillTransition` fires reliably on modern iOS (unlike the deprecated
-        // `willAnimateRotation`), so restore the user's torch intent once the rotation
-        // settles and re-sync the Watch, which would otherwise keep a stale torch state.
-        coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+        coordinator.animate(alongsideTransition: { [weak self] _ in
+            guard let self else { return }
+            // Mid-transition the window scene already reports the TARGET
+            // orientation (getOrientation()'s foreground-scene lookup would still
+            // return the old one if read before the animation block).
+            let newOrientation = self.view.window?.windowScene?.interfaceOrientation ?? getOrientation()
+            self.orientation = newOrientation
+            self.rotateCameraToOrientation(orientation: newOrientation)
+        }, completion: { [weak self] _ in
+            // iOS can drop the torch when the capture pipeline reconfigures during
+            // rotation, so restore the user's torch intent once the rotation
+            // settles and re-sync the Watch, which would otherwise keep a stale
+            // torch state.
             self?.applyDesiredTorch()
             self?.syncTorchToWatch()
-        }
+        })
+    }
+
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        // The preview is a bare CALayer — it does not track the view through
+        // rotation or layout changes, so keep it glued to the current bounds.
+        captureVideoPreviewLayer?.frame = view.bounds
     }
 
     func setupCamera() {


### PR DESCRIPTION
## Bug

Rotating the phone on the camera screen rotates the interface, but the camera preview stays portrait (and captured photos/videos get portrait orientation metadata in landscape).

## Root cause

The only rotation handler that updated the capture connections was `willAnimateRotation(to:duration:)` — deprecated in iOS 8 and **never called** on modern iOS. The adjacent `viewWillTransition` (which does fire) only restored the torch. Additionally, the preview layer's frame was only set at setup; a bare `CALayer` doesn't track the view through rotation, so it kept portrait bounds.

## Fix (additive — no behavior removed)

- `viewWillTransition` now updates `orientation` and calls `rotateCameraToOrientation` inside the transition coordinator's `alongsideTransition` block, reading the target orientation from `view.window?.windowScene?.interfaceOrientation` (already reports the new orientation mid-transition; `getOrientation()` would still return the old one). The existing torch restore moves to the completion block unchanged.
- `willAnimateRotation` is **kept** for any OS version that still invokes it — the orientation update is idempotent, so double-firing is harmless.
- New `viewDidLayoutSubviews` keeps `captureVideoPreviewLayer.frame = view.bounds`.

Applies to both camera screens (peer camera and Watch Remote), which embed `CameraViewController`.

## Testing

- 312 unit tests pass; iOS app builds. (No practical unit-test seam for AVFoundation rotation.)
- Manual: rotate the phone on the camera screen → preview should fill the screen and follow orientation in all four orientations; take a landscape photo and confirm it saves upright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)