### PR TITLE
UI modernization PR 7: CameraControlling seam — no actor knows UIKit

### DIFF
--- a/Docs/UI_MODERNIZATION.md
+++ b/Docs/UI_MODERNIZATION.md
@@ -110,7 +110,7 @@ CamStates.swift), `getCurrentTorchMode()`, `hasTorch()`, `setFlashMode()` (lefto
 prior migration's own comment claimed were "removed"), the deprecated
 `willAnimateRotation` stub, and tombstone comments.
 
-### PR 6: Decouple RemoteCamSession from DeviceScannerViewController — **this PR**
+### PR 6: Decouple RemoteCamSession from DeviceScannerViewController — **shipped (#127)**
 - New `ScannerLobby` protocol (peerID, role, scanner view model, `goToRole`,
   `returnToLobby`, `presentScanningError`) + `SetScannerLobby` + weak box —
   PR 4's recipe applied to the session.
@@ -124,7 +124,23 @@ prior migration's own comment claimed were "removed"), the deprecated
   `UICmd.BecomeCamera` into the camera states — that's exactly what PR 7's
   `CaptureEngine` replaces.
 
-### PR 7: Extract CaptureEngine from CameraViewController
+### PR 7: CameraControlling protocol seam — **this PR**
+The watch-hardening work had already built the seam (`WatchCameraControlling`,
+fake-backed); this PR generalizes it. Renamed `CameraControlling`, moved to its
+own file, extended with the nine members the phone camera states need
+(`cameraViewModel`, quality/aspect setters, capabilities, countdown chime/torch,
+`exitCamera`). `UICmd.BecomeCamera` now carries the protocol; camera/video state
+signatures follow; the session's direct `navigationController` pop became
+`exitCamera()`. The camera-side `OnPicture` handler now routes through the
+`photoLibrarySaver` seam like the watch path always did.
+
+Milestone completed: **no actor code references a UIKit type.** Payoff test:
+`testTakePictureHappyPathAcrossTheWire` — a fake camera behind the protocol lets
+the loopback harness run the full two-device photo capture (become camera →
+become monitor → TakePic → OnPicture → Ack + Resp with bytes → both sides back
+to steady state) in CI for the first time.
+
+### PR 8: Extract CaptureEngine from CameraViewController
 Move the ~1,100 engine lines (session setup, lens/zoom/capabilities, photo capture +
 crop math, AVAssetWriter recording, sample-buffer streaming) into a non-UI class with
 one owned serial queue — today session config runs on the actor thread, start/stop on
@@ -133,7 +149,7 @@ one owned serial queue — today session config runs on the actor thread, start/
 `AVCaptureDevice.RotationCoordinator`, and `isHighResolutionPhotoEnabled`
 (deprecated iOS 16) to `maxPhotoDimensions`.
 
-### PR 8+: Camera SwiftUI chrome
+### PR 9+: Camera SwiftUI chrome
 With the engine out, the VC is ~400 lines of real UI: SwiftUI chrome around a
 `UIViewRepresentable` preview layer. `WatchRemoteCameraController` follows.
 
@@ -225,3 +241,14 @@ With the engine out, the VC is ~400 lines of real UI: SwiftUI chrome around a
   a subclass whose whole job was dodging UIKit landmines in tests, died; a
   12-line `FakeScannerLobby` took its place.
 - 371/371 green on the first full run after the conversion.
+
+### PR 7 — camera protocol seam
+- Half the work was already done and hiding in plain sight: the watch-hardening
+  effort had built `WatchCameraControlling` — protocol, conformance, and a fake —
+  for the watch path only. Generalizing beat inventing.
+- The best assertion in the suite so far: a fake camera behind the seam let the
+  loopback harness run the complete two-device photo capture — become camera,
+  become monitor, TakePic across the wire, capture, Ack, Resp carrying the actual
+  bytes, both state machines back to steady state — all in-process, in CI.
+  Until now that flow had only ever been verified with two phones on a desk.
+- 372/372 green.

--- a/RemoteCam/CamStates.swift
+++ b/RemoteCam/CamStates.swift
@@ -14,7 +14,7 @@ import SwiftUI
 extension RemoteCamSession {
 
     // MARK: - Camera Capabilities Retry Helper
-    private func attemptToSendCapabilities(ctrl: CameraViewController, peer: MCPeerID, attempt: Int, maxAttempts: Int) {
+    private func attemptToSendCapabilities(ctrl: CameraControlling, peer: MCPeerID, attempt: Int, maxAttempts: Int) {
         debugLog("🔍 DEBUG: Attempt \(attempt)/\(maxAttempts) to gather camera capabilities")
         
         ctrl.gatherAllCameraCapabilities()
@@ -57,7 +57,7 @@ extension RemoteCamSession {
     }
     
     func cameraTakingPic(peer: MCPeerID,
-                         ctrl: CameraViewController,
+                         ctrl: CameraControlling,
                          lobby: WeakScannerLobby,
                          sendMediaToPeer: Bool) -> Receive {
         var alertHandle: AlertHandle?
@@ -84,7 +84,7 @@ extension RemoteCamSession {
 
             case let t as UICmd.OnPicture:
                 if let imageData = t.pic {
-                    savePicture(imageData)
+                    photoLibrarySaver(imageData)
                 }
                 ^{ [weak self] in
                     if let h = alertHandle { self?.alertPresenter.dismissAlert(h) }
@@ -124,7 +124,7 @@ extension RemoteCamSession {
     }
 
     func camera(peer: MCPeerID,
-                ctrl: CameraViewController,
+                ctrl: CameraControlling,
                 lobbyWrapper: WeakScannerLobby) -> Receive {
         
         return { [unowned self] (msg: Actor.Message) in

--- a/RemoteCam/CameraControlling.swift
+++ b/RemoteCam/CameraControlling.swift
@@ -1,0 +1,87 @@
+//
+//  CameraControlling.swift
+//  RemoteShutter
+//
+//  Copyright © 2026 Security Union. All rights reserved.
+//
+
+import Foundation
+import AVFoundation
+
+/// Everything the session's camera states (phone and Watch paths) need from
+/// the camera screen. `CameraViewController` is the production implementation;
+/// tests substitute a fake so the state machine can be exercised without
+/// AVFoundation or a view hierarchy.
+protocol CameraControlling: AnyObject {
+    var currentCameraMode: RecordingMode { get set }
+    var isRecording: Bool { get }
+    var isTorchActive: Bool { get }
+    var currentFlashMode: AVCaptureDevice.FlashMode { get }
+    var cameraViewModel: CameraViewModel { get }
+
+    func updateCameraStatus()
+    func takePicture(_ sendMediaToRemote: Bool)
+    func startRecordingVideo()
+    func stopRecordingVideo(_ shouldSendVideo: Bool)
+    func setZoom(zoomFactor: CGFloat) -> Try<(CGFloat, CameraLensType, RemoteCmd.ZoomRange)>
+    func switchLens(to lensType: CameraLensType) -> Try<(CameraLensType, [CameraLensType], CGFloat, RemoteCmd.ZoomRange)>
+    func toggleFlash() -> Try<AVCaptureDevice.FlashMode>
+    func toggleTorch() -> Try<AVCaptureDevice.TorchMode>
+    func toggleCamera() -> Try<(AVCaptureDevice.FlashMode?, AVCaptureDevice.Position)>
+    func setTorchMode(mode: AVCaptureDevice.TorchMode) -> Try<AVCaptureDevice.TorchMode>
+    func setVideoQuality(resolution: VideoResolution, frameRate: VideoFrameRate) -> (VideoResolution, VideoFrameRate)?
+    func setPhotoQuality(format: PhotoFormat, hdrMode: HDRMode) -> (PhotoFormat, HDRMode)?
+    func setAspectRatio(_ ratio: AspectRatio) -> AspectRatio
+    func gatherAllCameraCapabilities()
+    func gatherCurrentCameraCapabilities() -> RemoteCmd.CameraCapabilitiesResp?
+
+    func getCurrentZoomFactor() -> CGFloat
+    func getMinZoomFactor() -> CGFloat
+    func getMaxZoomFactor() -> CGFloat
+    func getCurrentLensType() -> CameraLensType
+    func getAvailableLensTypes() -> [CameraLensType]
+    func getZoomStops() -> [CGFloat]
+    func getWideAngleZoomFactor() -> CGFloat
+
+    /// Drives the on-phone countdown overlay/chime for timer captures.
+    /// value > 0: tick; 0: fired; < 0: cancelled.
+    func updateTimerCountdown(value: Int)
+    func playCountdownChime(remaining: Int)
+    func restoreTorchAfterCountdown()
+
+    /// Leave the camera screen (e.g. the peer refused the camera role).
+    func exitCamera()
+}
+
+// MARK: - Production implementation
+
+extension CameraViewController: CameraControlling {
+    var isTorchActive: Bool {
+        videoDeviceInput?.device.isTorchActive ?? false
+    }
+
+    var currentFlashMode: AVCaptureDevice.FlashMode {
+        cameraSettings.flashMode
+    }
+
+    func updateTimerCountdown(value: Int) {
+        ^{
+            if value > 0 {
+                self.cameraViewModel.showCountdown(value)
+                self.playCountdownChime(remaining: value)
+            } else if value == 0 {
+                self.cameraViewModel.clearCountdown()
+                self.restoreTorchAfterCountdown()
+            } else {
+                self.cameraViewModel.cancelCountdown()
+                self.restoreTorchAfterCountdown()
+            }
+        }
+    }
+
+    func exitCamera() {
+        ^{
+            self.navigationController?.popViewController(animated: true)
+        }
+    }
+}

--- a/RemoteCam/CameraVideoStates.swift
+++ b/RemoteCam/CameraVideoStates.swift
@@ -13,7 +13,7 @@ import Photos
 extension RemoteCamSession {
 
     func cameraShootingVideo(peer: MCPeerID,
-                             ctrl: CameraViewController,
+                             ctrl: CameraControlling,
                              lobby: WeakScannerLobby) -> Receive {
         return { [unowned self] (msg: Actor.Message) in
             switch msg {
@@ -83,7 +83,7 @@ extension RemoteCamSession {
     }
 
     func cameraTransmittingVideo(peer: MCPeerID,
-                             ctrl: CameraViewController,
+                             ctrl: CameraControlling,
                              lobby: WeakScannerLobby) -> Receive {
         // No timeout here — video transfer can take arbitrarily long depending on
         // file size and connection speed. Completion, failure, and disconnect are

--- a/RemoteCam/RemoteCamSession.swift
+++ b/RemoteCam/RemoteCamSession.swift
@@ -200,9 +200,7 @@ public class RemoteCamSession: Actor {
             self.become(name: .watchRemoteCamera, state: self.watchRemoteCamera(ctrl: m.ctrl))
 
         case let m as UICmd.BecomeCamera:
-            ^{
-                m.ctrl.navigationController?.popViewController(animated: true)
-            }
+            m.ctrl.exitCamera()
 
         case let m as UICmd.BecomeMonitor:
             m.sender! ! UICmd.BecomeMonitorFailed(sender: this)

--- a/RemoteCam/UICmds.swift
+++ b/RemoteCam/UICmds.swift
@@ -103,9 +103,9 @@ public class UICmd {
     }
 
     public class BecomeCamera: Actor.Message {
-        let ctrl: CameraViewController
+        let ctrl: CameraControlling
 
-        public init(sender: ActorRef?, ctrl: CameraViewController) {
+        init(sender: ActorRef?, ctrl: CameraControlling) {
             self.ctrl = ctrl
             super.init(sender: sender)
         }

--- a/RemoteCam/WatchRemoteCamStates.swift
+++ b/RemoteCam/WatchRemoteCamStates.swift
@@ -9,74 +9,14 @@
 import Foundation
 import AVFoundation
 
-// MARK: - Camera Control Seam
-
-/// Everything the watch states need from the camera screen. `CameraViewController`
-/// is the production implementation; tests substitute a fake so the state machine
-/// can be exercised without AVFoundation or a view hierarchy.
-protocol WatchCameraControlling: AnyObject {
-    var currentCameraMode: RecordingMode { get set }
-    var isRecording: Bool { get }
-    var isTorchActive: Bool { get }
-    var currentFlashMode: AVCaptureDevice.FlashMode { get }
-
-    func updateCameraStatus()
-    func takePicture(_ sendMediaToRemote: Bool)
-    func startRecordingVideo()
-    func stopRecordingVideo(_ shouldSendVideo: Bool)
-    func setZoom(zoomFactor: CGFloat) -> Try<(CGFloat, CameraLensType, RemoteCmd.ZoomRange)>
-    func switchLens(to lensType: CameraLensType) -> Try<(CameraLensType, [CameraLensType], CGFloat, RemoteCmd.ZoomRange)>
-    func toggleFlash() -> Try<AVCaptureDevice.FlashMode>
-    func toggleTorch() -> Try<AVCaptureDevice.TorchMode>
-    func toggleCamera() -> Try<(AVCaptureDevice.FlashMode?, AVCaptureDevice.Position)>
-    func gatherAllCameraCapabilities()
-
-    func getCurrentZoomFactor() -> CGFloat
-    func getMinZoomFactor() -> CGFloat
-    func getMaxZoomFactor() -> CGFloat
-    func getCurrentLensType() -> CameraLensType
-    func getAvailableLensTypes() -> [CameraLensType]
-    func getZoomStops() -> [CGFloat]
-    func getWideAngleZoomFactor() -> CGFloat
-
-    /// Drives the on-phone countdown overlay/chime for Watch-initiated timer
-    /// captures. value > 0: tick; 0: fired; < 0: cancelled.
-    func updateTimerCountdown(value: Int)
-}
-
-extension CameraViewController: WatchCameraControlling {
-    var isTorchActive: Bool {
-        videoDeviceInput?.device.isTorchActive ?? false
-    }
-
-    var currentFlashMode: AVCaptureDevice.FlashMode {
-        cameraSettings.flashMode
-    }
-
-    func updateTimerCountdown(value: Int) {
-        ^{
-            if value > 0 {
-                self.cameraViewModel.showCountdown(value)
-                self.playCountdownChime(remaining: value)
-            } else if value == 0 {
-                self.cameraViewModel.clearCountdown()
-                self.restoreTorchAfterCountdown()
-            } else {
-                self.cameraViewModel.cancelCountdown()
-                self.restoreTorchAfterCountdown()
-            }
-        }
-    }
-}
-
 // MARK: - UICmd for Watch Remote Mode
 
 extension UICmd {
     /// Sent by WatchRemoteCameraController to enter Watch Remote camera mode.
     public class BecomeWatchCamera: Actor.Message {
-        let ctrl: WatchCameraControlling
+        let ctrl: CameraControlling
 
-        init(ctrl: WatchCameraControlling) {
+        init(ctrl: CameraControlling) {
             self.ctrl = ctrl
             super.init(sender: nil)
         }
@@ -100,7 +40,7 @@ extension UICmd {
 
 extension RemoteCamSession {
 
-    func watchRemoteCamera(ctrl: WatchCameraControlling) -> Receive {
+    func watchRemoteCamera(ctrl: CameraControlling) -> Receive {
         return { [unowned self] (msg: Actor.Message) in
             switch msg {
             case is OnEnter:
@@ -233,7 +173,7 @@ extension RemoteCamSession {
 
     // MARK: - Watch Remote Taking Picture Sub-state
 
-    func watchRemoteCameraTakingPic(ctrl: WatchCameraControlling) -> Receive {
+    func watchRemoteCameraTakingPic(ctrl: CameraControlling) -> Receive {
         let gen = self.scheduleTimeout(stateName: .watchRemoteCameraTakingPic)
         return { [unowned self] (msg: Actor.Message) in
             switch msg {
@@ -290,7 +230,7 @@ extension RemoteCamSession {
     /// Waits for the capture pipeline to confirm recording actually started.
     /// Without this, a failed start (mic denied, session interrupted) left the
     /// actor wedged in the recording state with no way out.
-    func watchRemoteCameraStartingVideo(ctrl: WatchCameraControlling) -> Receive {
+    func watchRemoteCameraStartingVideo(ctrl: CameraControlling) -> Receive {
         let gen = self.scheduleTimeout(stateName: .watchRemoteCameraStartingVideo)
         return { [unowned self] (msg: Actor.Message) in
             switch msg {
@@ -352,7 +292,7 @@ extension RemoteCamSession {
 
     // MARK: - Watch Remote Recording Video Sub-state
 
-    func watchRemoteCameraRecordingVideo(ctrl: WatchCameraControlling) -> Receive {
+    func watchRemoteCameraRecordingVideo(ctrl: CameraControlling) -> Receive {
         // No blanket timeout: recordings legitimately run for minutes. A timeout
         // is armed only once stop is requested, to catch a stop that never
         // completes (capture session interrupted mid-recording).
@@ -420,7 +360,7 @@ extension RemoteCamSession {
 
     // MARK: - Watch State Push Helper (FlatBuffer-encoded)
 
-    func pushWatchState(ctrl: WatchCameraControlling,
+    func pushWatchState(ctrl: CameraControlling,
                         event: RemoteShutter_WatchEventType = .unknown) {
         watchStatePusher.pushCameraState(
             Self.watchStateSnapshot(ctrl: ctrl, event: event,
@@ -429,7 +369,7 @@ extension RemoteCamSession {
         )
     }
 
-    static func watchStateSnapshot(ctrl: WatchCameraControlling,
+    static func watchStateSnapshot(ctrl: CameraControlling,
                                    event: RemoteShutter_WatchEventType = .unknown,
                                    isBackgrounded: Bool = false,
                                    countdownRemaining: Int32 = 0) -> WatchCameraStateSnapshot {

--- a/RemoteCamTests/LoopbackSessionTests.swift
+++ b/RemoteCamTests/LoopbackSessionTests.swift
@@ -292,4 +292,63 @@ class LoopbackSessionTests: XCTestCase {
 
         XCTAssertEqual(monitorSession.currentStateName(), .scanning)
     }
+
+    // MARK: - Happy-path photo capture with a camera peer
+
+    func testTakePictureHappyPathAcrossTheWire() {
+        connectBothSessions()
+
+        // Camera side: enter the camera state with a fake capture device.
+        let fakeCamera = LoopbackFakeCamera()
+        fakeCamera.sessionRef = cameraRef
+        var cameraSaves: [Data] = []
+        cameraSession.photoLibrarySaver = { data in cameraSaves.append(data) }
+        cameraRef ! UICmd.BecomeCamera(sender: nil, ctrl: fakeCamera)
+        drainBothSessions()
+        XCTAssertEqual(cameraSession.currentStateName(), .camera)
+
+        becomeMonitor(mode: .Photo)
+        XCTAssertEqual(monitorSession.currentStateName(), .monitor)
+
+        monitorRef ! UICmd.TakePicture(sender: nil, sendMediaToRemote: true)
+        drainBothSessions()
+
+        // The fake camera captured exactly once and the photo was saved camera-side.
+        XCTAssertEqual(fakeCamera.takePictureCalls, [true])
+        XCTAssertEqual(cameraSaves, [fakeCamera.photoBytes])
+
+        // Ack + response carrying the picture crossed back to the monitor.
+        XCTAssertTrue(cameraTransport.sentMessages.contains { $0 is RemoteCmd.TakePicAck })
+        let resps = cameraTransport.sentMessages.compactMap { $0 as? RemoteCmd.TakePicResp }
+        XCTAssertEqual(resps.count, 1)
+        XCTAssertEqual(resps.first?.pic, fakeCamera.photoBytes)
+
+        // Both sides settled back into their steady states, with no errors surfaced.
+        XCTAssertEqual(monitorSession.currentStateName(), .monitor)
+        XCTAssertEqual(cameraSession.currentStateName(), .camera)
+        XCTAssertTrue(monitorAlerts.shownErrors.isEmpty)
+        XCTAssertTrue(cameraAlerts.shownErrors.isEmpty)
+    }
+}
+
+// MARK: - Fake camera for happy-path flows
+
+/// A `CameraControlling` fake that "captures" a photo by sending `OnPicture`
+/// back to its session — the same message the real capture callback sends.
+final class LoopbackFakeCamera: FakeWatchCameraController {
+    var sessionRef: ActorRef?
+    let photoBytes = Data([0xFF, 0xD8, 0xFF, 0xE0, 0x42])
+
+    override func takePicture(_ sendMediaToRemote: Bool) {
+        super.takePicture(sendMediaToRemote)
+        if let sessionRef {
+            sessionRef ! UICmd.OnPicture(sender: nil, pic: photoBytes)
+        }
+    }
+
+    override func gatherCurrentCameraCapabilities() -> RemoteCmd.CameraCapabilitiesResp? {
+        RemoteCmd.CameraCapabilitiesResp(
+            frontCamera: nil, backCamera: nil,
+            currentCamera: .back, currentLens: .wideAngle, currentZoom: 1.0, error: nil)
+    }
 }

--- a/RemoteCamTests/WatchRemoteCamStateTests.swift
+++ b/RemoteCamTests/WatchRemoteCamStateTests.swift
@@ -17,7 +17,7 @@ import MultipeerConnectivity
 
 // MARK: - Fakes
 
-final class FakeWatchCameraController: WatchCameraControlling {
+class FakeWatchCameraController: CameraControlling {
     var currentCameraMode: RecordingMode = .Photo
     var isRecording = false
     var isTorchActive = false
@@ -67,6 +67,27 @@ final class FakeWatchCameraController: WatchCameraControlling {
 
     var countdownTicks: [Int] = []
     func updateTimerCountdown(value: Int) { countdownTicks.append(value) }
+
+    let cameraViewModel = CameraViewModel()
+    var chimes: [Int] = []
+    var torchRestores = 0
+    var exits = 0
+
+    func gatherCurrentCameraCapabilities() -> RemoteCmd.CameraCapabilitiesResp? { nil }
+    func setTorchMode(mode: AVCaptureDevice.TorchMode) -> Try<AVCaptureDevice.TorchMode> {
+        isTorchActive = mode == .on
+        return Success(mode)
+    }
+    func setVideoQuality(resolution: VideoResolution, frameRate: VideoFrameRate) -> (VideoResolution, VideoFrameRate)? {
+        (resolution, frameRate)
+    }
+    func setPhotoQuality(format: PhotoFormat, hdrMode: HDRMode) -> (PhotoFormat, HDRMode)? {
+        (format, hdrMode)
+    }
+    func setAspectRatio(_ ratio: AspectRatio) -> AspectRatio { ratio }
+    func playCountdownChime(remaining: Int) { chimes.append(remaining) }
+    func restoreTorchAfterCountdown() { torchRestores += 1 }
+    func exitCamera() { exits += 1 }
 }
 
 final class FakeWatchStatePusher: WatchStatePushing {

--- a/RemoteShutter.xcodeproj/project.pbxproj
+++ b/RemoteShutter.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		8D834E942E3DF65BDAE055C5 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C9E06E2C406307CD182CFB2 /* SettingsView.swift */; };
 		8F558AB2F4887617AF3E8FCD /* RemoteShutterWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92E4A9C10FB90A6F07DB857 /* RemoteShutterWatchApp.swift */; };
 		8FC594E5A315D918BE429895 /* MonitorActorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B23042ABDA0FD46696039B /* MonitorActorTests.swift */; };
+		99F50887F138FD71CF957A08 /* CameraControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A0B888B31311AE2BB5EB70 /* CameraControlling.swift */; };
 		A0C6EAACDA1985B1DD5E8EC0 /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50951447985E618A5F3818CD /* WatchConnectivity.framework */; };
 		A31965B5A3A1F59F96002E63 /* RemoteShutterWatch.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 36D2A99A351652C2D0C29B95 /* RemoteShutterWatch.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		AA0001012E940001000A1001 /* AlertPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001032E940003000A1001 /* AlertPresenting.swift */; };
@@ -359,6 +360,7 @@
 		99FC5340BB98B2BD307FFA1A /* SoundManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SoundManager.swift; sourceTree = "<group>"; };
 		9B8080E0FDE21CFE4B92AEAB /* WatchSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RemoteShutterWatch/WatchSettingsView.swift; sourceTree = SOURCE_ROOT; };
 		9C74B20F636B4DD2AB0C6511 /* Pods-RemoteShutterTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RemoteShutterTests.release.xcconfig"; path = "Target Support Files/Pods-RemoteShutterTests/Pods-RemoteShutterTests.release.xcconfig"; sourceTree = "<group>"; };
+		A8A0B888B31311AE2BB5EB70 /* CameraControlling.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CameraControlling.swift; sourceTree = "<group>"; };
 		AA0001032E940003000A1001 /* AlertPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPresenting.swift; sourceTree = "<group>"; };
 		AA0001062E940006000A1001 /* UIAlertPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAlertPresenter.swift; sourceTree = "<group>"; };
 		AA0001202E940020000A1001 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -539,6 +541,7 @@
 				C65DE1A8EACAAA012BE9F840 /* MonitorDisplay.swift */,
 				B78950879170C5D3A3B9B134 /* MonitorActor.swift */,
 				35D7D050D0AB3D3E4F07879D /* ScannerLobby.swift */,
+				A8A0B888B31311AE2BB5EB70 /* CameraControlling.swift */,
 			);
 			path = RemoteCam;
 			sourceTree = "<group>";
@@ -1159,6 +1162,7 @@
 				2F485D44C59F540DB49140DD /* MonitorDisplay.swift in Sources */,
 				7BCEB5791B211861A0F6BE60 /* MonitorActor.swift in Sources */,
 				4259A755DF0013E098FD3CCC /* ScannerLobby.swift in Sources */,
+				99F50887F138FD71CF957A08 /* CameraControlling.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Seventh slice of `Docs/UI_MODERNIZATION.md`. Follows #122–#127. Completes the decoupling milestone the last three PRs were building toward.

## What

- **Generalizes the existing watch seam instead of inventing a new one.** The watch-hardening work had already defined `WatchCameraControlling` (protocol + `CameraViewController` conformance + test fake) for the watch path. It's now `CameraControlling`, in its own file, extended with the nine members the phone camera states need (`cameraViewModel`, video/photo-quality and aspect setters, `gatherCurrentCameraCapabilities`, countdown chime + torch restore, `exitCamera`).
- **`UICmd.BecomeCamera` carries the protocol** instead of the concrete `CameraViewController`; the camera/video state signatures follow suit.
- **The session's last direct UIKit touch** (`m.ctrl.navigationController?.popViewController`) became `exitCamera()` on the protocol.
- **Camera-side `OnPicture` routes through the `photoLibrarySaver` seam** — the watch path always did; the phone path was bypassing it straight into PHPhotoLibrary.

## The milestone

**No actor code references a UIKit type anymore.** MonitorActor (#125), RemoteCamSession (#127), and now the camera states all talk to protocols.

## The payoff test

`testTakePictureHappyPathAcrossTheWire`: with a fake camera behind the seam, the FlatBuffers loopback harness now runs the **complete two-device photo capture** — camera role assumed, monitor role assumed, `TakePic` across the wire, capture, `TakePicAck`, `TakePicResp` carrying the actual photo bytes, both state machines back to steady state. Until now, that flow had only ever been verified with two phones on a desk.

## Testing

- `xcodebuild test` on iPhone 16 sim: **372/372 pass** (371 existing + the happy-path capture test)

Next: PR 8 extracts the ~1,100-line `CaptureEngine` behind this protocol (threading fix + iOS 16/17 deprecation migration), then PR 9 repaints the camera shell in SwiftUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)