### PR TITLE
UI modernization PR 6: decouple RemoteCamSession from the scanner controller

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Never attempt to run `fastlane release` locally — it requires CI environment v
 The app uses the **Theater** pod — an actor-model framework. Actors communicate exclusively via messages (the `!` operator sends a message). All state transitions happen inside actor message handlers, never on the main thread (asserted in code).
 
 Key actors (registered under `RemoteCamSystem.shared`):
-- **`RemoteCamSession`** (`RemoteCam/user/RemoteCam Session`) — Central session actor managing the state machine. Subclasses `ViewCtrlActor<DeviceScannerViewController>`. Handles MultipeerConnectivity session and routes all remote commands.
+- **`RemoteCamSession`** (`RemoteCam/user/RemoteCam Session`) — Central session actor managing the state machine. Plain Theater `Actor` bound to the scanner screen through the `ScannerLobby` protocol (`SetScannerLobby` message). Handles MultipeerConnectivity session and routes all remote commands.
 - **`MonitorActor`** (`RemoteCam/user/MonitorActor`) — Bridge between session and `MonitorViewController`. Created/destroyed with the monitor screen lifecycle.
 - **`FrameSender`** (`RemoteCam/user/FrameSender`) — Manages camera frame streaming with back-pressure (waits for ack before sending next frame).
 

--- a/Docs/UI_MODERNIZATION.md
+++ b/Docs/UI_MODERNIZATION.md
@@ -102,7 +102,7 @@ the refactor under them:
 - `RemoteCamSession`'s `ViewCtrlActor<DeviceScannerViewController>` binding is the
   remaining coupling — PR 5.
 
-### PR 5: Camera dead-code sweep — **this PR**
+### PR 5: Camera dead-code sweep — **shipped (#126)**
 An audit of CameraViewController (1,729 lines) found it ~65% capture-engine code in a
 UIViewController costume, ~25% real UI, ~10% dead/deprecated. This PR is the deletion
 slice only: `sendCameraCapabilities()` (superseded by the retry-ladder push in
@@ -110,9 +110,19 @@ CamStates.swift), `getCurrentTorchMode()`, `hasTorch()`, `setFlashMode()` (lefto
 prior migration's own comment claimed were "removed"), the deprecated
 `willAnimateRotation` stub, and tombstone comments.
 
-### PR 6: Decouple RemoteCamSession from DeviceScannerViewController
-Re-target the session's lobby binding at a protocol/coordinator (same recipe as PR 4).
-Unblocks shrinking the DeviceScanner shell.
+### PR 6: Decouple RemoteCamSession from DeviceScannerViewController — **this PR**
+- New `ScannerLobby` protocol (peerID, role, scanner view model, `goToRole`,
+  `returnToLobby`, `presentScanningError`) + `SetScannerLobby` + weak box —
+  PR 4's recipe applied to the session.
+- `RemoteCamSession` is a plain `Actor` now (carries ViewCtrlActor's
+  `popToState`/`popToRootState` stop-at-root behavior with it, same state names).
+- Scanning-error alert construction moved from the actor into the VC.
+- All state signatures take `WeakScannerLobby`; `TestDeviceScannerViewController`
+  (the UIKit-dodging test subclass) is replaced by a plain `FakeScannerLobby`.
+- Milestone: no actor is generically bound to a UIKit controller anymore. The one
+  remaining UIKit handle in actor code is the `CameraViewController` passed through
+  `UICmd.BecomeCamera` into the camera states — that's exactly what PR 7's
+  `CaptureEngine` replaces.
 
 ### PR 7: Extract CaptureEngine from CameraViewController
 Move the ~1,100 engine lines (session setup, lens/zoom/capabilities, photo capture +
@@ -204,3 +214,14 @@ With the engine out, the VC is ~400 lines of real UI: SwiftUI chrome around a
 - Also filed for later (not deletions): the unsynchronized three-thread capture-session
   mutation, six-boolean recording state machine, and the iOS 16/17 AVFoundation
   deprecations — all queued for the PR 7 CaptureEngine extraction.
+
+### PR 6 — RemoteCamSession decoupling
+- Wider diff than PR 4 (13 signature swaps across 7 state files) but the same shape;
+  the actual lobby surface turned out to be tiny — most states only pass it through,
+  and only scanning/connected/startScanning ever dereference it.
+- The session kept ViewCtrlActor's exact state names ("waitingForCtrl"/"withCtrl9")
+  so the state machine's shape — and 60+ existing state tests — didn't move.
+- Test scaffolding upgrade as a side effect: `TestDeviceScannerViewController`,
+  a subclass whose whole job was dodging UIKit landmines in tests, died; a
+  12-line `FakeScannerLobby` took its place.
+- 371/371 green on the first full run after the conversion.

--- a/RemoteCam/CamStates.swift
+++ b/RemoteCam/CamStates.swift
@@ -58,7 +58,7 @@ extension RemoteCamSession {
     
     func cameraTakingPic(peer: MCPeerID,
                          ctrl: CameraViewController,
-                         lobby: Weak<DeviceScannerViewController>,
+                         lobby: WeakScannerLobby,
                          sendMediaToPeer: Bool) -> Receive {
         var alertHandle: AlertHandle?
         ^{ [weak self] in
@@ -125,7 +125,7 @@ extension RemoteCamSession {
 
     func camera(peer: MCPeerID,
                 ctrl: CameraViewController,
-                lobbyWrapper: Weak<DeviceScannerViewController>) -> Receive {
+                lobbyWrapper: WeakScannerLobby) -> Receive {
         
         return { [unowned self] (msg: Actor.Message) in
             guard lobbyWrapper.value != nil else {

--- a/RemoteCam/CameraVideoStates.swift
+++ b/RemoteCam/CameraVideoStates.swift
@@ -14,7 +14,7 @@ extension RemoteCamSession {
 
     func cameraShootingVideo(peer: MCPeerID,
                              ctrl: CameraViewController,
-                             lobby: Weak<DeviceScannerViewController>) -> Receive {
+                             lobby: WeakScannerLobby) -> Receive {
         return { [unowned self] (msg: Actor.Message) in
             switch msg {
             
@@ -84,7 +84,7 @@ extension RemoteCamSession {
 
     func cameraTransmittingVideo(peer: MCPeerID,
                              ctrl: CameraViewController,
-                             lobby: Weak<DeviceScannerViewController>) -> Receive {
+                             lobby: WeakScannerLobby) -> Receive {
         // No timeout here — video transfer can take arbitrarily long depending on
         // file size and connection speed. Completion, failure, and disconnect are
         // all handled explicitly below.

--- a/RemoteCam/DeviceScannerViewController.swift
+++ b/RemoteCam/DeviceScannerViewController.swift
@@ -114,7 +114,7 @@ public class DeviceScannerViewController: UIViewController {
         )
         remoteCamSession = rcs.ref
         remoteCamSessionInstanceId = rcs.instanceId
-        self.remoteCamSession ! SetViewCtrl(ctrl: self)
+        self.remoteCamSession ! SetScannerLobby(lobby: self)
         scannerViewModel.role = role
         setupSwiftUIView()
     }
@@ -337,5 +337,28 @@ public class DeviceScannerViewController: UIViewController {
         networkBrowser?.cancel()
         stopActorIfCurrent(ref: frameSender, instanceId: frameSenderInstanceId)
         stopActorIfCurrent(ref: remoteCamSession, instanceId: remoteCamSessionInstanceId)
+    }
+}
+
+// MARK: - ScannerLobby
+
+extension DeviceScannerViewController: ScannerLobby {
+    /// Pop navigation back to this screen when scanning restarts.
+    func returnToLobby() {
+        navigationController?.popToViewController(self, animated: true)
+    }
+
+    func presentScanningError() {
+        let alert = UIAlertController(
+            title: NSLocalizedString("Scanning Error", comment: ""),
+            message: NSLocalizedString("Unable to scan for nearby devices. Please check your network settings and try again.", comment: ""),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(
+            title: NSLocalizedString("OK", comment: ""),
+            style: .default,
+            handler: nil
+        ))
+        present(alert, animated: true)
     }
 }

--- a/RemoteCam/MonitorPhotoStates.swift
+++ b/RemoteCam/MonitorPhotoStates.swift
@@ -41,7 +41,7 @@ extension RemoteCamSession {
     
     func monitorPhotoMode(monitor: ActorRef,
                  peer: MCPeerID,
-                 lobby: Weak<DeviceScannerViewController>) -> Receive {
+                 lobby: WeakScannerLobby) -> Receive {
         return { [unowned self] (msg: Actor.Message) in
             switch msg {
             case is OnEnter:
@@ -210,7 +210,7 @@ extension RemoteCamSession {
 
     func monitorTakingPicture(monitor: ActorRef,
                               peer: MCPeerID,
-                              lobby: Weak<DeviceScannerViewController>) -> Receive {
+                              lobby: WeakScannerLobby) -> Receive {
         var alertHandle: AlertHandle?
         ^{ [weak self] in
             alertHandle = self?.alertPresenter.showAlert(title: "Requesting picture")

--- a/RemoteCam/MonitorStates.swift
+++ b/RemoteCam/MonitorStates.swift
@@ -31,7 +31,7 @@ extension RemoteCamSession {
 
     func monitorTogglingFlash(monitor: ActorRef,
                               peer: MCPeerID,
-                              lobby: Weak<DeviceScannerViewController>) -> Receive {
+                              lobby: WeakScannerLobby) -> Receive {
         var alertHandle: AlertHandle?
         ^{ [weak self] in
             alertHandle = self?.alertPresenter.showAlert(title: "Requesting flash toggle")
@@ -100,7 +100,7 @@ extension RemoteCamSession {
     // MARK: - Lens Switching State
     func monitorSwitchingLens(monitor: ActorRef,
                              peer: MCPeerID,
-                             lobby: Weak<DeviceScannerViewController>) -> Receive {
+                             lobby: WeakScannerLobby) -> Receive {
         var alertHandle: AlertHandle?
         ^{ [weak self] in
             alertHandle = self?.alertPresenter.showAlert(title: "Switching lens")
@@ -174,7 +174,7 @@ extension RemoteCamSession {
 
     func monitorTogglingCamera(monitor: ActorRef,
                                peer: MCPeerID,
-                               lobby: Weak<DeviceScannerViewController>) -> Receive {
+                               lobby: WeakScannerLobby) -> Receive {
         var alertHandle: AlertHandle?
         ^{ [weak self] in
             alertHandle = self?.alertPresenter.showAlert(title: "Requesting camera toggle")

--- a/RemoteCam/MonitorVideoStates.swift
+++ b/RemoteCam/MonitorVideoStates.swift
@@ -17,7 +17,7 @@ private typealias MonitorVideoStates = RemoteCamSession
 extension MonitorVideoStates {
     func monitorVideoMode(monitor: ActorRef,
                  peer: MCPeerID,
-                 lobby: Weak<DeviceScannerViewController>) -> Receive {
+                 lobby: WeakScannerLobby) -> Receive {
         return { [unowned self] (msg: Actor.Message) in
             switch msg {
             case is OnEnter:
@@ -176,7 +176,7 @@ extension MonitorVideoStates {
 
     func monitorRecordingVideo(monitor: ActorRef,
                                peer: MCPeerID,
-                               lobby: Weak<DeviceScannerViewController>) -> Receive {
+                               lobby: WeakScannerLobby) -> Receive {
         return { [unowned self] (msg: Actor.Message) in
             switch msg {
             case is OnEnter:
@@ -270,7 +270,7 @@ extension MonitorVideoStates {
 
     func monitorWaitingForVideo(monitor: ActorRef,
                                peer: MCPeerID,
-                               lobby: Weak<DeviceScannerViewController>) -> Receive {
+                               lobby: WeakScannerLobby) -> Receive {
         // Note: Progress UI is now handled by SwiftUI VideoTransferProgressView
         // No need for old UIAlertController
         return { [unowned self] (msg: Actor.Message) in

--- a/RemoteCam/RemoteCamConnected.swift
+++ b/RemoteCam/RemoteCamConnected.swift
@@ -15,7 +15,7 @@ extension RemoteCamSession {
         RemoteCamSystem.shared.selectActor(actorPath: "RemoteCam/user/RolePickerActor")
     }
 
-    func connected(lobbyWrapper: Weak<DeviceScannerViewController>,
+    func connected(lobbyWrapper: WeakScannerLobby,
                    peer: MCPeerID) -> Receive {
         return { [unowned self] (msg: Actor.Message) in
             guard let lobby = lobbyWrapper.value else {

--- a/RemoteCam/RemoteCamScanning.swift
+++ b/RemoteCam/RemoteCamScanning.swift
@@ -12,7 +12,7 @@ import UIKit
 
 extension RemoteCamSession {
 
-    func scanning(_ lobbyWrapper: Weak<DeviceScannerViewController>) -> Receive {
+    func scanning(_ lobbyWrapper: WeakScannerLobby) -> Receive {
         return { [unowned self] (msg: Actor.Message) in
             guard let lobby = lobbyWrapper.value else {
                 return
@@ -56,18 +56,7 @@ extension RemoteCamSession {
             case _ as UICmd.BrowserFailed:
                 ^{
                     lobby.scannerViewModel.scanningFailed()
-
-                    let alert = UIAlertController(
-                        title: NSLocalizedString("Scanning Error", comment: ""),
-                        message: NSLocalizedString("Unable to scan for nearby devices. Please check your network settings and try again.", comment: ""),
-                        preferredStyle: .alert
-                    )
-                    alert.addAction(UIAlertAction(
-                        title: NSLocalizedString("OK", comment: ""),
-                        style: .default,
-                        handler: nil
-                    ))
-                    lobby.present(alert, animated: true)
+                    lobby.presentScanningError()
                 }
 
             default:

--- a/RemoteCam/RemoteCamSession.swift
+++ b/RemoteCam/RemoteCamSession.swift
@@ -45,7 +45,12 @@ func stopActorIfCurrent(ref: ActorRef?, instanceId: ObjectIdentifier?) {
     RemoteCamSystem.shared.stopIfSameInstance(path: ref.path.asString, expectedId: instanceId)
 }
 
-public class RemoteCamSession: ViewCtrlActor<DeviceScannerViewController> {
+public class RemoteCamSession: Actor {
+
+    // Same state names ViewCtrlActor used, so the state machine's shape
+    // (and popToState's stop-at-root behavior) is unchanged.
+    public let waitingForCtrlState = "waitingForCtrl"
+    public let withCtrlState = "withCtrl9"
 
     var alertPresenter: AlertPresenting = UIAlertPresenter()
 
@@ -100,15 +105,55 @@ public class RemoteCamSession: ViewCtrlActor<DeviceScannerViewController> {
         super.init(context: context, ref: ref)
     }
 
+    override public func preStart() {
+        super.preStart()
+        become(name: waitingForCtrlState, state: waitingForLobby)
+    }
+
     override public func willStop() {
         multipeerService?.stopSession()
     }
 
-    override public func receiveWithCtrl(ctrl: Weak<DeviceScannerViewController>) -> Receive {
+    lazy var waitingForLobby: Receive = { [unowned self] (msg: Actor.Message) in
+        switch msg {
+        case let m as SetScannerLobby:
+            self.become(name: self.withCtrlState,
+                        state: self.receiveWithLobby(lobby: WeakScannerLobby(m.lobby)))
+        default:
+            self.receive(msg: msg)
+        }
+    }
+
+    /// Pop states from the statesStack until it finds name, stopping at the
+    /// bound-lobby root state (mirrors ViewCtrlActor's behavior).
+    public override func popToState(name: String) {
+        if let (hName, _) = self.statesStack.head() {
+            if hName != name && hName != self.withCtrlState {
+                unbecome()
+                popToState(name: name)
+            }
+        } else {
+            print("unable to find state with name \(name)")
+        }
+    }
+
+    /// Pop to the bound-lobby root state (mirrors ViewCtrlActor's behavior).
+    public func popToRootState() {
+        if let (hName, _) = self.statesStack.head() {
+            if hName != self.withCtrlState {
+                unbecome()
+                popToRootState()
+            }
+        } else {
+            print("unable to find root state")
+        }
+    }
+
+    func receiveWithLobby(lobby: WeakScannerLobby) -> Receive {
         return { [unowned self](msg: Message) in
             switch msg {
             case is UICmd.StartScanning:
-                self.become(name: .scanning, state: self.scanning(ctrl))
+                self.become(name: .scanning, state: self.scanning(lobby))
 
             default:
                 self.receive(msg: msg)
@@ -120,7 +165,7 @@ public class RemoteCamSession: ViewCtrlActor<DeviceScannerViewController> {
         self.popToState(name: .scanning)
     }
 
-    func startScanning(lobby: DeviceScannerViewController) {
+    func startScanning(lobby: ScannerLobby) {
         assert(Thread.isMainThread == false, "can't be called from the main thread")
 
         if multipeerService == nil {
@@ -138,7 +183,7 @@ public class RemoteCamSession: ViewCtrlActor<DeviceScannerViewController> {
         }
 
         ^{
-            lobby.navigationController?.popToViewController(lobby, animated: true)
+            lobby.returnToLobby()
             lobby.scannerViewModel.startedScanning()
         }
     }

--- a/RemoteCam/ScannerLobby.swift
+++ b/RemoteCam/ScannerLobby.swift
@@ -1,0 +1,49 @@
+//
+//  ScannerLobby.swift
+//  RemoteShutter
+//
+//  Copyright © 2026 Security Union. All rights reserved.
+//
+
+import Foundation
+import MultipeerConnectivity
+
+/// Everything `RemoteCamSession` needs from the device-scanner screen.
+///
+/// `DeviceScannerViewController` is the production implementation; tests
+/// drive the session with a fake. This is the seam that keeps the session
+/// actor ignorant of UIKit.
+protocol ScannerLobby: AnyObject {
+
+    var peerID: MCPeerID { get }
+    var role: DeviceRole { get }
+    var scannerViewModel: DeviceScannerViewModel { get }
+
+    /// Navigate to the role picker after a peer connects.
+    func goToRole()
+
+    /// Pop navigation back to the scanner screen (called when scanning restarts).
+    func returnToLobby()
+
+    /// Surface a "can't scan for nearby devices" failure to the user.
+    func presentScanningError()
+}
+
+/// Binds a `ScannerLobby` to `RemoteCamSession` — the protocol-typed
+/// counterpart of Theater's `SetViewCtrl` (whose generic parameter requires
+/// a concrete class).
+public class SetScannerLobby: Actor.Message {
+    let lobby: ScannerLobby
+
+    init(lobby: ScannerLobby) {
+        self.lobby = lobby
+        super.init(sender: nil)
+    }
+}
+
+/// Weak box for the lobby — `Weak<T>` requires a concrete class type, and
+/// the lobby is deliberately a protocol existential.
+final class WeakScannerLobby {
+    weak var value: ScannerLobby?
+    init(_ value: ScannerLobby) { self.value = value }
+}

--- a/RemoteCamTests/LoopbackSessionTests.swift
+++ b/RemoteCamTests/LoopbackSessionTests.swift
@@ -104,12 +104,12 @@ class LoopbackSessionTests: XCTestCase {
     private var cameraTransport: LoopbackMultipeerService!
     private var cameraAlerts: FakeAlertPresenter!
 
-    private static var sharedLobby: TestDeviceScannerViewController!
-    private var lobbyWrapper: Weak<DeviceScannerViewController>!
+    private static var sharedLobby: FakeScannerLobby!
+    private var lobbyWrapper: WeakScannerLobby!
 
     override class func setUp() {
         super.setUp()
-        sharedLobby = TestDeviceScannerViewController()
+        sharedLobby = FakeScannerLobby()
     }
 
     override class func tearDown() {
@@ -140,7 +140,7 @@ class LoopbackSessionTests: XCTestCase {
         monitorSession.alertPresenter = monitorAlerts
         cameraSession.alertPresenter = cameraAlerts
 
-        lobbyWrapper = Weak(Self.sharedLobby)
+        lobbyWrapper = WeakScannerLobby(Self.sharedLobby)
 
         drainBothSessions()
     }

--- a/RemoteCamTests/RemoteCamSessionTests.swift
+++ b/RemoteCamTests/RemoteCamSessionTests.swift
@@ -79,30 +79,26 @@ class FakeAlertPresenter: AlertPresenting {
 
 class TestableRemoteCamSession: RemoteCamSession {
 
-    override func startScanning(lobby: DeviceScannerViewController) {
+    override func startScanning(lobby: ScannerLobby) {
         // no-op — avoids MultipeerService creation and UI code
     }
 }
 
-// MARK: - Test ViewController
+// MARK: - Fake ScannerLobby
 
-/// Subclass that prevents actor system registration in tests.
-class TestDeviceScannerViewController: DeviceScannerViewController {
-    convenience init() {
-        self.init(role: .monitor)
-    }
+/// Plain fake for the session's lobby seam — no UIKit involved.
+class FakeScannerLobby: ScannerLobby {
+    let peerID = MCPeerID(displayName: "FakeLobby")
+    var role: DeviceRole = .monitor
+    let scannerViewModel = DeviceScannerViewModel()
 
-    override public func viewDidLoad() {
-        // Skip super — avoids actor system registration
-    }
+    var roleScreenShown = 0
+    var returnsToLobby = 0
+    var scanningErrors = 0
 
-    override func stopScanning() {
-        // no-op — avoids accessing splash/tableView
-    }
-
-    override func startScanning() {
-        // no-op
-    }
+    func goToRole() { roleScreenShown += 1 }
+    func returnToLobby() { returnsToLobby += 1 }
+    func presentScanningError() { scanningErrors += 1 }
 }
 
 // MARK: - Test Helpers
@@ -126,21 +122,8 @@ class RemoteCamSessionTests: XCTestCase {
     private var fakeMP: FakeMultipeerService!
     private var fakeAlerts: FakeAlertPresenter!
 
-    // Class-level to avoid race between VC init (registers actors) and
-    // previous VC's async deinit (Harakiri cleanup).
-    private static var sharedLobby: TestDeviceScannerViewController!
-    private var lobby: DeviceScannerViewController!
-    private var lobbyWrapper: Weak<DeviceScannerViewController>!
-
-    override class func setUp() {
-        super.setUp()
-        sharedLobby = TestDeviceScannerViewController()
-    }
-
-    override class func tearDown() {
-        sharedLobby = nil
-        super.tearDown()
-    }
+    private var lobby: FakeScannerLobby!
+    private var lobbyWrapper: WeakScannerLobby!
 
     override func setUp() {
         super.setUp()
@@ -150,8 +133,8 @@ class RemoteCamSessionTests: XCTestCase {
         session = system.actorForRef(ref: ref!) as! TestableRemoteCamSession
         peer = MCPeerID(displayName: "TestPeer")
 
-        lobby = Self.sharedLobby
-        lobbyWrapper = Weak(lobby)
+        lobby = FakeScannerLobby()
+        lobbyWrapper = WeakScannerLobby(lobby)
 
         fakeMP = FakeMultipeerService()
         fakeMP.connectedPeers = [peer]
@@ -273,7 +256,7 @@ class RemoteCamSessionTests: XCTestCase {
     func testConnectedStateNilLobbyPopsToScanning() {
         pushScanningState()
 
-        let weakLobby = Weak(lobby!)
+        let weakLobby = WeakScannerLobby(lobby!)
         session.become(name: .connected,
                        state: session.connected(lobbyWrapper: weakLobby, peer: peer))
         waitForMailbox(session, test: self)

--- a/RemoteShutter.xcodeproj/project.pbxproj
+++ b/RemoteShutter.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		30592B547D1C32386D1541C4 /* RemoteCmdFlatBuffers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B28B6F9DA6B3E3677C5C532 /* RemoteCmdFlatBuffers.swift */; };
 		33F5D268690A3D022A6A54BA /* WatchControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F37D4A9FA8416A43EFEFF1 /* WatchControlView.swift */; };
 		3DBD14F1A5F01D3D9C2DB30D /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036824F9CFF7D4D8699380C8 /* SettingsViewModelTests.swift */; };
+		4259A755DF0013E098FD3CCC /* ScannerLobby.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D7D050D0AB3D3E4F07879D /* ScannerLobby.swift */; };
 		448ED35E2633C93396E1AC66 /* WatchSharedTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E655FAEBED183EB237F41DEA /* WatchSharedTypes.swift */; };
 		47568AFE6BD007664267E717 /* CountdownTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 305D87D0EED76E6031FC1E07 /* CountdownTimerTests.swift */; };
 		531BD3C020987337266B50EC /* ControllerWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C3D2AB20DA09223CE0EF3D /* ControllerWiringTests.swift */; };
@@ -328,6 +329,7 @@
 		2F2F16CCCC931B7EC3877C89 /* SettingsViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		305D87D0EED76E6031FC1E07 /* CountdownTimerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CountdownTimerTests.swift; sourceTree = "<group>"; };
 		333D17BC86CE5F7AA48593A9 /* LoopbackSessionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoopbackSessionTests.swift; sourceTree = "<group>"; };
+		35D7D050D0AB3D3E4F07879D /* ScannerLobby.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScannerLobby.swift; sourceTree = "<group>"; };
 		36D2A99A351652C2D0C29B95 /* RemoteShutterWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RemoteShutterWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		381BB7BCEF561D22B0F194A6 /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = System/Library/Frameworks/WatchConnectivity.framework; sourceTree = SDKROOT; };
 		3B3FB0EA0E2B04051EF232D6 /* Pods-RemoteShutterWatch.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RemoteShutterWatch.release.xcconfig"; path = "Target Support Files/Pods-RemoteShutterWatch/Pods-RemoteShutterWatch.release.xcconfig"; sourceTree = "<group>"; };
@@ -536,6 +538,7 @@
 				77D6F0EE27D62251BDB065B7 /* UIViewController+SwiftUIHosting.swift */,
 				C65DE1A8EACAAA012BE9F840 /* MonitorDisplay.swift */,
 				B78950879170C5D3A3B9B134 /* MonitorActor.swift */,
+				35D7D050D0AB3D3E4F07879D /* ScannerLobby.swift */,
 			);
 			path = RemoteCam;
 			sourceTree = "<group>";
@@ -1155,6 +1158,7 @@
 				B2AB4B5C5BB274C6AB180189 /* UIViewController+SwiftUIHosting.swift in Sources */,
 				2F485D44C59F540DB49140DD /* MonitorDisplay.swift in Sources */,
 				7BCEB5791B211861A0F6BE60 /* MonitorActor.swift in Sources */,
+				4259A755DF0013E098FD3CCC /* ScannerLobby.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Sixth slice of `Docs/UI_MODERNIZATION.md` — PR #125's recipe applied to the bigger weld. Follows #122–#126.

## What

- **New `ScannerLobby` protocol** — the full surface the session actor needs from the scanner screen: `peerID`, `role`, the scanner view model, and three navigation/UX intents (`goToRole`, `returnToLobby`, `presentScanningError`).
- **`RemoteCamSession` is a plain `Actor` now** — bound via a `SetScannerLobby` message + weak box instead of `ViewCtrlActor<DeviceScannerViewController>`. It carries ViewCtrlActor's `popToState`/`popToRootState` stop-at-root behavior and keeps the exact same state names, so the hierarchical state machine (and its 60+ existing tests) didn't move.
- **13 signature swaps across 7 state files** (`Weak<DeviceScannerViewController>` → `WeakScannerLobby`) — wide but shallow; only scanning/connected/`startScanning` ever dereference the lobby.
- **UIAlertController construction left the actor**: the browser-failure alert is now built by the view controller behind `presentScanningError()`.
- **Test scaffolding upgrade**: `TestDeviceScannerViewController` — a subclass whose only job was dodging UIKit landmines in tests — is replaced by a 12-line `FakeScannerLobby`.

## Milestone

No actor in the app is generically bound to a UIKit controller anymore. The single remaining UIKit handle in actor code is the `CameraViewController` reference passed through `UICmd.BecomeCamera` into the camera states — which is precisely what PR 7 (CaptureEngine extraction) replaces.

## Testing

- `xcodebuild test` on iPhone 16 sim: **371/371 pass**, green on the first full run after the conversion
- The wiring, loopback, and session state-machine suites all passed without modification beyond the fake-lobby swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)