### PR TITLE
UI modernization PR 5: CameraViewController dead-code sweep

### DIFF
--- a/Docs/UI_MODERNIZATION.md
+++ b/Docs/UI_MODERNIZATION.md
@@ -87,7 +87,7 @@ the refactor under them:
   replace 5 copies of the embed boilerplate and 4 copies of the help-sheet code
 - Dead `connectedPrompt`, `pinchGestureRecognizer`, `lastPinchScale` removed
 
-### PR 4: Decouple MonitorActor from MonitorViewController — **this PR**
+### PR 4: Decouple MonitorActor from MonitorViewController — **shipped (#125)**
 - New `MonitorDisplay` protocol — everything the actor needs from the monitor screen
   (mode configuration, view-model updates, frame routing, exit navigation).
 - `MonitorActor` moved out of MonitorViewController.swift into `MonitorActor.swift` and
@@ -102,13 +102,30 @@ the refactor under them:
 - `RemoteCamSession`'s `ViewCtrlActor<DeviceScannerViewController>` binding is the
   remaining coupling — PR 5.
 
-### PR 5: Decouple RemoteCamSession from DeviceScannerViewController
+### PR 5: Camera dead-code sweep — **this PR**
+An audit of CameraViewController (1,729 lines) found it ~65% capture-engine code in a
+UIViewController costume, ~25% real UI, ~10% dead/deprecated. This PR is the deletion
+slice only: `sendCameraCapabilities()` (superseded by the retry-ladder push in
+CamStates.swift), `getCurrentTorchMode()`, `hasTorch()`, `setFlashMode()` (leftovers a
+prior migration's own comment claimed were "removed"), the deprecated
+`willAnimateRotation` stub, and tombstone comments.
+
+### PR 6: Decouple RemoteCamSession from DeviceScannerViewController
 Re-target the session's lobby binding at a protocol/coordinator (same recipe as PR 4).
 Unblocks shrinking the DeviceScanner shell.
 
-### PR 6+: Camera surface
-SwiftUI chrome around a `UIViewRepresentable` preview layer for `CameraViewController`;
-`WatchRemoteCameraController` follows.
+### PR 7: Extract CaptureEngine from CameraViewController
+Move the ~1,100 engine lines (session setup, lens/zoom/capabilities, photo capture +
+crop math, AVAssetWriter recording, sample-buffer streaming) into a non-UI class with
+one owned serial queue — today session config runs on the actor thread, start/stop on
+`cameraConfigQueue`, and setup on main, unsynchronized. This is also where
+`AVCaptureVideoOrientation` (deprecated iOS 17) migrates to
+`AVCaptureDevice.RotationCoordinator`, and `isHighResolutionPhotoEnabled`
+(deprecated iOS 16) to `maxPhotoDimensions`.
+
+### PR 8+: Camera SwiftUI chrome
+With the engine out, the VC is ~400 lines of real UI: SwiftUI chrome around a
+`UIViewRepresentable` preview layer. `WatchRemoteCameraController` follows.
 
 ## Worklog (blog raw material)
 
@@ -175,3 +192,15 @@ SwiftUI chrome around a `UIViewRepresentable` preview layer for `CameraViewContr
   against a fake display object. Before this PR that required a live UIKit controller.
 - PR 3's wiring + loopback tests passed unchanged across the swap — the safety net
   did its job on the first PR it was built for.
+
+### PR 5 — camera dead-code sweep
+- The audit's best find: four torch/flash/capabilities methods that a comment in
+  *another file* claimed were already removed ("Legacy setFlashMode and setTorchMode
+  functions removed"). The comment was aspirational; the code was still compiling.
+- `sendCameraCapabilities()` told the story of its own replacement: it fire-and-forgot
+  capabilities through the session actor's root receive, while the live path in
+  CamStates.swift pushes with a 4-attempt retry ladder because the capture device
+  isn't ready right after setup. The old path lost the race and nobody buried it.
+- Also filed for later (not deletions): the unsynchronized three-thread capture-session
+  mutation, six-boolean recording state machine, and the iOS 16/17 AVFoundation
+  deprecations — all queued for the PR 7 CaptureEngine extraction.

--- a/RemoteCam/CameraViewController.swift
+++ b/RemoteCam/CameraViewController.swift
@@ -404,14 +404,6 @@ public class CameraViewController: UIViewController,
         return !isRecording
     }
 
-    public override func willAnimateRotation(to toInterfaceOrientation: UIInterfaceOrientation, duration: TimeInterval) {
-        // Deprecated and not called on modern iOS; kept for any OS version that
-        // still invokes it. `viewWillTransition` below is the live rotation path —
-        // both funnel into the same idempotent orientation update.
-        orientation = getOrientation()
-        self.rotateCameraToOrientation(orientation: toInterfaceOrientation)
-    }
-
     public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         coordinator.animate(alongsideTransition: { [weak self] _ in
@@ -488,9 +480,6 @@ public class CameraViewController: UIViewController,
                 videoDevice.unlockForConfiguration()
             }
             self.currentZoomFactor = videoDevice.videoZoomFactor
-
-            // Camera capabilities are now sent through peer-to-peer communication in CamStates.swift
-            // No need to send to session actor directly here
 
             // Audio setup will be done only when starting video recording
             // This prevents requesting microphone permission upfront
@@ -629,29 +618,6 @@ public class CameraViewController: UIViewController,
         }
     }
     
-    func getCurrentTorchMode() -> AVCaptureDevice.TorchMode {
-        return videoDeviceInput?.device.torchMode ?? .off
-    }
-    
-    func hasTorch() -> Bool {
-        return videoDeviceInput?.device.hasTorch ?? false
-    }
-
-    func setFlashMode(mode: AVCaptureDevice.FlashMode, device: AVCaptureDevice) -> Try<AVCaptureDevice.FlashMode> {
-        if device.hasFlash {
-            do {
-                try device.lockForConfiguration()
-                self.cameraSettings.flashMode = mode
-                device.unlockForConfiguration()
-            } catch let error as NSError {
-                return Failure(error: error)
-            } catch {
-                return Failure(error: NSError(domain: "Unknown error", code: 0, userInfo: nil))
-            }
-        }
-        return Success(mode)
-    }
-
     // MARK: - Virtual Device Preference
 
     /// Returns the best camera device for the given position, preferring virtual devices.
@@ -856,25 +822,6 @@ public class CameraViewController: UIViewController,
         )
     }
     
-    func sendCameraCapabilities() {
-        guard let currentDevice = self.videoDeviceInput?.device else { return }
-        
-        let capabilities = RemoteCmd.CameraCapabilitiesResp(
-            frontCamera: frontCameraInfo,
-            backCamera: backCameraInfo,
-            currentCamera: currentDevice.position,
-            currentLens: currentLensType,
-            currentZoom: currentZoomFactor,
-            currentVideoResolution: currentVideoResolution,
-            currentVideoFrameRate: currentVideoFrameRate,
-            currentPhotoFormat: currentPhotoFormat,
-            currentHDRMode: currentHDRMode,
-            error: nil
-        )
-
-        session ! capabilities
-    }
-
     // MARK: - Current Camera Capabilities for Toggle Response
     func gatherCurrentCameraCapabilities() -> RemoteCmd.CameraCapabilitiesResp? {
         debugLog("🔍 DEBUG: gatherCurrentCameraCapabilities called")
@@ -1540,10 +1487,6 @@ extension CameraViewController: AVCaptureVideoDataOutputSampleBufferDelegate, AV
         print("📤 DEBUG: Sent SendVideoResource message to actor system")
     }
     
-    // MARK: - Video Transfer Progress
-    // Video transfer progress is now handled directly in CameraVideoStates.swift
-    // via the direct ctrl reference passed to camera states
-
    func setupAssetWriterVideoInput(_ formatDescription: CMVideoFormatDescription,
                                     assetWriter: AVAssetWriter) -> Bool {
         var videoSettings = self.videoDataOutput.recommendedVideoSettingsForAssetWriter(writingTo: .mov)


### PR DESCRIPTION
Fifth slice of `Docs/UI_MODERNIZATION.md`. Deletion-only, scoped per review discussion — the camera engine extraction and deprecation fixes are queued as PR 7.

## What

A legacy audit of `CameraViewController` (1,729 lines) found it roughly 65% capture-engine code, 25% real UI, 10% dead/deprecated. This PR removes the dead 10% that has zero callers:

- **`sendCameraCapabilities()`** — the pre-retry capabilities path: it fire-and-forgot a `CameraCapabilitiesResp` through the session actor, while the live path (`CamStates.attemptToSendCapabilities`) pushes directly to the peer with a 4-attempt backoff ladder. The old path was replaced but never deleted.
- **`getCurrentTorchMode()`, `hasTorch()`, `setFlashMode()`** — leftovers of an earlier migration whose own comment (in MonitorViewController) claimed these were "removed". They weren't.
- **`willAnimateRotation(to:duration:)`** — deprecated UIKit rotation callback, never called on iOS 15+ (`viewWillTransition` is the live path).
- Tombstone comments describing code that no longer exists.

## Deliberately NOT in this PR (queued as PR 7, CaptureEngine extraction)

The audit also flagged real problems that need more than deletion: capture-session mutation split across three unsynchronized threads, a six-boolean recording state machine, `AVCaptureVideoOrientation` (deprecated iOS 17 → `RotationCoordinator`), and `isHighResolutionPhotoEnabled` (deprecated iOS 16 → `maxPhotoDimensions`). Details in `Docs/UI_MODERNIZATION.md`.

## Testing

- `xcodebuild test` on iPhone 16 sim: **371/371 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)