### PR TITLE
Robust preview streaming: HEIC frames + stall-proof transport (phone monitor & Watch)

### DIFF
--- a/RemoteCam/CameraViewController.swift
+++ b/RemoteCam/CameraViewController.swift
@@ -89,6 +89,19 @@ public class CameraViewController: UIViewController,
     /// JPEG fallback), and hands frames to the FrameSender actor.
     /// Runs on `videoDataOutputQueue`.
     private lazy var frameStreamer = FrameStreamer { [frameSender] frame in frameSender ! frame }
+    /// Encoder chain for the Watch preview (HEIC with permanent JPEG fallback).
+    /// Runs on `videoDataOutputQueue` via `watchPreviewStreamer.offer`.
+    private lazy var watchFrameEncoders: [FrameEncoding] = {
+        let config = StreamingConfig.default
+        return [
+            HEICFrameEncoder(context: watchPreviewContext,
+                             maxLongEdge: config.watchMaxLongEdge,
+                             quality: config.watchHEICQuality),
+            JPEGFrameEncoder(context: watchPreviewContext,
+                             maxLongEdge: config.watchMaxLongEdge,
+                             quality: config.watchJPEGQuality)
+        ]
+    }()
     var pixelBufferAdaptor: AVAssetWriterInputPixelBufferAdaptor?
     var cachedVideoCropRect: CGRect? // Computed once at recording start, reused per frame
     
@@ -1442,7 +1455,7 @@ extension CameraViewController: AVCaptureVideoDataOutputSampleBufferDelegate, AV
         // and the only consumer is the Apple Watch. The streamer applies ack back-pressure
         // and only invokes the encode when it's actually ready to send.
         if isWatchRemoteMode {
-            watchPreviewStreamer.offer { [weak self] in self?.watchPreviewJPEG(from: sampleBuffer) }
+            watchPreviewStreamer.offer { [weak self] in self?.watchPreviewImageData(from: sampleBuffer) }
             return
         }
 
@@ -1454,19 +1467,15 @@ extension CameraViewController: AVCaptureVideoDataOutputSampleBufferDelegate, AV
                              fps: fps)
     }
 
-    /// Builds a compact JPEG of the current frame for the Apple Watch live preview:
-    /// long edge ~320 px (matching the Watch screen width) at quality 0.55, ~10-20 KB
-    /// per frame. The sample buffer is already oriented by
-    /// `videoConnection.videoOrientation`, so it renders upright.
-    private func watchPreviewJPEG(from sampleBuffer: CMSampleBuffer) -> Data? {
+    /// Builds a compact still of the current frame for the Apple Watch live
+    /// preview: long edge ~320 px (matching the Watch screen width), HEIC when
+    /// the hardware supports it (~half the bytes of JPEG, so roughly double the
+    /// frame rate over the WCSession pipe), JPEG otherwise. The Watch decodes
+    /// either transparently via UIImage(data:). The sample buffer is already
+    /// oriented by `videoConnection.videoOrientation`, so it renders upright.
+    private func watchPreviewImageData(from sampleBuffer: CMSampleBuffer) -> Data? {
         guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return nil }
-        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
-        let longEdge = max(ciImage.extent.width, ciImage.extent.height)
-        guard longEdge > 0 else { return nil }
-        let scale = min(1.0, 320.0 / longEdge)
-        let scaled = ciImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
-        guard let cgImage = watchPreviewContext.createCGImage(scaled, from: scaled.extent) else { return nil }
-        return UIImage(cgImage: cgImage).jpegData(compressionQuality: 0.55)
+        return encodeWithFallback(&watchFrameEncoders, pixelBuffer: pixelBuffer)
     }
 
     /// The Watch acked the in-flight preview frame — let the streamer send the next.

--- a/RemoteCam/CameraViewController.swift
+++ b/RemoteCam/CameraViewController.swift
@@ -85,6 +85,10 @@ public class CameraViewController: UIViewController,
     /// Streams preview frames to the Apple Watch with ack back-pressure and lazy encoding.
     /// Runs on `videoDataOutputQueue`, where the capture callback hands it sample buffers.
     private lazy var watchPreviewStreamer = WatchPreviewStreamer(queue: videoDataOutputQueue)
+    /// Streams preview frames to the phone monitor: paces, encodes (HEIC with
+    /// JPEG fallback), and hands frames to the FrameSender actor.
+    /// Runs on `videoDataOutputQueue`.
+    private lazy var frameStreamer = FrameStreamer { [frameSender] frame in frameSender ! frame }
     var pixelBufferAdaptor: AVAssetWriterInputPixelBufferAdaptor?
     var cachedVideoCropRect: CGRect? // Computed once at recording start, reused per frame
     
@@ -93,9 +97,6 @@ public class CameraViewController: UIViewController,
     private var videoInput: AVAssetWriterInput!
     private var audioInput: AVAssetWriterInput!
 
-    // Variable used to downsample the camera preview, please use with care.
-    private var sendFrame = true
-    
     // MARK: - Recording Timer Properties
     private var recordingStartTime: Date?
     private var recordingTimerController: CameraRecordingTimerViewController?
@@ -1437,11 +1438,6 @@ extension CameraViewController: AVCaptureVideoDataOutputSampleBufferDelegate, AV
     public func sendFrameToMonitor(_ captureOutput: AVCaptureOutput,
                               didOutput sampleBuffer: CMSampleBuffer,
                               from connection: AVCaptureConnection) {
-        sendFrame = !sendFrame
-        if !sendFrame {
-            return
-        }
-
         // Watch Remote mode has no MultipeerConnectivity peer — the iPhone is the camera
         // and the only consumer is the Apple Watch. The streamer applies ack back-pressure
         // and only invokes the encode when it's actually ready to send.
@@ -1450,15 +1446,12 @@ extension CameraViewController: AVCaptureVideoDataOutputSampleBufferDelegate, AV
             return
         }
 
-        if let cgBackedImage = imageFromSampleBuffer(sampleBuffer: sampleBuffer),
-           let imageData = cgBackedImage.jpegData(compressionQuality: 0.1),
-           let device = self.videoDeviceInput?.device {
-            frameSender ! RemoteCmd.SendFrame(data: imageData,
-                    sender: nil,
-                    fps: fps,
-                    camPosition: device.position,
-                    camOrientation: self.orientation)
-        }
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer),
+              let device = self.videoDeviceInput?.device else { return }
+        frameStreamer.handle(pixelBuffer: pixelBuffer,
+                             position: device.position,
+                             orientation: self.orientation,
+                             fps: fps)
     }
 
     /// Builds a compact JPEG of the current frame for the Apple Watch live preview:

--- a/RemoteCam/FlatBufferSchemas.fbs
+++ b/RemoteCam/FlatBufferSchemas.fbs
@@ -101,6 +101,15 @@ enum AspectRatioEnum : byte {
     OneOne = 3
 }
 
+// Payload format of FrameData.image_data. Unknown = legacy peer that predates
+// this field — treat as JPEG. HEVC is reserved for the video-codec follow-up.
+enum StreamCodec : byte {
+    Unknown = 0,
+    JPEG = 1,
+    HEVC = 2,
+    HEIC = 3
+}
+
 // MARK: - Command Parameters
 
 table CommandParameters {
@@ -207,6 +216,9 @@ table FrameData {
     fps: int;
     camera_position: CameraPosition;
     orientation: int;
+    // Appended fields only below this line (FlatBuffers schema evolution).
+    codec: StreamCodec;              // absent/Unknown => JPEG (legacy sender)
+    sequence_number: uint32;         // per-stream monotonic; gaps are logged on the monitor
 }
 
 // MARK: - P2P Message Envelope

--- a/RemoteCam/FlatBufferSchemas.fbs
+++ b/RemoteCam/FlatBufferSchemas.fbs
@@ -323,7 +323,8 @@ table WatchCommandAck {
 // Low-res, heavily-compressed live preview frame streamed iPhone -> Watch so the
 // user can frame the shot. Separate from the full-quality capture pipeline.
 table WatchPreviewFrame {
-    jpeg: [ubyte];
+    jpeg: [ubyte];        // still-image container: HEIC when the iPhone has an HEVC
+                          // encoder, JPEG otherwise; UIImage(data:) sniffs either
     epoch_ms: uint64;     // ordering, mirrors WatchCameraState.state_epoch_ms
 }
 

--- a/RemoteCam/FlatBufferSchemas_generated.swift
+++ b/RemoteCam/FlatBufferSchemas_generated.swift
@@ -179,6 +179,20 @@ public enum RemoteShutter_AspectRatioEnum: Int8, Enum, Verifiable {
 }
 
 
+public enum RemoteShutter_StreamCodec: Int8, Enum, Verifiable {
+  public typealias T = Int8
+  public static var byteSize: Int { return MemoryLayout<Int8>.size }
+  public var value: Int8 { return self.rawValue }
+  case unknown = 0
+  case jpeg = 1
+  case hevc = 2
+  case heic = 3
+
+  public static var max: RemoteShutter_StreamCodec { return .heic }
+  public static var min: RemoteShutter_StreamCodec { return .unknown }
+}
+
+
 public enum RemoteShutter_WatchCommandAction: Int8, Enum, Verifiable {
   public typealias T = Int8
   public static var byteSize: Int { return MemoryLayout<Int8>.size }
@@ -1000,6 +1014,8 @@ public struct RemoteShutter_FrameData: FlatBufferObject, Verifiable {
     case fps = 6
     case cameraPosition = 8
     case orientation = 10
+    case codec = 12
+    case sequenceNumber = 14
     var v: Int32 { Int32(self.rawValue) }
     var p: VOffset { self.rawValue }
   }
@@ -1011,24 +1027,32 @@ public struct RemoteShutter_FrameData: FlatBufferObject, Verifiable {
   public var fps: Int32 { let o = _accessor.offset(VTOFFSET.fps.v); return o == 0 ? 0 : _accessor.readBuffer(of: Int32.self, at: o) }
   public var cameraPosition: RemoteShutter_CameraPosition { let o = _accessor.offset(VTOFFSET.cameraPosition.v); return o == 0 ? .back : RemoteShutter_CameraPosition(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .back }
   public var orientation: Int32 { let o = _accessor.offset(VTOFFSET.orientation.v); return o == 0 ? 0 : _accessor.readBuffer(of: Int32.self, at: o) }
-  public static func startFrameData(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 4) }
+  public var codec: RemoteShutter_StreamCodec { let o = _accessor.offset(VTOFFSET.codec.v); return o == 0 ? .unknown : RemoteShutter_StreamCodec(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .unknown }
+  public var sequenceNumber: UInt32 { let o = _accessor.offset(VTOFFSET.sequenceNumber.v); return o == 0 ? 0 : _accessor.readBuffer(of: UInt32.self, at: o) }
+  public static func startFrameData(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 6) }
   public static func addVectorOf(imageData: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: imageData, at: VTOFFSET.imageData.p) }
   public static func add(fps: Int32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: fps, def: 0, at: VTOFFSET.fps.p) }
   public static func add(cameraPosition: RemoteShutter_CameraPosition, _ fbb: inout FlatBufferBuilder) { fbb.add(element: cameraPosition.rawValue, def: 0, at: VTOFFSET.cameraPosition.p) }
   public static func add(orientation: Int32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: orientation, def: 0, at: VTOFFSET.orientation.p) }
+  public static func add(codec: RemoteShutter_StreamCodec, _ fbb: inout FlatBufferBuilder) { fbb.add(element: codec.rawValue, def: 0, at: VTOFFSET.codec.p) }
+  public static func add(sequenceNumber: UInt32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: sequenceNumber, def: 0, at: VTOFFSET.sequenceNumber.p) }
   public static func endFrameData(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createFrameData(
     _ fbb: inout FlatBufferBuilder,
     imageDataVectorOffset imageData: Offset = Offset(),
     fps: Int32 = 0,
     cameraPosition: RemoteShutter_CameraPosition = .back,
-    orientation: Int32 = 0
+    orientation: Int32 = 0,
+    codec: RemoteShutter_StreamCodec = .unknown,
+    sequenceNumber: UInt32 = 0
   ) -> Offset {
     let __start = RemoteShutter_FrameData.startFrameData(&fbb)
     RemoteShutter_FrameData.addVectorOf(imageData: imageData, &fbb)
     RemoteShutter_FrameData.add(fps: fps, &fbb)
     RemoteShutter_FrameData.add(cameraPosition: cameraPosition, &fbb)
     RemoteShutter_FrameData.add(orientation: orientation, &fbb)
+    RemoteShutter_FrameData.add(codec: codec, &fbb)
+    RemoteShutter_FrameData.add(sequenceNumber: sequenceNumber, &fbb)
     return RemoteShutter_FrameData.endFrameData(&fbb, start: __start)
   }
 
@@ -1038,6 +1062,8 @@ public struct RemoteShutter_FrameData: FlatBufferObject, Verifiable {
     try _v.visit(field: VTOFFSET.fps.p, fieldName: "fps", required: false, type: Int32.self)
     try _v.visit(field: VTOFFSET.cameraPosition.p, fieldName: "cameraPosition", required: false, type: RemoteShutter_CameraPosition.self)
     try _v.visit(field: VTOFFSET.orientation.p, fieldName: "orientation", required: false, type: Int32.self)
+    try _v.visit(field: VTOFFSET.codec.p, fieldName: "codec", required: false, type: RemoteShutter_StreamCodec.self)
+    try _v.visit(field: VTOFFSET.sequenceNumber.p, fieldName: "sequenceNumber", required: false, type: UInt32.self)
     _v.finish()
   }
 }

--- a/RemoteCam/FrameCodecs.swift
+++ b/RemoteCam/FrameCodecs.swift
@@ -1,0 +1,34 @@
+//
+//  FrameCodecs.swift
+//  RemoteShutter
+//
+//  Encoder abstraction for the preview stream. Each encoder is a named,
+//  self-contained strategy (JPEGFrameEncoder, HEICFrameEncoder, later
+//  HEVCFrameEncoder for true video) so codecs can be added without touching
+//  the pipeline. The wire carries RemoteCmd.StreamCodec per frame, so the
+//  receiver decodes whatever arrives.
+//
+
+import Foundation
+import CoreImage
+import CoreVideo
+
+/// A synchronous still-frame encoder. Called on the capture queue; must not
+/// block longer than a frame interval. Returns nil when this codec cannot
+/// encode on the current hardware — the streamer then falls back to the next
+/// preferred codec permanently.
+protocol FrameEncoding: AnyObject {
+    var codec: RemoteCmd.StreamCodec { get }
+    func encode(pixelBuffer: CVPixelBuffer) -> Data?
+}
+
+/// Downscales a capture pixel buffer so its long edge is at most `maxLongEdge`.
+/// The buffer is already oriented by the capture connection's videoOrientation,
+/// so no rotation is applied here.
+func downscaledCIImage(from pixelBuffer: CVPixelBuffer, maxLongEdge: CGFloat) -> CIImage? {
+    let image = CIImage(cvPixelBuffer: pixelBuffer)
+    let longEdge = max(image.extent.width, image.extent.height)
+    guard longEdge > 0 else { return nil }
+    let scale = min(1.0, maxLongEdge / longEdge)
+    return image.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+}

--- a/RemoteCam/FrameCodecs.swift
+++ b/RemoteCam/FrameCodecs.swift
@@ -22,6 +22,22 @@ protocol FrameEncoding: AnyObject {
     func encode(pixelBuffer: CVPixelBuffer) -> Data?
 }
 
+/// Encodes with the first working encoder in `chain`, permanently dropping
+/// encoders that fail (e.g. HEIC on hardware without an HEVC encoder). Shared
+/// by the phone-monitor pipeline (FrameStreamer) and the Watch preview path.
+/// Confined to the caller's queue; `chain` is mutated on fallback.
+func encodeWithFallback(_ chain: inout [FrameEncoding], pixelBuffer: CVPixelBuffer) -> Data? {
+    while let encoder = chain.first {
+        if let data = encoder.encode(pixelBuffer: pixelBuffer) {
+            return data
+        }
+        chain.removeFirst()
+        let next = chain.first.map { String(describing: $0.codec) } ?? "none"
+        StreamLog.encode.error("\(String(describing: encoder.codec)) encoder failed — falling back to \(next)")
+    }
+    return nil
+}
+
 /// Downscales a capture pixel buffer so its long edge is at most `maxLongEdge`.
 /// The buffer is already oriented by the capture connection's videoOrientation,
 /// so no rotation is applied here.

--- a/RemoteCam/FrameSender.swift
+++ b/RemoteCam/FrameSender.swift
@@ -19,12 +19,31 @@ class SetSession : Actor.Message {
     }
 }
 
+/// Watchdog message the sender schedules to itself when it starts waiting for
+/// the monitor's `RequestFrame` ack. The generation counter makes timeouts from
+/// completed waits harmless (same pattern as `RemoteCamSession.scheduleTimeout`).
+class AckTimeout: Actor.Message {
+    let generation: Int
+    init(generation: Int) {
+        self.generation = generation
+        super.init()
+    }
+}
+
 let readyToSendFrame = "readyToSendFrame"
 let waitingForAckName = "waitingForAck"
 
 class FrameSender: Actor {
 
+    /// How long to wait for the monitor's `RequestFrame` ack before concluding
+    /// it was lost and re-opening the send gate. Without this, one lost ack
+    /// wedges the stream forever: the monitor only acks frames it receives, and
+    /// the camera only sends frames when acked.
+    static let ackTimeout: TimeInterval = 1.0
+
     weak var ressionRef: ActorRef?
+
+    private(set) var ackGeneration = 0
 
     public required init(context: ActorSystem, ref: ActorRef) {
         super.init(context: context, ref: ref)
@@ -33,6 +52,8 @@ class FrameSender: Actor {
     override func receive(msg: Actor.Message) {
         switch msg {
         case is OnEnter:
+            break
+        case is AckTimeout:
             break
         case let s as SetSession:
             self.become(name: readyToSendFrame, state: readyToSend(s), discardOld: true)
@@ -46,12 +67,16 @@ class FrameSender: Actor {
             switch msg {
             case is OnEnter:
                 break
+            case is AckTimeout:
+                break // stale: the wait it guarded is already over
+
             case let s as SetSession:
                 self.become(name: readyToSendFrame, state: readyToSend(s), discardOld: true)
 
             case let s as RemoteCmd.SendFrame:
                 data.session?.sendCommandOrGoToScanning(peer: [data.peer], msg: s, mode: .unreliable)
                 self.become(name: waitingForAckName, state: waitingForAck(data), discardOld: true)
+                self.armAckWatchdog()
             default:
                 self.receive(msg: msg)
             }
@@ -64,16 +89,32 @@ class FrameSender: Actor {
             case is OnEnter:
                 break
             case is RemoteCmd.SendFrame:
-                break
+                break // back-pressure: drop frames until the in-flight one is acked
+
             case let s as SetSession:
                 self.become(name: readyToSendFrame, state: readyToSend(s), discardOld: true)
 
             case is RemoteCmd.RequestFrame:
                 self.become(name: readyToSendFrame, state: readyToSend(session), discardOld: true)
 
+            case let timeout as AckTimeout:
+                guard timeout.generation == self.ackGeneration else { break }
+                StreamLog.transport.info("ack watchdog fired after \(Self.ackTimeout, format: .fixed(precision: 1))s — re-arming sender")
+                self.become(name: readyToSendFrame, state: readyToSend(session), discardOld: true)
+
             default:
                 self.receive(msg: msg)
             }
+        }
+    }
+
+    private func armAckWatchdog() {
+        ackGeneration += 1
+        let generation = ackGeneration
+        let actorRef = this
+        DispatchQueue.global().asyncAfter(deadline: .now() + Self.ackTimeout) { [weak self] in
+            guard self != nil else { return }
+            actorRef ! AckTimeout(generation: generation)
         }
     }
 

--- a/RemoteCam/FrameSender.swift
+++ b/RemoteCam/FrameSender.swift
@@ -9,7 +9,7 @@
 import Foundation
 import MultipeerConnectivity
 
-class SetSession : Actor.Message {
+class SetSession: Actor.Message {
     let peer: MCPeerID
     unowned var session: RemoteCamSession?
     init(peer: MCPeerID, session: RemoteCamSession) {
@@ -55,8 +55,8 @@ class FrameSender: Actor {
             break
         case is AckTimeout:
             break
-        case let s as SetSession:
-            self.become(name: readyToSendFrame, state: readyToSend(s), discardOld: true)
+        case let newSession as SetSession:
+            self.become(name: readyToSendFrame, state: readyToSend(newSession), discardOld: true)
         default:
             super.receive(msg: msg)
         }
@@ -70,11 +70,11 @@ class FrameSender: Actor {
             case is AckTimeout:
                 break // stale: the wait it guarded is already over
 
-            case let s as SetSession:
-                self.become(name: readyToSendFrame, state: readyToSend(s), discardOld: true)
+            case let newSession as SetSession:
+                self.become(name: readyToSendFrame, state: readyToSend(newSession), discardOld: true)
 
-            case let s as RemoteCmd.SendFrame:
-                data.session?.sendCommandOrGoToScanning(peer: [data.peer], msg: s, mode: .unreliable)
+            case let frame as RemoteCmd.SendFrame:
+                data.session?.sendCommandOrGoToScanning(peer: [data.peer], msg: frame, mode: .unreliable)
                 self.become(name: waitingForAckName, state: waitingForAck(data), discardOld: true)
                 self.armAckWatchdog()
             default:
@@ -91,15 +91,16 @@ class FrameSender: Actor {
             case is RemoteCmd.SendFrame:
                 break // back-pressure: drop frames until the in-flight one is acked
 
-            case let s as SetSession:
-                self.become(name: readyToSendFrame, state: readyToSend(s), discardOld: true)
+            case let newSession as SetSession:
+                self.become(name: readyToSendFrame, state: readyToSend(newSession), discardOld: true)
 
             case is RemoteCmd.RequestFrame:
                 self.become(name: readyToSendFrame, state: readyToSend(session), discardOld: true)
 
             case let timeout as AckTimeout:
                 guard timeout.generation == self.ackGeneration else { break }
-                StreamLog.transport.info("ack watchdog fired after \(Self.ackTimeout, format: .fixed(precision: 1))s — re-arming sender")
+                StreamLog.transport.info(
+                    "ack watchdog fired after \(Self.ackTimeout, format: .fixed(precision: 1))s — re-arming sender")
                 self.become(name: readyToSendFrame, state: readyToSend(session), discardOld: true)
 
             default:

--- a/RemoteCam/FrameStreamReceiver.swift
+++ b/RemoteCam/FrameStreamReceiver.swift
@@ -97,7 +97,8 @@ final class FrameStreamReceiver {
         trackStats(frame, at: time)
 
         guard let image = UIImage(data: frame.data) else {
-            StreamLog.decode.error("undecodable frame seq=\(frame.sequenceNumber) codec=\(String(describing: frame.codec)) bytes=\(frame.data.count)")
+            StreamLog.decode.error(
+                "undecodable frame seq=\(frame.sequenceNumber) codec=\(String(describing: frame.codec)) bytes=\(frame.data.count)")
             return
         }
         onImage?(image)
@@ -121,7 +122,11 @@ final class FrameStreamReceiver {
         guard elapsed >= 1.0 else { return }
         let fps = Double(statsFrames) / elapsed
         let kbPerFrame = Double(statsBytes) / Double(statsFrames) / 1024.0
-        StreamLog.decode.debug("stream stats: \(fps, format: .fixed(precision: 1))fps \(kbPerFrame, format: .fixed(precision: 1))KB/frame codec=\(String(describing: frame.codec))")
+        StreamLog.decode.debug(
+            """
+            stream stats: \(fps, format: .fixed(precision: 1))fps \
+            \(kbPerFrame, format: .fixed(precision: 1))KB/frame codec=\(String(describing: frame.codec))
+            """)
         statsWindowStart = time
         statsFrames = 0
         statsBytes = 0
@@ -132,7 +137,8 @@ final class FrameStreamReceiver {
         guard time - lastFrameAt > config.stallTimeout,
               time - lastStallReportAt > config.stallTimeout else { return }
         lastStallReportAt = time
-        StreamLog.transport.info("no frame for \(time - self.lastFrameAt, format: .fixed(precision: 1))s — raising StreamStalled")
+        StreamLog.transport.info(
+            "no frame for \(time - self.lastFrameAt, format: .fixed(precision: 1))s — raising StreamStalled")
         onStall?()
     }
 

--- a/RemoteCam/FrameStreamReceiver.swift
+++ b/RemoteCam/FrameStreamReceiver.swift
@@ -1,0 +1,143 @@
+//
+//  FrameStreamReceiver.swift
+//  RemoteShutter
+//
+//  Monitor-side streaming pipeline: decodes incoming frames off the actor
+//  mailbox on a dedicated queue, watches for stalls (no frame for
+//  stallTimeout -> onStall so the state machine re-requests one), recovers on
+//  foreground, and logs sequence gaps + per-second stream stats.
+//
+//  UIImage(data:) sniffs the container from magic bytes, so JPEG and HEIC
+//  frames (and frames from legacy peers) all decode through the same path.
+//
+
+import UIKit
+
+final class FrameStreamReceiver {
+
+    /// Decoded frame ready for display. Called on the decode queue — hop to
+    /// main before touching UI.
+    var onImage: ((UIImage) -> Void)?
+    /// No frame has arrived for `config.stallTimeout`. Called on the decode
+    /// queue, at most once per timeout while the stall persists.
+    var onStall: (() -> Void)?
+
+    private let config: StreamingConfig
+    private let now: () -> TimeInterval
+    let decodeQueue = DispatchQueue(label: "frame stream decode queue", qos: .userInteractive)
+
+    private var timer: DispatchSourceTimer?
+    private var foregroundObserver: NSObjectProtocol?
+
+    // State below is confined to decodeQueue.
+    private var lastFrameAt: TimeInterval = 0
+    private var lastStallReportAt: TimeInterval = 0
+    private var lastSequenceNumber: UInt32 = 0
+    private(set) var sequenceGapCount = 0
+    private var statsFrames = 0
+    private var statsBytes = 0
+    private var statsWindowStart: TimeInterval = 0
+
+    init(config: StreamingConfig = .default,
+         now: @escaping () -> TimeInterval = { Date().timeIntervalSinceReferenceDate },
+         notificationCenter: NotificationCenter = .default) {
+        self.config = config
+        self.now = now
+        foregroundObserver = notificationCenter.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            guard let self else { return }
+            self.decodeQueue.async {
+                // iOS may have frozen both peers while backgrounded; the
+                // in-flight ping-pong message is likely gone. Re-request
+                // immediately instead of waiting for the stall watchdog.
+                StreamLog.lifecycle.info("monitor foregrounded — re-requesting frame")
+                self.resetStallClock()
+                self.onStall?()
+            }
+        }
+    }
+
+    deinit {
+        if let foregroundObserver {
+            NotificationCenter.default.removeObserver(foregroundObserver)
+        }
+        timer?.cancel()
+    }
+
+    /// Arms the stall watchdog. Call once the monitor UI is up.
+    func start() {
+        decodeQueue.async { self.resetStallClock() }
+        let timer = DispatchSource.makeTimerSource(queue: decodeQueue)
+        timer.schedule(deadline: .now() + config.stallCheckInterval,
+                       repeating: config.stallCheckInterval)
+        timer.setEventHandler { [weak self] in self?.checkForStall() }
+        timer.resume()
+        self.timer = timer
+    }
+
+    func invalidate() {
+        timer?.cancel()
+        timer = nil
+    }
+
+    /// Thread-safe entry point: decode + display a received frame.
+    func receive(_ frame: RemoteCmd.OnFrame) {
+        decodeQueue.async { self.process(frame) }
+    }
+
+    // MARK: - decodeQueue
+
+    private func process(_ frame: RemoteCmd.OnFrame) {
+        let time = now()
+        lastFrameAt = time
+        trackSequence(frame)
+        trackStats(frame, at: time)
+
+        guard let image = UIImage(data: frame.data) else {
+            StreamLog.decode.error("undecodable frame seq=\(frame.sequenceNumber) codec=\(String(describing: frame.codec)) bytes=\(frame.data.count)")
+            return
+        }
+        onImage?(image)
+    }
+
+    /// Sequence gaps are expected occasionally (frames ride .unreliable); for
+    /// stills the next frame self-heals, so gaps are a debug signal only.
+    private func trackSequence(_ frame: RemoteCmd.OnFrame) {
+        defer { lastSequenceNumber = frame.sequenceNumber }
+        guard frame.sequenceNumber != 0, lastSequenceNumber != 0,
+              frame.sequenceNumber > lastSequenceNumber &+ 1 else { return }
+        sequenceGapCount += 1
+        StreamLog.decode.debug("sequence gap: \(self.lastSequenceNumber) -> \(frame.sequenceNumber)")
+    }
+
+    private func trackStats(_ frame: RemoteCmd.OnFrame, at time: TimeInterval) {
+        if statsWindowStart == 0 { statsWindowStart = time }
+        statsFrames += 1
+        statsBytes += frame.data.count
+        let elapsed = time - statsWindowStart
+        guard elapsed >= 1.0 else { return }
+        let fps = Double(statsFrames) / elapsed
+        let kbPerFrame = Double(statsBytes) / Double(statsFrames) / 1024.0
+        StreamLog.decode.debug("stream stats: \(fps, format: .fixed(precision: 1))fps \(kbPerFrame, format: .fixed(precision: 1))KB/frame codec=\(String(describing: frame.codec))")
+        statsWindowStart = time
+        statsFrames = 0
+        statsBytes = 0
+    }
+
+    func checkForStall() {
+        let time = now()
+        guard time - lastFrameAt > config.stallTimeout,
+              time - lastStallReportAt > config.stallTimeout else { return }
+        lastStallReportAt = time
+        StreamLog.transport.info("no frame for \(time - self.lastFrameAt, format: .fixed(precision: 1))s — raising StreamStalled")
+        onStall?()
+    }
+
+    private func resetStallClock() {
+        lastFrameAt = now()
+        lastStallReportAt = 0
+    }
+}

--- a/RemoteCam/FrameStreamer.swift
+++ b/RemoteCam/FrameStreamer.swift
@@ -1,0 +1,93 @@
+//
+//  FrameStreamer.swift
+//  RemoteShutter
+//
+//  Camera-side streaming pipeline: paces capture callbacks, encodes with the
+//  first working codec from StreamingConfig.preferredCodecs (permanent
+//  fallback on encoder failure), stamps sequence numbers, and hands the
+//  result to the FrameSender actor for ack-gated transport.
+//
+//  Confined to the capture queue: `handle` must only be called from the
+//  AVCaptureVideoDataOutput callback queue (same contract as
+//  WatchPreviewStreamer).
+//
+
+import UIKit
+import AVFoundation
+
+final class FrameStreamer {
+
+    typealias Send = (RemoteCmd.SendFrame) -> Void
+
+    private let config: StreamingConfig
+    private let send: Send
+
+    /// Remaining codec chain; first entry is the active encoder.
+    private var encoders: [FrameEncoding]
+    private var frameCount = 0
+    private var sequenceNumber: UInt32 = 0
+
+    /// - Parameter encoders: injectable for tests; nil builds the chain from
+    ///   `config.preferredCodecs`.
+    init(config: StreamingConfig = .default,
+         encoders: [FrameEncoding]? = nil,
+         send: @escaping Send) {
+        self.config = config
+        self.send = send
+        self.encoders = encoders ?? Self.makeEncoders(config: config)
+    }
+
+    var activeCodec: RemoteCmd.StreamCodec? { encoders.first?.codec }
+
+    /// Capture-queue only. Encodes and sends this frame unless pacing skips it
+    /// or every codec in the chain has failed.
+    func handle(pixelBuffer: CVPixelBuffer,
+                position: AVCaptureDevice.Position,
+                orientation: UIInterfaceOrientation,
+                fps: Int) {
+        frameCount += 1
+        guard frameCount % config.frameDivisor == 0 else { return }
+
+        guard let data = encodeWithFallback(pixelBuffer: pixelBuffer),
+              let codec = activeCodec else { return }
+
+        sequenceNumber &+= 1
+        StreamLog.encode.debug("frame seq=\(self.sequenceNumber) codec=\(String(describing: codec)) bytes=\(data.count)")
+        send(RemoteCmd.SendFrame(
+            data: data,
+            sender: nil,
+            fps: fps,
+            camPosition: position,
+            camOrientation: orientation,
+            codec: codec,
+            sequenceNumber: sequenceNumber
+        ))
+    }
+
+    private func encodeWithFallback(pixelBuffer: CVPixelBuffer) -> Data? {
+        while let encoder = encoders.first {
+            if let data = encoder.encode(pixelBuffer: pixelBuffer) {
+                return data
+            }
+            // Permanent fallback: an encoder that fails once (e.g. no HEVC
+            // hardware) is dropped from the chain for the session's lifetime.
+            encoders.removeFirst()
+            let next = encoders.first.map { String(describing: $0.codec) } ?? "none"
+            StreamLog.encode.error("\(String(describing: encoder.codec)) encoder failed — falling back to \(next)")
+        }
+        return nil
+    }
+
+    private static func makeEncoders(config: StreamingConfig) -> [FrameEncoding] {
+        config.preferredCodecs.compactMap { codec in
+            switch codec {
+            case .heic:
+                return HEICFrameEncoder(maxLongEdge: config.maxLongEdge, quality: config.heicQuality)
+            case .jpeg:
+                return JPEGFrameEncoder(maxLongEdge: config.maxLongEdge, quality: config.jpegQuality)
+            case .hevc:
+                return nil // video codec: follow-up PR (HEVCFrameEncoder)
+            }
+        }
+    }
+}

--- a/RemoteCam/FrameStreamer.swift
+++ b/RemoteCam/FrameStreamer.swift
@@ -48,11 +48,12 @@ final class FrameStreamer {
         frameCount += 1
         guard frameCount % config.frameDivisor == 0 else { return }
 
-        guard let data = encodeWithFallback(pixelBuffer: pixelBuffer),
+        guard let data = encodeWithFallback(&encoders, pixelBuffer: pixelBuffer),
               let codec = activeCodec else { return }
 
         sequenceNumber &+= 1
-        StreamLog.encode.debug("frame seq=\(self.sequenceNumber) codec=\(String(describing: codec)) bytes=\(data.count)")
+        StreamLog.encode.debug(
+            "frame seq=\(self.sequenceNumber) codec=\(String(describing: codec)) bytes=\(data.count)")
         send(RemoteCmd.SendFrame(
             data: data,
             sender: nil,
@@ -62,20 +63,6 @@ final class FrameStreamer {
             codec: codec,
             sequenceNumber: sequenceNumber
         ))
-    }
-
-    private func encodeWithFallback(pixelBuffer: CVPixelBuffer) -> Data? {
-        while let encoder = encoders.first {
-            if let data = encoder.encode(pixelBuffer: pixelBuffer) {
-                return data
-            }
-            // Permanent fallback: an encoder that fails once (e.g. no HEVC
-            // hardware) is dropped from the chain for the session's lifetime.
-            encoders.removeFirst()
-            let next = encoders.first.map { String(describing: $0.codec) } ?? "none"
-            StreamLog.encode.error("\(String(describing: encoder.codec)) encoder failed — falling back to \(next)")
-        }
-        return nil
     }
 
     private static func makeEncoders(config: StreamingConfig) -> [FrameEncoding] {

--- a/RemoteCam/HEICFrameEncoder.swift
+++ b/RemoteCam/HEICFrameEncoder.swift
@@ -1,0 +1,45 @@
+//
+//  HEICFrameEncoder.swift
+//  RemoteShutter
+//
+//  Default still encoder: HEIC rides the same hardware HEVC block the video
+//  pipeline uses and is roughly half the bytes of JPEG at equal quality, which
+//  directly doubles the deliverable frame rate on bandwidth-bound links
+//  (MultipeerConnectivity and especially WCSession to the Watch). Decodes
+//  natively via ImageIO/UIImage(data:) on iOS and watchOS alike.
+//
+//  encode() returns nil on hardware without an HEVC encoder (pre-A10 devices)
+//  or on any CoreImage failure; the streamer then falls back to JPEG.
+//
+
+import UIKit
+import CoreImage
+import AVFoundation
+
+final class HEICFrameEncoder: FrameEncoding {
+
+    let codec: RemoteCmd.StreamCodec = .heic
+
+    private let context: CIContext
+    private let maxLongEdge: CGFloat
+    private let quality: CGFloat
+    private let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+
+    init(context: CIContext = CIContext(options: [.useSoftwareRenderer: false]),
+         maxLongEdge: CGFloat,
+         quality: CGFloat) {
+        self.context = context
+        self.maxLongEdge = maxLongEdge
+        self.quality = quality
+    }
+
+    func encode(pixelBuffer: CVPixelBuffer) -> Data? {
+        guard let scaled = downscaledCIImage(from: pixelBuffer, maxLongEdge: maxLongEdge) else { return nil }
+        return context.heifRepresentation(
+            of: scaled,
+            format: .RGBA8,
+            colorSpace: colorSpace,
+            options: [kCGImageDestinationLossyCompressionQuality as CIImageRepresentationOption: quality]
+        )
+    }
+}

--- a/RemoteCam/JPEGFrameEncoder.swift
+++ b/RemoteCam/JPEGFrameEncoder.swift
@@ -1,0 +1,33 @@
+//
+//  JPEGFrameEncoder.swift
+//  RemoteShutter
+//
+//  Universal-fallback still encoder: every iOS device and every peer app
+//  version can decode JPEG.
+//
+
+import UIKit
+import CoreImage
+
+final class JPEGFrameEncoder: FrameEncoding {
+
+    let codec: RemoteCmd.StreamCodec = .jpeg
+
+    private let context: CIContext
+    private let maxLongEdge: CGFloat
+    private let quality: CGFloat
+
+    init(context: CIContext = CIContext(options: [.useSoftwareRenderer: false]),
+         maxLongEdge: CGFloat,
+         quality: CGFloat) {
+        self.context = context
+        self.maxLongEdge = maxLongEdge
+        self.quality = quality
+    }
+
+    func encode(pixelBuffer: CVPixelBuffer) -> Data? {
+        guard let scaled = downscaledCIImage(from: pixelBuffer, maxLongEdge: maxLongEdge),
+              let cgImage = context.createCGImage(scaled, from: scaled.extent) else { return nil }
+        return UIImage(cgImage: cgImage).jpegData(compressionQuality: quality)
+    }
+}

--- a/RemoteCam/MediaProcessors.swift
+++ b/RemoteCam/MediaProcessors.swift
@@ -24,25 +24,3 @@ func cleanupFileAt(_ url: URL) {
     }
 }
 
-func imageFromSampleBuffer(sampleBuffer: CMSampleBuffer) -> UIImage? {
-    if let imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) {
-        CVPixelBufferLockBaseAddress(imageBuffer, CVPixelBufferLockFlags(rawValue: 0))
-        let baseAddress = CVPixelBufferGetBaseAddress(imageBuffer)
-        let bytesPerRow = CVPixelBufferGetBytesPerRow(imageBuffer)
-        let width = CVPixelBufferGetWidth(imageBuffer)
-        let height = CVPixelBufferGetHeight(imageBuffer)
-        let colorSpace = CGColorSpaceCreateDeviceRGB()
-        guard let context = CGContext(data: baseAddress, width: width, height: height, bitsPerComponent: 8, bytesPerRow: bytesPerRow, space: colorSpace, bitmapInfo: CGBitmapInfo.byteOrder32Little.rawValue | CGImageAlphaInfo.premultipliedFirst.rawValue) else {
-            return nil
-        }
-
-        let quartzImage = context.makeImage()
-        CVPixelBufferUnlockBaseAddress(imageBuffer, CVPixelBufferLockFlags(rawValue: 0))
-
-        if let quartzImage = quartzImage {
-            let image = UIImage(cgImage: quartzImage)
-            return image
-        }
-    }
-    return nil
-}

--- a/RemoteCam/MonitorPhotoStates.swift
+++ b/RemoteCam/MonitorPhotoStates.swift
@@ -52,6 +52,10 @@ extension RemoteCamSession {
                 monitor ! msg
                 self.requestFrame([peer])
 
+            case is UICmd.StreamStalled:
+                StreamLog.transport.info("photo monitor stalled — re-requesting frame")
+                self.requestFrame([peer])
+
             case is UICmd.UnbecomeMonitor:
                 self.popToState(name: .connected)
 

--- a/RemoteCam/MonitorVideoStates.swift
+++ b/RemoteCam/MonitorVideoStates.swift
@@ -28,6 +28,10 @@ extension MonitorVideoStates {
                 monitor ! msg
                 self.requestFrame([peer])
 
+            case is UICmd.StreamStalled:
+                StreamLog.transport.info("video monitor stalled — re-requesting frame")
+                self.requestFrame([peer])
+
             case is UICmd.UnbecomeMonitor:
                 self.popToState(name: .connected)
 
@@ -182,7 +186,11 @@ extension MonitorVideoStates {
             case is RemoteCmd.OnFrame:
                 monitor ! msg
                 self.requestFrame([peer])
-                
+
+            case is UICmd.StreamStalled:
+                StreamLog.transport.info("recording monitor stalled — re-requesting frame")
+                self.requestFrame([peer])
+
             case let ack as RemoteCmd.StartRecordingVideoAck:
                 // Check if this is an error response
                 if let error = ack.error {

--- a/RemoteCam/MonitorViewController.swift
+++ b/RemoteCam/MonitorViewController.swift
@@ -91,13 +91,9 @@ public class MonitorActor: ViewCtrlActor<MonitorViewController> {
                 }
 
             case let f as RemoteCmd.OnFrame:
-                if let cgImage = UIImage(data: f.data) {
-                    OperationQueue.main.addOperation {[weak ctrl] in
-                        if let ctrl = ctrl?.value {
-                            ctrl.updateCameraImageInViewModel(cgImage)
-                        }
-                    }
-                }
+                // Decode off the mailbox: the receiver's queue handles JPEG and
+                // HEIC alike and drives the stall watchdog.
+                ctrl.value?.frameStreamReceiver.receive(f)
                 
             // MARK: - Camera Capabilities Response Handling
             case let capabilities as RemoteCmd.CameraCapabilitiesResp:
@@ -267,6 +263,10 @@ public class MonitorViewController: iAdViewController, UIImagePickerControllerDe
     private(set) var monitor: ActorRef!
     private var monitorInstanceId: ObjectIdentifier?
 
+    /// Decodes incoming preview frames (JPEG/HEIC) off the actor mailbox and
+    /// raises StreamStalled when the stream goes quiet.
+    let frameStreamReceiver = FrameStreamReceiver()
+
     let timer: RCTimer = RCTimer()
 
     let soundManager: CPSoundManager = CPSoundManager()
@@ -349,6 +349,18 @@ public class MonitorViewController: iAdViewController, UIImagePickerControllerDe
         monitorInstanceId = m.instanceId
 
         monitor ! SetViewCtrl(ctrl: self)
+
+        frameStreamReceiver.onImage = { [weak self] image in
+            OperationQueue.main.addOperation {
+                self?.updateCameraImageInViewModel(image)
+            }
+        }
+        frameStreamReceiver.onStall = { [weak self] in
+            if let session = self?.session {
+                session ! UICmd.StreamStalled()
+            }
+        }
+        frameStreamReceiver.start()
         
         // Setup SwiftUI view instead of storyboard
         setupSwiftUIView()
@@ -373,6 +385,7 @@ public class MonitorViewController: iAdViewController, UIImagePickerControllerDe
 
     deinit {
         print("MonitorViewController deinit")
+        self.frameStreamReceiver.invalidate()
         self.timer.cancel()
         self.zoomLabelTimer?.invalidate()
         self.soundManager.stopPlayer()

--- a/RemoteCam/MultipeerDelegates.swift
+++ b/RemoteCam/MultipeerDelegates.swift
@@ -49,7 +49,9 @@ extension RemoteCamSession: MultipeerServiceDelegate {
             peerId: peer,
             fps: frame.fps,
             camPosition: frame.camPosition,
-            camOrientation: frame.camOrientation)
+            camOrientation: frame.camOrientation,
+            codec: frame.codec,
+            sequenceNumber: frame.sequenceNumber)
     }
 
     func peerDidConnect(_ peer: MCPeerID) {

--- a/RemoteCam/RemoteCamSession.swift
+++ b/RemoteCam/RemoteCamSession.swift
@@ -288,7 +288,7 @@ public class RemoteCamSession: ViewCtrlActor<DeviceScannerViewController> {
             debugLog("🔍 DEBUG: - Transmission error: \(switchResp.error?.localizedDescription ?? "nil")")
         }
         
-        if self.sendMessage(peer: self.connectedPeers, msg: msg).isFailure() {
+        if self.sendMessage(peer: self.connectedPeers, msg: msg, mode: mode).isFailure() {
             debugLog("❌ DEBUG: sendCommandOrGoToScanning failed to send message")
             self.popToState(name: .scanning)
             ^{ [weak self] in

--- a/RemoteCam/RemoteCmdFlatBuffers.swift
+++ b/RemoteCam/RemoteCmdFlatBuffers.swift
@@ -109,6 +109,23 @@ private func fromFBCamPos(_ pos: RemoteShutter_CameraPosition) -> AVCaptureDevic
     }
 }
 
+private func toFBStreamCodec(_ codec: RemoteCmd.StreamCodec) -> RemoteShutter_StreamCodec {
+    switch codec {
+    case .jpeg: return .jpeg
+    case .hevc: return .hevc
+    case .heic: return .heic
+    }
+}
+
+private func fromFBStreamCodec(_ codec: RemoteShutter_StreamCodec) -> RemoteCmd.StreamCodec {
+    switch codec {
+    case .jpeg: return .jpeg
+    case .hevc: return .hevc
+    case .heic: return .heic
+    case .unknown: return .jpeg   // legacy sender: field absent => JPEG payload
+    }
+}
+
 private func toFBTorch(_ mode: AVCaptureDevice.TorchMode) -> RemoteShutter_TorchMode {
     switch mode {
     case .off: return .off
@@ -452,7 +469,9 @@ extension RemoteCmd.SendFrame {
             imageDataVectorOffset: imageOffset,
             fps: Int32(fps),
             cameraPosition: toFBCamPos(camPosition),
-            orientation: Int32(camOrientation.rawValue)
+            orientation: Int32(camOrientation.rawValue),
+            codec: toFBStreamCodec(codec),
+            sequenceNumber: sequenceNumber
         )
         return buildFrame(&fbb, frame: frame)
     }
@@ -1133,7 +1152,9 @@ extension RemoteCmd {
             sender: nil,
             fps: Int(frame.fps),
             camPosition: position,
-            camOrientation: orientation
+            camOrientation: orientation,
+            codec: fromFBStreamCodec(frame.codec),
+            sequenceNumber: frame.sequenceNumber
         )
     }
 }

--- a/RemoteCam/RemoteCmds.swift
+++ b/RemoteCam/RemoteCmds.swift
@@ -136,17 +136,36 @@ public class RemoteCmd: Actor.Message {
         }
     }
 
+    /// Payload format of a streamed preview frame. Mirrors the wire enum
+    /// `RemoteShutter_StreamCodec`; frames from peers that predate the field
+    /// arrive as `.jpeg`. `.hevc` is reserved for the video-codec follow-up.
+    public enum StreamCodec {
+        case jpeg
+        case hevc
+        case heic
+    }
+
     public class SendFrame: Actor.Message {
         public let data: Data
         public let fps: NSInteger
         public let camPosition: AVCaptureDevice.Position
         public let camOrientation: UIInterfaceOrientation
+        public let codec: StreamCodec
+        public let sequenceNumber: UInt32
 
-        init(data: Data, sender: ActorRef?, fps: NSInteger, camPosition: AVCaptureDevice.Position, camOrientation: UIInterfaceOrientation) {
+        init(data: Data,
+             sender: ActorRef?,
+             fps: NSInteger,
+             camPosition: AVCaptureDevice.Position,
+             camOrientation: UIInterfaceOrientation,
+             codec: StreamCodec = .jpeg,
+             sequenceNumber: UInt32 = 0) {
             self.data = data
             self.fps = fps
             self.camPosition = camPosition
             self.camOrientation = camOrientation
+            self.codec = codec
+            self.sequenceNumber = sequenceNumber
             super.init(sender: sender)
         }
     }
@@ -163,13 +182,24 @@ public class RemoteCmd: Actor.Message {
         public let fps: NSInteger
         public let camPosition: AVCaptureDevice.Position
         public let camOrientation: UIInterfaceOrientation
+        public let codec: StreamCodec
+        public let sequenceNumber: UInt32
 
-        init(data: Data, sender: ActorRef?, peerId: MCPeerID, fps: NSInteger, camPosition: AVCaptureDevice.Position, camOrientation: UIInterfaceOrientation) {
+        init(data: Data,
+             sender: ActorRef?,
+             peerId: MCPeerID,
+             fps: NSInteger,
+             camPosition: AVCaptureDevice.Position,
+             camOrientation: UIInterfaceOrientation,
+             codec: StreamCodec = .jpeg,
+             sequenceNumber: UInt32 = 0) {
             self.camPosition = camPosition
             self.data = data
             self.peerId = peerId
             self.fps = fps
             self.camOrientation = camOrientation
+            self.codec = codec
+            self.sequenceNumber = sequenceNumber
             super.init(sender: sender)
         }
     }

--- a/RemoteCam/StreamLog.swift
+++ b/RemoteCam/StreamLog.swift
@@ -1,0 +1,20 @@
+//
+//  StreamLog.swift
+//  RemoteShutter
+//
+//  Structured loggers for the preview streaming pipeline. Filter in Console.app
+//  by subsystem + category, e.g. category:stream.transport. Per-frame chatter is
+//  logged at .debug (off by default); recovery events (watchdog fired, stall,
+//  codec fallback) at .info/.error so field issues are diagnosable from a sysdiagnose.
+//
+
+import Foundation
+import os
+
+enum StreamLog {
+    private static let subsystem = Bundle.main.bundleIdentifier ?? "RemoteShutter"
+    static let encode = Logger(subsystem: subsystem, category: "stream.encode")
+    static let decode = Logger(subsystem: subsystem, category: "stream.decode")
+    static let transport = Logger(subsystem: subsystem, category: "stream.transport")
+    static let lifecycle = Logger(subsystem: subsystem, category: "stream.lifecycle")
+}

--- a/RemoteCam/StreamingConfig.swift
+++ b/RemoteCam/StreamingConfig.swift
@@ -1,0 +1,42 @@
+//
+//  StreamingConfig.swift
+//  RemoteShutter
+//
+//  Tuning knobs for the preview streaming pipeline (camera -> monitor and
+//  camera -> Watch). Code constants on purpose: a bundled JSON config would
+//  hide typos until runtime and cost pbxproj wiring for nothing.
+//
+
+import Foundation
+import CoreGraphics
+
+struct StreamingConfig {
+
+    /// Codecs to try on the camera side, in order. The streamer permanently
+    /// falls back to the next entry when an encoder fails (e.g. HEIC on
+    /// hardware without an HEVC encoder).
+    var preferredCodecs: [RemoteCmd.StreamCodec] = [.heic, .jpeg]
+
+    /// Long edge of the frame sent to the phone monitor. Replaces the old
+    /// full-sensor-resolution JPEG at quality 0.1.
+    var maxLongEdge: CGFloat = 960
+    var heicQuality: CGFloat = 0.5
+    var jpegQuality: CGFloat = 0.6
+
+    /// Send every Nth capture callback (30fps capture / 2 = 15fps offered).
+    var frameDivisor: Int = 2
+
+    /// Long edge of the Apple Watch preview (matches the Watch screen width).
+    var watchMaxLongEdge: CGFloat = 320
+    var watchHEICQuality: CGFloat = 0.5
+    var watchJPEGQuality: CGFloat = 0.55
+
+    /// Monitor-side stall watchdog: if no frame arrives for this long, raise
+    /// `UICmd.StreamStalled` so the state machine re-requests a frame.
+    /// Re-raises at most once per interval while the stall persists.
+    var stallTimeout: TimeInterval = 2.0
+    /// How often the stall watchdog wakes up to check.
+    var stallCheckInterval: TimeInterval = 1.0
+
+    static let `default` = StreamingConfig()
+}

--- a/RemoteCam/UICmds.swift
+++ b/RemoteCam/UICmds.swift
@@ -568,4 +568,16 @@ public class UICmd {
             super.init(sender: nil)
         }
     }
+
+    // MARK: - Streaming
+
+    /// Raised by the monitor's frame receiver when no frame has arrived for
+    /// `StreamingConfig.stallTimeout`. Monitor states respond by re-sending
+    /// `RemoteCmd.RequestFrame`, re-arming the one-frame-in-flight ping-pong
+    /// after a lost message on either side.
+    public class StreamStalled: Actor.Message {
+        public init() {
+            super.init(sender: nil)
+        }
+    }
 }

--- a/RemoteCamTests/FrameSenderTests.swift
+++ b/RemoteCamTests/FrameSenderTests.swift
@@ -1,0 +1,190 @@
+//
+//  FrameSenderTests.swift
+//  RemoteShutterTests
+//
+//  State-machine tests for the camera-side frame sender: one-frame-in-flight
+//  back-pressure, and the ack watchdog that keeps a lost RequestFrame ack from
+//  wedging the stream forever.
+//
+
+import XCTest
+import MultipeerConnectivity
+
+@testable import RemoteShutter
+
+class FrameSenderTests: XCTestCase {
+
+    private var system: TestActorSystem!
+    private var sessionRef: ActorRef!
+    private var session: TestableRemoteCamSession!
+    private var senderRef: ActorRef!
+    private var frameSender: FrameSender!
+    private var peer: MCPeerID!
+    private var fakeMP: FakeMultipeerService!
+
+    override func setUp() {
+        super.setUp()
+        system = TestActorSystem(name: "frameSenderTests")
+        sessionRef = system.actorOf(clz: TestableRemoteCamSession.self, name: "session")
+        session = (system.actorForRef(ref: sessionRef) as! TestableRemoteCamSession)
+        senderRef = system.actorOf(clz: FrameSender.self, name: "frameSender")
+        frameSender = (system.actorForRef(ref: senderRef) as! FrameSender)
+
+        peer = MCPeerID(displayName: "TestPeer")
+        fakeMP = FakeMultipeerService()
+        fakeMP.connectedPeers = [peer]
+        fakeMP.sendResult = Success(Actor.Message())
+        session.multipeerService = fakeMP
+
+        senderRef ! SetSession(peer: peer, session: session)
+        drainSenderMailbox()
+    }
+
+    override func tearDown() {
+        drainMailboxPumpingRunLoop()
+        system.stop()
+        drainMailboxPumpingRunLoop()
+        system = nil
+        sessionRef = nil
+        session = nil
+        senderRef = nil
+        frameSender = nil
+        peer = nil
+        fakeMP = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func drainSenderMailbox() {
+        let expectation = expectation(description: "frame sender mailbox drained")
+        frameSender.mailbox.addOperation { expectation.fulfill() }
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    private func drainMailboxPumpingRunLoop() {
+        let deadline = Date(timeIntervalSinceNow: 5.0)
+        while frameSender.mailbox.operationCount > 0 && Date() < deadline {
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.01))
+        }
+    }
+
+    private func makeFrame() -> RemoteCmd.SendFrame {
+        RemoteCmd.SendFrame(
+            data: Data([1, 2, 3]),
+            sender: nil,
+            fps: 30,
+            camPosition: .back,
+            camOrientation: .portrait
+        )
+    }
+
+    private var sentFrameCount: Int {
+        fakeMP.sentMessages.filter { $0.msg is RemoteCmd.SendFrame }.count
+    }
+
+    // MARK: - Send path
+
+    func testSendFrameSendsUnreliablyAndWaitsForAck() {
+        senderRef ! makeFrame()
+        drainSenderMailbox()
+
+        XCTAssertEqual(sentFrameCount, 1)
+        let sent = fakeMP.sentMessages[0]
+        XCTAssertEqual(sent.peers, [peer])
+        XCTAssertEqual(sent.mode, .unreliable)
+        XCTAssertEqual(frameSender.currentState()?.0, waitingForAckName)
+    }
+
+    func testFramesDroppedWhileWaitingForAck() {
+        senderRef ! makeFrame()
+        senderRef ! makeFrame()
+        senderRef ! makeFrame()
+        drainSenderMailbox()
+
+        XCTAssertEqual(sentFrameCount, 1, "back-pressure must drop frames until the in-flight one is acked")
+        XCTAssertEqual(frameSender.currentState()?.0, waitingForAckName)
+    }
+
+    func testRequestFrameAckReopensGate() {
+        senderRef ! makeFrame()
+        senderRef ! RemoteCmd.RequestFrame(sender: nil)
+        senderRef ! makeFrame()
+        drainSenderMailbox()
+
+        XCTAssertEqual(sentFrameCount, 2)
+        XCTAssertEqual(frameSender.currentState()?.0, waitingForAckName)
+    }
+
+    // MARK: - Ack watchdog
+
+    func testAckTimeoutReopensGate() {
+        senderRef ! makeFrame()
+        drainSenderMailbox()
+        XCTAssertEqual(frameSender.currentState()?.0, waitingForAckName)
+
+        // Deliver the watchdog for the wait that is actually in flight.
+        senderRef ! AckTimeout(generation: frameSender.ackGeneration)
+        drainSenderMailbox()
+        XCTAssertEqual(frameSender.currentState()?.0, readyToSendFrame)
+
+        // The gate is open again: the next frame flows without any ack.
+        senderRef ! makeFrame()
+        drainSenderMailbox()
+        XCTAssertEqual(sentFrameCount, 2)
+    }
+
+    func testStaleAckTimeoutIgnoredWhileWaiting() {
+        // Complete one send/ack cycle so a watchdog for generation 1 is stale.
+        senderRef ! makeFrame()
+        senderRef ! RemoteCmd.RequestFrame(sender: nil)
+        senderRef ! makeFrame()
+        drainSenderMailbox()
+        XCTAssertEqual(frameSender.ackGeneration, 2)
+
+        senderRef ! AckTimeout(generation: 1)
+        drainSenderMailbox()
+
+        XCTAssertEqual(frameSender.currentState()?.0, waitingForAckName,
+                       "a watchdog from an already-completed wait must not re-open the gate")
+    }
+
+    func testAckTimeoutIgnoredWhenReady() {
+        senderRef ! AckTimeout(generation: frameSender.ackGeneration)
+        drainSenderMailbox()
+
+        XCTAssertEqual(frameSender.currentState()?.0, readyToSendFrame)
+
+        senderRef ! makeFrame()
+        drainSenderMailbox()
+        XCTAssertEqual(sentFrameCount, 1)
+    }
+
+    /// End-to-end: the scheduled watchdog itself (not an injected message)
+    /// re-opens the gate after `FrameSender.ackTimeout` when the ack is lost.
+    func testScheduledWatchdogRecoversFromLostAck() {
+        senderRef ! makeFrame()
+        drainSenderMailbox()
+        XCTAssertEqual(sentFrameCount, 1)
+
+        // No ack arrives. After the timeout the sender must accept frames again.
+        let deadline = Date(timeIntervalSinceNow: FrameSender.ackTimeout + 1.0)
+        while sentFrameCount < 2 && Date() < deadline {
+            senderRef ! makeFrame()
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.05))
+        }
+        XCTAssertEqual(sentFrameCount, 2, "watchdog should have re-armed the sender within \(FrameSender.ackTimeout)s")
+    }
+
+    // MARK: - SetSession resets
+
+    func testSetSessionWhileWaitingReturnsToReady() {
+        senderRef ! makeFrame()
+        drainSenderMailbox()
+        XCTAssertEqual(frameSender.currentState()?.0, waitingForAckName)
+
+        senderRef ! SetSession(peer: peer, session: session)
+        drainSenderMailbox()
+        XCTAssertEqual(frameSender.currentState()?.0, readyToSendFrame)
+    }
+}

--- a/RemoteCamTests/FrameStreamingTests.swift
+++ b/RemoteCamTests/FrameStreamingTests.swift
@@ -1,0 +1,266 @@
+//
+//  FrameStreamingTests.swift
+//  RemoteShutterTests
+//
+//  Tests for the camera-side FrameStreamer (pacing, codec fallback, sequence
+//  numbering), the monitor-side FrameStreamReceiver (decode, stall watchdog,
+//  gap tracking), and the real JPEG/HEIC encoders against a synthetic pixel
+//  buffer.
+//
+
+import XCTest
+import CoreVideo
+import MultipeerConnectivity
+
+@testable import RemoteShutter
+
+// MARK: - Fakes
+
+private final class FakeEncoder: FrameEncoding {
+    let codec: RemoteCmd.StreamCodec
+    var result: Data?
+    private(set) var encodeCount = 0
+
+    init(codec: RemoteCmd.StreamCodec, result: Data?) {
+        self.codec = codec
+        self.result = result
+    }
+
+    func encode(pixelBuffer: CVPixelBuffer) -> Data? {
+        encodeCount += 1
+        return result
+    }
+}
+
+// MARK: - Helpers
+
+func makePixelBuffer(width: Int = 64, height: Int = 32) -> CVPixelBuffer {
+    var pixelBuffer: CVPixelBuffer?
+    let status = CVPixelBufferCreate(
+        kCFAllocatorDefault, width, height, kCVPixelFormatType_32BGRA,
+        [kCVPixelBufferCGImageCompatibilityKey: true,
+         kCVPixelBufferCGBitmapContextCompatibilityKey: true] as CFDictionary,
+        &pixelBuffer)
+    precondition(status == kCVReturnSuccess, "CVPixelBufferCreate failed: \(status)")
+    return pixelBuffer!
+}
+
+private func makeOnFrame(data: Data = Data([1]),
+                         codec: RemoteCmd.StreamCodec = .jpeg,
+                         sequenceNumber: UInt32) -> RemoteCmd.OnFrame {
+    RemoteCmd.OnFrame(
+        data: data,
+        sender: nil,
+        peerId: MCPeerID(displayName: "peer"),
+        fps: 30,
+        camPosition: .back,
+        camOrientation: .portrait,
+        codec: codec,
+        sequenceNumber: sequenceNumber
+    )
+}
+
+// MARK: - FrameStreamer
+
+final class FrameStreamerTests: XCTestCase {
+
+    private var sentFrames: [RemoteCmd.SendFrame] = []
+
+    private func makeStreamer(encoders: [FrameEncoding],
+                              frameDivisor: Int = 1) -> FrameStreamer {
+        var config = StreamingConfig.default
+        config.frameDivisor = frameDivisor
+        return FrameStreamer(config: config, encoders: encoders) { [weak self] frame in
+            self?.sentFrames.append(frame)
+        }
+    }
+
+    func testPacingSkipsFramesPerDivisor() {
+        let encoder = FakeEncoder(codec: .jpeg, result: Data([1]))
+        let streamer = makeStreamer(encoders: [encoder], frameDivisor: 2)
+
+        for _ in 0..<6 {
+            streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
+        }
+
+        XCTAssertEqual(sentFrames.count, 3, "divisor 2 sends every other capture callback")
+        XCTAssertEqual(encoder.encodeCount, 3, "skipped frames must not be encoded")
+    }
+
+    func testSequenceNumbersAreMonotonicFromOne() {
+        let streamer = makeStreamer(encoders: [FakeEncoder(codec: .heic, result: Data([1]))])
+
+        for _ in 0..<3 {
+            streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
+        }
+
+        XCTAssertEqual(sentFrames.map(\.sequenceNumber), [1, 2, 3])
+        XCTAssertEqual(sentFrames.map(\.codec), [.heic, .heic, .heic])
+    }
+
+    func testFallsBackPermanentlyWhenEncoderFails() {
+        let heic = FakeEncoder(codec: .heic, result: nil)
+        let jpeg = FakeEncoder(codec: .jpeg, result: Data([2]))
+        let streamer = makeStreamer(encoders: [heic, jpeg])
+
+        streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
+        streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
+
+        XCTAssertEqual(sentFrames.count, 2)
+        XCTAssertEqual(sentFrames.map(\.codec), [.jpeg, .jpeg])
+        XCTAssertEqual(heic.encodeCount, 1, "failed encoder must be dropped from the chain, not retried")
+        XCTAssertEqual(streamer.activeCodec, .jpeg)
+    }
+
+    func testDropsFrameWhenAllEncodersFail() {
+        let streamer = makeStreamer(encoders: [FakeEncoder(codec: .jpeg, result: nil)])
+
+        streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
+
+        XCTAssertTrue(sentFrames.isEmpty)
+        XCTAssertNil(streamer.activeCodec)
+    }
+
+    func testFrameCarriesCameraMetadata() {
+        let streamer = makeStreamer(encoders: [FakeEncoder(codec: .jpeg, result: Data([7]))])
+
+        streamer.handle(pixelBuffer: makePixelBuffer(), position: .front, orientation: .landscapeRight, fps: 24)
+
+        XCTAssertEqual(sentFrames.count, 1)
+        XCTAssertEqual(sentFrames[0].camPosition, .front)
+        XCTAssertEqual(sentFrames[0].camOrientation, .landscapeRight)
+        XCTAssertEqual(sentFrames[0].fps, 24)
+        XCTAssertEqual(sentFrames[0].data, Data([7]))
+    }
+}
+
+// MARK: - FrameStreamReceiver
+
+final class FrameStreamReceiverTests: XCTestCase {
+
+    private var clock: TimeInterval = 1000
+    private var receiver: FrameStreamReceiver!
+    private var images: [UIImage] = []
+    private var stallCount = 0
+
+    override func setUp() {
+        super.setUp()
+        receiver = FrameStreamReceiver(now: { [weak self] in self?.clock ?? 0 })
+        receiver.onImage = { [weak self] in self?.images.append($0) }
+        receiver.onStall = { [weak self] in self?.stallCount += 1 }
+    }
+
+    override func tearDown() {
+        receiver.invalidate()
+        receiver = nil
+        super.tearDown()
+    }
+
+    /// Runs the receive on the decode queue and waits for it.
+    private func deliver(_ frame: RemoteCmd.OnFrame) {
+        receiver.receive(frame)
+        receiver.decodeQueue.sync {}
+    }
+
+    private func checkForStallAndWait() {
+        receiver.decodeQueue.sync { receiver.checkForStall() }
+    }
+
+    private var validJPEG: Data {
+        UIImage(cgImage: {
+            let context = CGContext(data: nil, width: 4, height: 4, bitsPerComponent: 8,
+                                    bytesPerRow: 0, space: CGColorSpaceCreateDeviceRGB(),
+                                    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
+            return context.makeImage()!
+        }()).jpegData(compressionQuality: 0.8)!
+    }
+
+    func testDecodesFrameAndEmitsImage() {
+        deliver(makeOnFrame(data: validJPEG, sequenceNumber: 1))
+        XCTAssertEqual(images.count, 1)
+    }
+
+    func testUndecodableFrameEmitsNothingButCountsAsActivity() {
+        deliver(makeOnFrame(data: Data([0xDE, 0xAD]), sequenceNumber: 1))
+        XCTAssertTrue(images.isEmpty)
+
+        // The broken frame still proves the link is alive — no stall.
+        clock += 1.0
+        checkForStallAndWait()
+        XCTAssertEqual(stallCount, 0)
+    }
+
+    func testStallFiresAfterTimeoutAndRateLimits() {
+        deliver(makeOnFrame(data: validJPEG, sequenceNumber: 1))
+
+        clock += 2.5
+        checkForStallAndWait()
+        XCTAssertEqual(stallCount, 1)
+
+        // Still stalled but within the rate-limit window: no second report.
+        clock += 1.0
+        checkForStallAndWait()
+        XCTAssertEqual(stallCount, 1)
+
+        // Past the window and still stalled: report again (retries the request).
+        clock += 1.5
+        checkForStallAndWait()
+        XCTAssertEqual(stallCount, 2)
+    }
+
+    func testFrameArrivalResetsStallClock() {
+        deliver(makeOnFrame(data: validJPEG, sequenceNumber: 1))
+        clock += 1.5
+        deliver(makeOnFrame(data: validJPEG, sequenceNumber: 2))
+        clock += 1.5
+        checkForStallAndWait()
+        XCTAssertEqual(stallCount, 0, "2s stall timeout is measured from the LAST frame")
+    }
+
+    func testSequenceGapsAreCounted() {
+        deliver(makeOnFrame(data: validJPEG, sequenceNumber: 1))
+        deliver(makeOnFrame(data: validJPEG, sequenceNumber: 2))
+        deliver(makeOnFrame(data: validJPEG, sequenceNumber: 5))
+        deliver(makeOnFrame(data: validJPEG, sequenceNumber: 6))
+
+        receiver.decodeQueue.sync {
+            XCTAssertEqual(receiver.sequenceGapCount, 1)
+        }
+    }
+
+    func testLegacyFramesWithoutSequenceNumbersNeverCountGaps() {
+        deliver(makeOnFrame(data: validJPEG, sequenceNumber: 0))
+        deliver(makeOnFrame(data: validJPEG, sequenceNumber: 0))
+
+        receiver.decodeQueue.sync {
+            XCTAssertEqual(receiver.sequenceGapCount, 0)
+        }
+    }
+}
+
+// MARK: - Real encoders
+
+final class FrameEncoderTests: XCTestCase {
+
+    func testJPEGEncoderProducesDecodableDownscaledImage() throws {
+        let encoder = JPEGFrameEncoder(maxLongEdge: 100, quality: 0.6)
+        let data = try XCTUnwrap(encoder.encode(pixelBuffer: makePixelBuffer(width: 400, height: 200)))
+        let image = try XCTUnwrap(UIImage(data: data))
+        XCTAssertLessThanOrEqual(max(image.size.width, image.size.height), 100)
+    }
+
+    func testHEICEncoderProducesDecodableDownscaledImage() throws {
+        let encoder = HEICFrameEncoder(maxLongEdge: 100, quality: 0.5)
+        let data = encoder.encode(pixelBuffer: makePixelBuffer(width: 400, height: 200))
+        try XCTSkipIf(data == nil, "HEVC encoder unavailable on this simulator/host")
+        let image = try XCTUnwrap(UIImage(data: data!))
+        XCTAssertLessThanOrEqual(max(image.size.width, image.size.height), 100)
+    }
+
+    func testSmallFrameIsNotUpscaled() throws {
+        let encoder = JPEGFrameEncoder(maxLongEdge: 960, quality: 0.6)
+        let data = try XCTUnwrap(encoder.encode(pixelBuffer: makePixelBuffer(width: 64, height: 32)))
+        let image = try XCTUnwrap(UIImage(data: data))
+        XCTAssertEqual(max(image.size.width, image.size.height), 64)
+    }
+}

--- a/RemoteCamTests/RemoteCmdSerializationTests.swift
+++ b/RemoteCamTests/RemoteCmdSerializationTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 import AVFoundation
+import FlatBuffers
 
 @testable import RemoteShutter
 
@@ -223,6 +224,58 @@ final class RemoteCmdSerializationTests: XCTestCase {
         XCTAssertEqual(decoded.fps, 60)
         XCTAssertEqual(decoded.camPosition, .front)
         XCTAssertEqual(decoded.camOrientation, .portrait)
+    }
+
+    func testSendFrame_codecAndSequenceRoundTrip() {
+        let original = RemoteCmd.SendFrame(
+            data: Data([9, 9, 9]),
+            sender: nil,
+            fps: 30,
+            camPosition: .back,
+            camOrientation: .portrait,
+            codec: .heic,
+            sequenceNumber: 42_001
+        )
+        let decoded: RemoteCmd.SendFrame = roundTrip(original)
+        XCTAssertEqual(decoded.codec, .heic)
+        XCTAssertEqual(decoded.sequenceNumber, 42_001)
+    }
+
+    func testSendFrame_defaultsToJPEGCodec() {
+        // Call sites that predate the codec field compile unchanged and must
+        // stay on the JPEG wire value.
+        let original = RemoteCmd.SendFrame(
+            data: Data([1]),
+            sender: nil,
+            fps: 30,
+            camPosition: .back,
+            camOrientation: .portrait
+        )
+        let decoded: RemoteCmd.SendFrame = roundTrip(original)
+        XCTAssertEqual(decoded.codec, .jpeg)
+        XCTAssertEqual(decoded.sequenceNumber, 0)
+    }
+
+    /// A frame from an old app build has no codec/sequence fields at all.
+    /// Decoding must treat it as JPEG, not drop it.
+    func testSendFrame_legacyFrameWithoutCodecDecodesAsJPEG() throws {
+        var fbb = FlatBufferBuilder()
+        let imageOffset = fbb.createVector(bytes: Data([7, 7]))
+        let frame = RemoteShutter_FrameData.createFrameData(
+            &fbb,
+            imageDataVectorOffset: imageOffset,
+            fps: 24,
+            cameraPosition: .front,
+            orientation: 1
+            // codec / sequenceNumber intentionally omitted (legacy layout)
+        )
+        let msg = RemoteShutter_P2PMessage.createP2PMessage(&fbb, type: .framedata, frameDataOffset: frame)
+        fbb.finish(offset: msg, fileId: "RCAM")
+        let decoded = try XCTUnwrap(RemoteCmd.fromFlatBuffer(fbb.data) as? RemoteCmd.SendFrame)
+        XCTAssertEqual(decoded.codec, .jpeg)
+        XCTAssertEqual(decoded.sequenceNumber, 0)
+        XCTAssertEqual(decoded.data, Data([7, 7]))
+        XCTAssertEqual(decoded.fps, 24)
     }
 
     // MARK: - 10. RequestFrame

--- a/RemoteShutter.xcodeproj/project.pbxproj
+++ b/RemoteShutter.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		AA00020000000004 /* StoreManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00020000000003 /* StoreManagerTests.swift */; };
 		AA00020000000006 /* PurchaseManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00020000000005 /* PurchaseManaging.swift */; };
 		AABB00022E930001009TESTS /* RemoteCamSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00012E930001009TESTS /* RemoteCamSessionTests.swift */; };
+		AABB00322E930031009TESTS /* FrameSenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00312E930031009TESTS /* FrameSenderTests.swift */; };
 		AABB00042E930002009TESTS /* RemoteCmdSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00032E930002009TESTS /* RemoteCmdSerializationTests.swift */; };
 		AB31E7ED97070E2109B89652 /* MultipeerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3644AC8CC7EEDECC00BE3D9 /* MultipeerService.swift */; };
 		ABE88EBB0583BA42617B496C /* Pods_RemoteShutter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E06F124E7E28CC7B25BDE83 /* Pods_RemoteShutter.framework */; };
@@ -163,6 +164,8 @@
 		DCDBA5102EA8C85C82D8E2FC /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2F16CCCC931B7EC3877C89 /* SettingsViewModel.swift */; };
 		DEADBEEF0001000000000002 /* DebugLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEADBEEF0001000000000001 /* DebugLog.swift */; };
 		DEADBEEF0001000000000003 /* DebugLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEADBEEF0001000000000001 /* DebugLog.swift */; };
+		CAFEBABE0009000000000002 /* StreamLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE0009000000000001 /* StreamLog.swift */; };
+		CAFEBABE0009000000000003 /* StreamLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE0009000000000001 /* StreamLog.swift */; };
 		E2292969B1882D3FCB671CB3 /* WatchConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9A830256BC7B3762B17FEF /* WatchConnectionView.swift */; };
 		E602233EB8B13D1B2BB12016 /* WelcomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52FB0F878CA54F1AC0BC42EB /* WelcomeViewModel.swift */; };
 		E9256A91DEEB414C3FE6C48D /* ActorSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4711EC884DF706A90B90662D /* ActorSystem.swift */; };
@@ -358,6 +361,7 @@
 		AA00020000000003 /* StoreManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreManagerTests.swift; sourceTree = "<group>"; };
 		AA00020000000005 /* PurchaseManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseManaging.swift; sourceTree = "<group>"; };
 		AABB00012E930001009TESTS /* RemoteCamSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteCamSessionTests.swift; sourceTree = "<group>"; };
+		AABB00312E930031009TESTS /* FrameSenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameSenderTests.swift; sourceTree = "<group>"; };
 		AABB00032E930002009TESTS /* RemoteCmdSerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteCmdSerializationTests.swift; sourceTree = "<group>"; };
 		B1C0DE0100000001 /* RolePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolePickerView.swift; sourceTree = "<group>"; };
 		B1C0DE0200000001 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
@@ -378,6 +382,7 @@
 		D9C44C88664AD8685AFA3CDF /* Pods-RemoteShutter.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RemoteShutter.release.xcconfig"; path = "Target Support Files/Pods-RemoteShutter/Pods-RemoteShutter.release.xcconfig"; sourceTree = "<group>"; };
 		DC9A830256BC7B3762B17FEF /* WatchConnectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RemoteShutterWatch/WatchConnectionView.swift; sourceTree = SOURCE_ROOT; };
 		DEADBEEF0001000000000001 /* DebugLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLog.swift; sourceTree = "<group>"; };
+		CAFEBABE0009000000000001 /* StreamLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamLog.swift; sourceTree = "<group>"; };
 		E655FAEBED183EB237F41DEA /* WatchSharedTypes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Shared/WatchSharedTypes.swift; sourceTree = SOURCE_ROOT; };
 		E6BA9B353DB915CF86861C92 /* ViewControllerActor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerActor.swift; sourceTree = "<group>"; };
 		F3644AC8CC7EEDECC00BE3D9 /* MultipeerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipeerService.swift; sourceTree = "<group>"; };
@@ -524,6 +529,7 @@
 			isa = PBXGroup;
 			children = (
 				AABB00012E930001009TESTS /* RemoteCamSessionTests.swift */,
+				AABB00312E930031009TESTS /* FrameSenderTests.swift */,
 				AABB00032E930002009TESTS /* RemoteCmdSerializationTests.swift */,
 				CAFEBABE0001000000000001 /* CropRectTests.swift */,
 				CAFEBABE0002000000000001 /* WatchCaptureCountdownTests.swift */,
@@ -581,6 +587,7 @@
 			children = (
 				06BB79B72E374D410094E085 /* FeatureFlags.swift */,
 				DEADBEEF0001000000000001 /* DebugLog.swift */,
+				CAFEBABE0009000000000001 /* StreamLog.swift */,
 				06CDFB1D252E9CD200EA56FB /* UICmds.swift */,
 				06CDFB16252E9A7900EA56FB /* RemoteCmds.swift */,
 				069284451BE5C0E600AF4678 /* MultipeerMessages.swift */,
@@ -1056,6 +1063,7 @@
 				06AEE43425333B4A00C2ED90 /* UIAlertController.swift in Sources */,
 				068EF0C62531915A00A84DFA /* MultipeerDelegates.swift in Sources */,
 				DEADBEEF0001000000000002 /* DebugLog.swift in Sources */,
+				CAFEBABE0009000000000002 /* StreamLog.swift in Sources */,
 				77CE73A56185CD1426B83EEE /* MultipeerService.swift in Sources */,
 				AA0001012E940001000A1001 /* AlertPresenting.swift in Sources */,
 				AA0001052E940005000A1001 /* UIAlertPresenter.swift in Sources */,
@@ -1135,6 +1143,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AABB00022E930001009TESTS /* RemoteCamSessionTests.swift in Sources */,
+				AABB00322E930031009TESTS /* FrameSenderTests.swift in Sources */,
 				AABB00042E930002009TESTS /* RemoteCmdSerializationTests.swift in Sources */,
 				CAFEBABE0001000000000002 /* CropRectTests.swift in Sources */,
 				CAFEBABE0002000000000002 /* WatchCaptureCountdownTests.swift in Sources */,
@@ -1176,6 +1185,7 @@
 				B1C0DE0300000002 /* DeviceScannerViewModel.swift in Sources */,
 				068EF0C82531915A00A84DFA /* MultipeerDelegates.swift in Sources */,
 				DEADBEEF0001000000000003 /* DebugLog.swift in Sources */,
+				CAFEBABE0009000000000003 /* StreamLog.swift in Sources */,
 				AB31E7ED97070E2109B89652 /* MultipeerService.swift in Sources */,
 				AA0001042E940004000A1001 /* AlertPresenting.swift in Sources */,
 				AA0001072E940007000A1001 /* UIAlertPresenter.swift in Sources */,

--- a/RemoteShutter.xcodeproj/project.pbxproj
+++ b/RemoteShutter.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		AA00020000000006 /* PurchaseManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00020000000005 /* PurchaseManaging.swift */; };
 		AABB00022E930001009TESTS /* RemoteCamSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00012E930001009TESTS /* RemoteCamSessionTests.swift */; };
 		AABB00322E930031009TESTS /* FrameSenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00312E930031009TESTS /* FrameSenderTests.swift */; };
+		AABB00342E930033009TESTS /* FrameStreamingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00332E930033009TESTS /* FrameStreamingTests.swift */; };
 		AABB00042E930002009TESTS /* RemoteCmdSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00032E930002009TESTS /* RemoteCmdSerializationTests.swift */; };
 		AB31E7ED97070E2109B89652 /* MultipeerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3644AC8CC7EEDECC00BE3D9 /* MultipeerService.swift */; };
 		ABE88EBB0583BA42617B496C /* Pods_RemoteShutter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E06F124E7E28CC7B25BDE83 /* Pods_RemoteShutter.framework */; };
@@ -166,6 +167,18 @@
 		DEADBEEF0001000000000003 /* DebugLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEADBEEF0001000000000001 /* DebugLog.swift */; };
 		CAFEBABE0009000000000002 /* StreamLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE0009000000000001 /* StreamLog.swift */; };
 		CAFEBABE0009000000000003 /* StreamLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE0009000000000001 /* StreamLog.swift */; };
+		CAFEBABE000A000000000002 /* StreamingConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE000A000000000001 /* StreamingConfig.swift */; };
+		CAFEBABE000A000000000003 /* StreamingConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE000A000000000001 /* StreamingConfig.swift */; };
+		CAFEBABE000B000000000002 /* FrameCodecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE000B000000000001 /* FrameCodecs.swift */; };
+		CAFEBABE000B000000000003 /* FrameCodecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE000B000000000001 /* FrameCodecs.swift */; };
+		CAFEBABE000C000000000002 /* JPEGFrameEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE000C000000000001 /* JPEGFrameEncoder.swift */; };
+		CAFEBABE000C000000000003 /* JPEGFrameEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE000C000000000001 /* JPEGFrameEncoder.swift */; };
+		CAFEBABE000D000000000002 /* HEICFrameEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE000D000000000001 /* HEICFrameEncoder.swift */; };
+		CAFEBABE000D000000000003 /* HEICFrameEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE000D000000000001 /* HEICFrameEncoder.swift */; };
+		CAFEBABE000E000000000002 /* FrameStreamer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE000E000000000001 /* FrameStreamer.swift */; };
+		CAFEBABE000E000000000003 /* FrameStreamer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE000E000000000001 /* FrameStreamer.swift */; };
+		CAFEBABE000F000000000002 /* FrameStreamReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE000F000000000001 /* FrameStreamReceiver.swift */; };
+		CAFEBABE000F000000000003 /* FrameStreamReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE000F000000000001 /* FrameStreamReceiver.swift */; };
 		E2292969B1882D3FCB671CB3 /* WatchConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9A830256BC7B3762B17FEF /* WatchConnectionView.swift */; };
 		E602233EB8B13D1B2BB12016 /* WelcomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52FB0F878CA54F1AC0BC42EB /* WelcomeViewModel.swift */; };
 		E9256A91DEEB414C3FE6C48D /* ActorSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4711EC884DF706A90B90662D /* ActorSystem.swift */; };
@@ -362,6 +375,7 @@
 		AA00020000000005 /* PurchaseManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseManaging.swift; sourceTree = "<group>"; };
 		AABB00012E930001009TESTS /* RemoteCamSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteCamSessionTests.swift; sourceTree = "<group>"; };
 		AABB00312E930031009TESTS /* FrameSenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameSenderTests.swift; sourceTree = "<group>"; };
+		AABB00332E930033009TESTS /* FrameStreamingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameStreamingTests.swift; sourceTree = "<group>"; };
 		AABB00032E930002009TESTS /* RemoteCmdSerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteCmdSerializationTests.swift; sourceTree = "<group>"; };
 		B1C0DE0100000001 /* RolePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolePickerView.swift; sourceTree = "<group>"; };
 		B1C0DE0200000001 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
@@ -383,6 +397,12 @@
 		DC9A830256BC7B3762B17FEF /* WatchConnectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RemoteShutterWatch/WatchConnectionView.swift; sourceTree = SOURCE_ROOT; };
 		DEADBEEF0001000000000001 /* DebugLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLog.swift; sourceTree = "<group>"; };
 		CAFEBABE0009000000000001 /* StreamLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamLog.swift; sourceTree = "<group>"; };
+		CAFEBABE000A000000000001 /* StreamingConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingConfig.swift; sourceTree = "<group>"; };
+		CAFEBABE000B000000000001 /* FrameCodecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameCodecs.swift; sourceTree = "<group>"; };
+		CAFEBABE000C000000000001 /* JPEGFrameEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JPEGFrameEncoder.swift; sourceTree = "<group>"; };
+		CAFEBABE000D000000000001 /* HEICFrameEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HEICFrameEncoder.swift; sourceTree = "<group>"; };
+		CAFEBABE000E000000000001 /* FrameStreamer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameStreamer.swift; sourceTree = "<group>"; };
+		CAFEBABE000F000000000001 /* FrameStreamReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameStreamReceiver.swift; sourceTree = "<group>"; };
 		E655FAEBED183EB237F41DEA /* WatchSharedTypes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Shared/WatchSharedTypes.swift; sourceTree = SOURCE_ROOT; };
 		E6BA9B353DB915CF86861C92 /* ViewControllerActor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerActor.swift; sourceTree = "<group>"; };
 		F3644AC8CC7EEDECC00BE3D9 /* MultipeerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipeerService.swift; sourceTree = "<group>"; };
@@ -530,6 +550,7 @@
 			children = (
 				AABB00012E930001009TESTS /* RemoteCamSessionTests.swift */,
 				AABB00312E930031009TESTS /* FrameSenderTests.swift */,
+				AABB00332E930033009TESTS /* FrameStreamingTests.swift */,
 				AABB00032E930002009TESTS /* RemoteCmdSerializationTests.swift */,
 				CAFEBABE0001000000000001 /* CropRectTests.swift */,
 				CAFEBABE0002000000000001 /* WatchCaptureCountdownTests.swift */,
@@ -588,6 +609,12 @@
 				06BB79B72E374D410094E085 /* FeatureFlags.swift */,
 				DEADBEEF0001000000000001 /* DebugLog.swift */,
 				CAFEBABE0009000000000001 /* StreamLog.swift */,
+				CAFEBABE000A000000000001 /* StreamingConfig.swift */,
+				CAFEBABE000B000000000001 /* FrameCodecs.swift */,
+				CAFEBABE000C000000000001 /* JPEGFrameEncoder.swift */,
+				CAFEBABE000D000000000001 /* HEICFrameEncoder.swift */,
+				CAFEBABE000E000000000001 /* FrameStreamer.swift */,
+				CAFEBABE000F000000000001 /* FrameStreamReceiver.swift */,
 				06CDFB1D252E9CD200EA56FB /* UICmds.swift */,
 				06CDFB16252E9A7900EA56FB /* RemoteCmds.swift */,
 				069284451BE5C0E600AF4678 /* MultipeerMessages.swift */,
@@ -1064,6 +1091,12 @@
 				068EF0C62531915A00A84DFA /* MultipeerDelegates.swift in Sources */,
 				DEADBEEF0001000000000002 /* DebugLog.swift in Sources */,
 				CAFEBABE0009000000000002 /* StreamLog.swift in Sources */,
+				CAFEBABE000A000000000002 /* StreamingConfig.swift in Sources */,
+				CAFEBABE000B000000000002 /* FrameCodecs.swift in Sources */,
+				CAFEBABE000C000000000002 /* JPEGFrameEncoder.swift in Sources */,
+				CAFEBABE000D000000000002 /* HEICFrameEncoder.swift in Sources */,
+				CAFEBABE000E000000000002 /* FrameStreamer.swift in Sources */,
+				CAFEBABE000F000000000002 /* FrameStreamReceiver.swift in Sources */,
 				77CE73A56185CD1426B83EEE /* MultipeerService.swift in Sources */,
 				AA0001012E940001000A1001 /* AlertPresenting.swift in Sources */,
 				AA0001052E940005000A1001 /* UIAlertPresenter.swift in Sources */,
@@ -1144,6 +1177,7 @@
 			files = (
 				AABB00022E930001009TESTS /* RemoteCamSessionTests.swift in Sources */,
 				AABB00322E930031009TESTS /* FrameSenderTests.swift in Sources */,
+				AABB00342E930033009TESTS /* FrameStreamingTests.swift in Sources */,
 				AABB00042E930002009TESTS /* RemoteCmdSerializationTests.swift in Sources */,
 				CAFEBABE0001000000000002 /* CropRectTests.swift in Sources */,
 				CAFEBABE0002000000000002 /* WatchCaptureCountdownTests.swift in Sources */,
@@ -1186,6 +1220,12 @@
 				068EF0C82531915A00A84DFA /* MultipeerDelegates.swift in Sources */,
 				DEADBEEF0001000000000003 /* DebugLog.swift in Sources */,
 				CAFEBABE0009000000000003 /* StreamLog.swift in Sources */,
+				CAFEBABE000A000000000003 /* StreamingConfig.swift in Sources */,
+				CAFEBABE000B000000000003 /* FrameCodecs.swift in Sources */,
+				CAFEBABE000C000000000003 /* JPEGFrameEncoder.swift in Sources */,
+				CAFEBABE000D000000000003 /* HEICFrameEncoder.swift in Sources */,
+				CAFEBABE000E000000000003 /* FrameStreamer.swift in Sources */,
+				CAFEBABE000F000000000003 /* FrameStreamReceiver.swift in Sources */,
 				AB31E7ED97070E2109B89652 /* MultipeerService.swift in Sources */,
 				AA0001042E940004000A1001 /* AlertPresenting.swift in Sources */,
 				AA0001072E940007000A1001 /* UIAlertPresenter.swift in Sources */,


### PR DESCRIPTION
## What

Replaces the preview stream payload with **HEIC stills** (hardware HEVC-compressed, ~half the bytes of JPEG at equal quality) for both the phone monitor and the Apple Watch, behind a named-encoder abstraction (`HEICFrameEncoder`, `JPEGFrameEncoder` — `HEVCFrameEncoder` slots in later for true video). Fixes every known way the preview stream could stop permanently (the edge cases in POC #62).

## Why streaming used to stop

The stream is a strict ping-pong: camera sends one frame → monitor acks with `RequestFrame` → camera sends the next. It had **no timeouts anywhere**, so one lost message deadlocked both sides forever. There was also zero background/foreground handling.

## The fixes

| Failure | Fix |
|---|---|
| Lost ack wedges `FrameSender` forever | 1s ack watchdog (generation-guarded, mirrors the `scheduleTimeout` pattern) re-opens the send gate |
| Circular send/ack deadlock | Monitor-side 2s stall watchdog raises `UICmd.StreamStalled` → state machine re-sends `RequestFrame` |
| Frozen preview after lock/unlock | Monitor re-requests a frame on `didBecomeActive` |
| `sendCommandOrGoToScanning` silently dropped its `mode` parameter | Pre-existing bug, now passes through (caught by new tests) |

Every recovery path logs via `os.Logger` (`stream.encode` / `stream.decode` / `stream.transport` / `stream.lifecycle`), so field issues are diagnosable from Console.app.

## Wire changes (additive, FlatBuffers evolution)

- `FrameData` += `codec: StreamCodec (Unknown=0, JPEG, HEVC, HEVC reserved, HEIC)` + `sequence_number` — legacy frames decode as JPEG; the receiver decodes whatever arrives per frame.
- No new `CommandAction` (note for the HEVC follow-up: 14–18 are taken, and old builds decode unknown actions as `.takepicture` — next free value is 19).

## Quality/perf side effects

- Phone monitor frames were full sensor resolution at JPEG quality 0.1; now 960px long edge HEIC q0.5 (JPEG q0.6 fallback) — better looking *and* smaller.
- Watch preview (320px) switches JPEG→HEIC: ~2× fewer bytes over the WCSession pipe → roughly double deliverable fps. Zero Watch-target code changes (`UIImage(data:)` decodes HEIC natively on watchOS).

## Out of scope (follow-up PR)

True HEVC video (port of POC #62's `VTCompressionSession` pipeline) — drops into the `FrameStreamer`/`FrameStreamReceiver` seams using the reserved `StreamCodec.HEVC` value, keyframe policy, and `.reliable` transport. Deliberately cut to keep this PR lean; VideoToolbox doesn't exist on watchOS, so HEIC is the Watch's native ceiling regardless.

## Testing

- 344 unit tests pass (25 new: FrameSender watchdog state machine, streamer pacing/fallback/sequencing, receiver stall/gap/decode, real JPEG+HEIC encoder round-trips, wire round-trips incl. legacy-frame decode).
- Device matrix still to verify on hardware: fresh connect, monitor/camera lock-unlock, kill-and-relaunch monitor, out-of-range reconnect, Watch remote mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)