### PR TITLE
Extract RecordingPipeline from CameraViewController (UI modernization PR 9)

### DIFF
--- a/Docs/UI_MODERNIZATION.md
+++ b/Docs/UI_MODERNIZATION.md
@@ -140,7 +140,7 @@ the loopback harness run the full two-device photo capture (become camera →
 become monitor → TakePic → OnPicture → Ack + Resp with bytes → both sides back
 to steady state) in CI for the first time.
 
-### PR 8: Extract CaptureEngine (configuration + stills) — **this PR**
+### PR 8: Extract CaptureEngine (configuration + stills)
 Mechanical extraction, no behavior/threading changes: `CaptureEngine` (non-UI,
 `NSObject`, the photo-capture delegate) now owns the capture session, device/lens/zoom
 discovery, capabilities, flash/torch intent, quality/format/aspect config, and still
@@ -152,9 +152,24 @@ Still queued for follow-ups: single owned serial queue (threading fix),
 `RotationCoordinator` (iOS 17) and `maxPhotoDimensions` (iOS 16) migrations,
 recording pipeline extraction.
 
-### PR 9+: Camera SwiftUI chrome
-With the engine out, the VC is ~400 lines of real UI: SwiftUI chrome around a
-`UIViewRepresentable` preview layer. `WatchRemoteCameraController` follows.
+### PR 9: Extract RecordingPipeline (video recording) — **this PR**
+Same playbook as PR 8 — mechanical move, no behavior/threading changes:
+`RecordingPipeline` (non-UI) owns the asset writer and its inputs, the
+recording state machine, the writing queue, per-frame write/crop, and
+saving/sending the finished movie. The VC stays the sample-buffer delegate
+(the frame streamers are live preview, not recording) and keeps the
+microphone-permission flow, forwarding recording frames to
+`pipeline.processFrame`. Pipeline↔UI seams: `sendMessage` (actor relay for
+the start ack, stop response and video resource), `onRecordingStarted`/
+`onRecordingStopped` (timer overlay), `onModeChanged` (idle vs recording
+chrome), `onError`, `onPhotosAccessDenied`. Still queued for follow-ups:
+single owned serial queue (threading fix), `RotationCoordinator` (iOS 17)
+and `maxPhotoDimensions` (iOS 16) migrations, frame-streaming extraction.
+
+### PR 10+: Camera SwiftUI chrome
+With capture and recording out, the VC is real UI plus the frame streamers:
+SwiftUI chrome around a `UIViewRepresentable` preview layer.
+`WatchRemoteCameraController` follows.
 
 ## Worklog (blog raw material)
 
@@ -283,3 +298,23 @@ With the engine out, the VC is ~400 lines of real UI: SwiftUI chrome around a
   why nobody noticed. Fix: one forwarding case in `cameraShootingVideo`.
   The loopback harness caught in an afternoon what shipped unnoticed for years —
   because nobody ever watched both phones' timers at once.
+
+### PR 9 — RecordingPipeline extraction
+- The smaller sibling of PR 8: 962 → 632 VC lines; `RecordingPipeline` is 407
+  lines with no UIKit at all. The six-boolean recording state machine moved
+  intact — extraction first, redesign later (still queued behind the
+  single-queue threading fix).
+- The delegate split was the only real design decision: the VC stays the
+  sample-buffer delegate because `captureOutput` fans out to *two* consumers —
+  frame streaming (live preview, stays) and recording (moves). The pipeline
+  gets frames forwarded, mirroring how the audio delegate is passed into
+  `startRecording` the same way PR 8 passed it into `setupCamera`.
+- One seam replaced three actor touchpoints: `sendMessage` relays the start
+  ack, stop response and video resource without the pipeline knowing the actor
+  system — which also made the no-op guards assertable in tests (inject a
+  recorder, assert nothing was sent).
+- New device-free coverage: asset-writer input setup including the 4:3
+  even-rounded crop rect (1920×1080 → 1440×1080 at x=240) — the "must be even
+  for the codec" rounding had never been asserted anywhere.
+- 385/385 green (381 + 4 pipeline tests); the loopback video round-trips —
+  including the 3-step stop protocol — passed unchanged across the move.

--- a/RemoteCam/CameraViewController.swift
+++ b/RemoteCam/CameraViewController.swift
@@ -262,7 +262,6 @@ public class CameraViewController: UIViewController {
                 overlayController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
             ])
         }
-        print("📱 DEBUG: CameraViewController - Setup progress overlay")
     }
 
     

--- a/RemoteCam/CameraViewController.swift
+++ b/RemoteCam/CameraViewController.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 import AVFoundation
-import Photos
 import StoreKit
 import SwiftUI
 import Combine
@@ -30,16 +29,14 @@ public class CameraViewController: UIViewController {
     }
 
     /// Owns the capture session, still-photo capture and all camera configuration.
-    /// This VC keeps the preview layer, the recording/sample-buffer pipeline, and
-    /// the UI/lifecycle glue.
+    /// This VC keeps the preview layer, the frame streamers, and the UI/lifecycle glue.
     let engine = CaptureEngine()
 
-    var isRecording: Bool = false
-    var recordingWillBeStarted: Bool = false
-    var recordingWillBeStopped: Bool = false
-    var readyToRecordVideo: Bool = false
-    var readyToRecordAudio: Bool = false
-    var assetWriter: AVAssetWriter?
+    /// Owns the asset writer, recording state machine and per-frame writing.
+    /// The VC stays the sample-buffer delegate and forwards recording frames.
+    lazy var pipeline = RecordingPipeline(engine: engine)
+
+    var isRecording: Bool { pipeline.isRecording }
 
     var captureVideoPreviewLayer: AVCaptureVideoPreviewLayer?
     /// Orientation used for the preview layer and the frame streamer. The engine
@@ -52,10 +49,8 @@ public class CameraViewController: UIViewController {
     /// Suppresses MultipeerConnectivity-related actor messages (BecomeCamera/UnbecomeCamera).
     var isWatchRemoteMode = false
 
-    // MARK: - Aspect Ratio
-    let videoCropContext = CIContext(options: [.useSoftwareRenderer: false])
     /// Dedicated context for the tiny Apple Watch preview, kept off the recording
-    /// crop context to avoid cross-queue contention.
+    /// pipeline's crop context to avoid cross-queue contention.
     private let watchPreviewContext = CIContext(options: [.useSoftwareRenderer: false])
     /// Streams preview frames to the Apple Watch with ack back-pressure and lazy encoding.
     /// Runs on `videoDataOutputQueue`, where the capture callback hands it sample buffers.
@@ -80,14 +75,6 @@ public class CameraViewController: UIViewController {
                              quality: config.watchJPEGQuality)
         ]
     }()
-    var pixelBufferAdaptor: AVAssetWriterInputPixelBufferAdaptor?
-    var cachedVideoCropRect: CGRect? // Computed once at recording start, reused per frame
-    
-    private let writingQueue = DispatchQueue(label: "asset recorder writing queue", attributes: [], target: nil)
-
-    private var videoInput: AVAssetWriterInput!
-    private var audioInput: AVAssetWriterInput!
-
     // MARK: - Recording Timer Properties
     private var recordingStartTime: Date?
     private var recordingTimerController: CameraRecordingTimerViewController?
@@ -153,6 +140,32 @@ public class CameraViewController: UIViewController {
         }
         engine.onStatusChanged = { [weak self] in
             self?.updateCameraStatus()
+        }
+        // Captures the session ref (not self) so recording acks/responses still
+        // reach the actor if the VC deallocates mid-recording.
+        pipeline.sendMessage = { [session] msg in
+            session ! msg
+        }
+        pipeline.onRecordingStarted = { [weak self] startTime in
+            self?.recordingStartTime = startTime
+            self?.updateRecordingTimerDisplay()
+        }
+        pipeline.onRecordingStopped = { [weak self] in
+            self?.recordingStartTime = nil
+            self?.updateRecordingTimerDisplay()
+        }
+        pipeline.onModeChanged = { [weak self] idle in
+            if idle {
+                self?.configureIdleMode()
+            } else {
+                self?.configureVideoModeRecording()
+            }
+        }
+        pipeline.onError = { message in
+            showError(message)
+        }
+        pipeline.onPhotosAccessDenied = { [weak self] in
+            self?.showPhotosAccessDeniedModal(for: .video)
         }
     }
 
@@ -509,11 +522,13 @@ extension CameraViewController {
         // Check microphone permission before starting video recording
         PermissionManager.shared.requestMicrophonePermission { [weak self] granted in
             DispatchQueue.main.async {
+                guard let self = self else { return }
                 if granted {
-                    self?.setupAudioAndStartRecording()
+                    // The VC stays the audio sample-buffer delegate (captureOutput below).
+                    self.pipeline.startRecording(audioSampleBufferDelegate: self)
                 } else {
                     // Microphone denied - show prompt and send error to remote
-                    self?.handleMicrophoneDenied()
+                    self.handleMicrophoneDenied()
                 }
             }
         }
@@ -562,117 +577,8 @@ extension CameraViewController {
         }
     }
     
-    private func setupAudioAndStartRecording() {
-        writingQueue.async { [weak self] in
-            guard let self = self else { return }
-            if self.recordingWillBeStarted || self.isRecording {
-                return
-            }
-            
-            // Setup audio input for video recording
-            do {
-                let audioDevice = AVCaptureDevice.default(for: .audio)
-                let audioDeviceInput = try AVCaptureDeviceInput(device: audioDevice!)
-                
-                self.engine.captureSession.beginConfiguration()
-
-                if self.engine.captureSession.canAddInput(audioDeviceInput) {
-                    self.engine.captureSession.addInput(audioDeviceInput)
-                } else {
-                    print("Could not add audio device input to the session")
-                }
-
-                if self.engine.captureSession.canAddOutput(self.engine.audioDataOutput) {
-                    self.engine.captureSession.addOutput(self.engine.audioDataOutput)
-                    self.engine.audioDataOutput.setSampleBufferDelegate(self, queue: self.engine.audioDataOutputQueue)
-                }
-
-                self.engine.captureSession.commitConfiguration()
-
-                // Restore the user's torch preference — iOS resets the torch on commitConfiguration.
-                self.engine.applyDesiredTorch()
-
-                // Update audio connection
-                self.engine.audioConnection = self.engine.audioDataOutput.connection(with: .audio)
-                
-                self.startVideoRecordingProcess()
-                
-            } catch {
-                print("Error setting up audio for video recording: \(error)")
-                // Start recording without audio
-                self.startVideoRecordingWithoutAudio()
-            }
-        }
-    }
-    
-    private func startVideoRecordingWithoutAudio() {
-        writingQueue.async { [weak self] in
-            self?.startVideoRecordingProcess()
-        }
-    }
-    
-    private func startVideoRecordingProcess() {
-        if self.recordingWillBeStarted || self.isRecording {
-            return
-        }
-
-        self.recordingWillBeStarted = true
-
-        // Remove the file if one with the same name already exists
-        let outputFilePath = movieUrl()
-        cleanupFileAt(outputFilePath)
-        // Create an asset writer
-        do {
-            self.assetWriter = try AVAssetWriter(outputURL: outputFilePath, fileType: .mov)
-        } catch {
-            showError(NSLocalizedString("Unable to start recording", comment: ""))
-        }
-        OperationQueue.main.addOperation {[weak self] in
-            if let recordingWillBeStarted = self?.recordingWillBeStarted,
-               let isRecording = self?.isRecording {
-                if !recordingWillBeStarted && !isRecording {
-                    self?.configureIdleMode()
-                } else {
-                    self?.configureVideoModeRecording()
-                }
-            }
-        }
-    }
-
-    func stopRecordingVideo(_ shouldSendVideo:Bool) {
-        writingQueue.async {[weak self] in
-            guard let self = self else { return }
-            if self.recordingWillBeStopped || !self.isRecording {
-                return
-            }
-            self.isRecording = false
-            self.recordingWillBeStopped = true
-            
-            // Stop recording timer
-            DispatchQueue.main.async { [weak self] in
-                self?.recordingStartTime = nil
-                self?.updateRecordingTimerDisplay()
-            }
-            self.assetWriter?.finishWriting {[weak self] in
-                self?.assetWriter = nil
-                self?.pixelBufferAdaptor = nil
-                self?.cachedVideoCropRect = nil
-                self?.readyToRecordVideo = false
-                self?.readyToRecordAudio = false
-                self?.recordingWillBeStopped = false
-                self?.saveMovieToPhotosAppAndRemotePeer(shouldSendVideo)
-            }
-            OperationQueue.main.addOperation {[weak self] in
-                if let recordingWillBeStopped = self?.recordingWillBeStopped,
-                   let isRecording = self?.isRecording {
-                    if recordingWillBeStopped && !isRecording {
-                        self?.configureIdleMode()
-                    } else {
-                        self?.configureVideoModeRecording()
-                    }
-                }
-            }
-        }
+    func stopRecordingVideo(_ shouldSendVideo: Bool) {
+        pipeline.stopRecording(shouldSendVideo)
     }
 }
 
@@ -683,8 +589,8 @@ extension CameraViewController: AVCaptureVideoDataOutputSampleBufferDelegate, AV
         if connection == engine.videoConnection {
             sendFrameToMonitor(captureOutput, didOutput: sampleBuffer, from: connection)
         }
-        if (recordingWillBeStarted || isRecording) && !recordingWillBeStopped {
-            self.processFrame(captureOutput, didOutput: sampleBuffer, from: connection)
+        if (pipeline.recordingWillBeStarted || pipeline.isRecording) && !pipeline.recordingWillBeStopped {
+            pipeline.processFrame(captureOutput, didOutput: sampleBuffer, from: connection)
         }
     }
 
@@ -723,240 +629,4 @@ extension CameraViewController: AVCaptureVideoDataOutputSampleBufferDelegate, AV
         watchPreviewStreamer.acknowledge()
     }
 
-    func saveMovieToPhotosAppAndRemotePeer(_ sendVideoToPeer:Bool) {
-        let outputFileURL = movieUrl()
-        
-                 // Send video to the monitor using resource transfer if requested
-         if sendVideoToPeer {
-             sendVideoAsResource(outputFileURL)
-         } else {
-             // Send empty response when not sending video
-             session ! RemoteCmd.StopRecordingVideoResp(sender: nil, pic: nil, error: nil)
-         }
-         
-         // Check the authorization status.
-         PHPhotoLibrary.requestAuthorization { status in
-             if status == .authorized {
-                 // Save the movie file to the photo library and cleanup.
-                 PHPhotoLibrary.shared().performChanges({
-                     let options = PHAssetResourceCreationOptions()
-                     options.shouldMoveFile = true
-                     let creationRequest = PHAssetCreationRequest.forAsset()
-                     creationRequest.addResource(with: .video, fileURL: outputFileURL, options: options)
-                 }, completionHandler: { success, error in
-                     if !success {
-                         print("AVCam couldn't save the movie to your photo library: \(String(describing: error))")
-                     }
-                     cleanupFileAt(outputFileURL)
-                 }
-                 )
-             } else {
-                 DispatchQueue.main.async {[weak self] in
-                     self?.showPhotosAccessDeniedModal(for: .video)
-                 }
-                 cleanupFileAt(outputFileURL)
-                        }
-       }
-   }
-   
-       // MARK: - Video Resource Transfer
-    private func sendVideoAsResource(_ videoURL: URL) {
-        // Get connected peers through the session
-        // Note: We can't access session.connectedPeers directly since session is ActorRef
-        // Instead, we'll send a message to let the actor handle peer checking
-        
-        // Send message to RemoteCamSession actor to handle video resource transfer
-        let sendVideoMsg = UICmd.SendVideoResource(
-            videoURL: videoURL,
-            peers: [], // Will be populated by the actor from its session
-            shouldSendToPeer: true,
-            sender: nil
-        )
-        
-        session ! sendVideoMsg
-        print("📤 DEBUG: Sent SendVideoResource message to actor system")
-    }
-    
-   func setupAssetWriterVideoInput(_ formatDescription: CMVideoFormatDescription,
-                                    assetWriter: AVAssetWriter) -> Bool {
-        var videoSettings = self.engine.videoDataOutput.recommendedVideoSettingsForAssetWriter(writingTo: .mov)
-        videoSettings?[AVVideoCodecKey] = AVVideoCodecType.hevc
-
-        let dims = CMVideoFormatDescriptionGetDimensions(formatDescription)
-        let sourceWidth = CGFloat(dims.width)
-        let sourceHeight = CGFloat(dims.height)
-
-        // Compute and cache the crop rect once — reused for every frame
-        let needsCrop = engine.currentAspectRatio != .sixteenNine
-        if needsCrop, let rawRect = CaptureEngine.cropRect(sourceWidth: sourceWidth, sourceHeight: sourceHeight, aspectRatio: engine.currentAspectRatio) {
-            // Round to even for codec compatibility
-            let evenRect = CGRect(
-                x: floor(rawRect.origin.x / 2) * 2,
-                y: floor(rawRect.origin.y / 2) * 2,
-                width: floor(rawRect.width / 2) * 2,
-                height: floor(rawRect.height / 2) * 2
-            )
-            cachedVideoCropRect = evenRect
-
-            if var settings = videoSettings {
-                settings[AVVideoWidthKey] = Int(evenRect.width)
-                settings[AVVideoHeightKey] = Int(evenRect.height)
-                videoSettings = settings
-            }
-        } else {
-            cachedVideoCropRect = nil
-        }
-
-        if assetWriter.canApply(outputSettings: videoSettings, forMediaType: .video) {
-            videoInput = AVAssetWriterInput(
-                mediaType: .video,
-                outputSettings: videoSettings)
-            videoInput.expectsMediaDataInRealTime = true
-
-            if cachedVideoCropRect != nil {
-                // Pool attributes match output dimensions — avoids per-frame CVPixelBufferCreate
-                let poolAttrs: [String: Any] = [
-                    kCVPixelBufferWidthKey as String: Int(cachedVideoCropRect!.width),
-                    kCVPixelBufferHeightKey as String: Int(cachedVideoCropRect!.height),
-                    kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA)
-                ]
-                pixelBufferAdaptor = AVAssetWriterInputPixelBufferAdaptor(
-                    assetWriterInput: videoInput,
-                    sourcePixelBufferAttributes: poolAttrs)
-            } else {
-                pixelBufferAdaptor = nil
-            }
-
-            if assetWriter.canAdd(videoInput) {
-                assetWriter.add(videoInput)
-            } else {
-                return false
-            }
-        } else {
-            return false
-        }
-        return true
-    }
-
-    func setupAssetWriterAudioInput(_ formatDescription: CMFormatDescription,
-                                    assetWriter: AVAssetWriter) -> Bool {
-        let audioSettings = [AVFormatIDKey: kAudioFormatMPEG4AAC]
-        if assetWriter.canApply(outputSettings: audioSettings, forMediaType: .audio) {
-            audioInput = AVAssetWriterInput(mediaType: .audio, outputSettings: audioSettings, sourceFormatHint: formatDescription)
-            audioInput.expectsMediaDataInRealTime = true
-
-            if assetWriter.canAdd(audioInput) {
-                assetWriter.add(audioInput)
-            } else {
-                print("Cannot add audio input to asset writer")
-                return false
-            }
-        } else {
-            print("Cannot apply audio settings to asset writer")
-            return false
-        }
-        return true
-    }
-
-    public func processFrame(_ captureOutput: AVCaptureOutput,
-                              didOutput sampleBuffer: CMSampleBuffer,
-                              from connection: AVCaptureConnection) {
-
-        if let assetWriter = self.assetWriter {
-            let wasReadyToRecord = (readyToRecordAudio && readyToRecordVideo)
-            if connection == self.engine.videoConnection {
-                if let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer), !readyToRecordVideo {
-                    readyToRecordVideo = self.setupAssetWriterVideoInput(formatDescription, assetWriter: assetWriter)
-                }
-
-                if readyToRecordVideo && readyToRecordAudio {
-                    self.writeSampleBuffer(sampleBuffer: sampleBuffer, ofType: .video)
-                }
-            } else if connection == self.engine.audioConnection {
-                if let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer), !readyToRecordAudio {
-                    readyToRecordAudio = self.setupAssetWriterAudioInput(formatDescription,
-                                                                         assetWriter: assetWriter)
-                }
-
-                if readyToRecordAudio && readyToRecordVideo {
-                    self.writeSampleBuffer(sampleBuffer: sampleBuffer, ofType: .audio)
-                }
-            }
-            let isReadyToRecord = readyToRecordAudio && readyToRecordVideo
-            if !wasReadyToRecord && isReadyToRecord {
-                recordingWillBeStarted = false
-                self.isRecording = true
-                
-                // Start recording timer and notify monitor
-                DispatchQueue.main.async { [weak self] in
-                    let startTime = Date()
-                    self?.recordingStartTime = startTime
-                    self?.updateRecordingTimerDisplay()
-                    
-                    // Send recording start time to monitor for synchronization
-                    if let session = self?.session {
-                        session ! RemoteCmd.StartRecordingVideoAck(sender: nil, recordingStartTime: startTime)
-                    }
-                    
-                }
-            }
-        }
-    }
-
-    func writeSampleBuffer(sampleBuffer: CMSampleBuffer,
-                           ofType mediaType: AVMediaType) {
-        if !isRecording {
-            return
-        }
-        writingQueue.async { [weak self] in
-            guard let self = self else { return }
-            guard let assetWriter = self.assetWriter else {
-                return
-            }
-            if assetWriter.status == .unknown {
-                if assetWriter.startWriting() {
-                    assetWriter.startSession(atSourceTime: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
-                } else {
-                    // TODO: Show error
-                }
-            }
-
-            if mediaType == .video, let adaptor = self.pixelBufferAdaptor,
-               self.engine.currentAspectRatio != .sixteenNine {
-                // Crop video frame for non-16:9 aspect ratios
-                if self.videoInput.isReadyForMoreMediaData,
-                   let croppedBuffer = self.cropSampleBuffer(sampleBuffer) {
-                    let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
-                    adaptor.append(croppedBuffer, withPresentationTime: pts)
-                }
-            } else if let input = (mediaType == .video) ? self.videoInput : self.audioInput {
-                if input.isReadyForMoreMediaData {
-                    input.append(sampleBuffer)
-                }
-            }
-        }
-    }
-
-    /// Crops a video frame using the cached crop rect and the adaptor's pixel buffer pool.
-    /// Called on every video frame during recording — must be fast.
-    private func cropSampleBuffer(_ sampleBuffer: CMSampleBuffer) -> CVPixelBuffer? {
-        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return nil }
-
-        // No crop needed — pass through the original buffer
-        guard let cropRect = cachedVideoCropRect,
-              let pool = pixelBufferAdaptor?.pixelBufferPool else {
-            return pixelBuffer
-        }
-
-        // Get a buffer from the pool (reuses memory, no per-frame allocation)
-        var outputBuffer: CVPixelBuffer?
-        let status = CVPixelBufferPoolCreatePixelBuffer(nil, pool, &outputBuffer)
-        guard status == kCVReturnSuccess, let output = outputBuffer else { return nil }
-
-        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
-            .cropped(to: cropRect)
-            .transformed(by: CGAffineTransform(translationX: -cropRect.origin.x, y: -cropRect.origin.y))
-        videoCropContext.render(ciImage, to: output)
-        return output
-    }
 }

--- a/RemoteCam/RecordingPipeline.swift
+++ b/RemoteCam/RecordingPipeline.swift
@@ -1,0 +1,407 @@
+//
+//  RecordingPipeline.swift
+//  RemoteShutter
+//
+//  Copyright © 2026 Security Union LLC. All rights reserved.
+//
+
+import Foundation
+import AVFoundation
+import Photos
+import CoreImage
+
+/**
+ Owns the video-recording path: the asset writer, its inputs, the recording
+ state machine, per-frame writing/cropping, and saving/sending the finished
+ movie. Non-UI — the view controller keeps the sample-buffer delegate role,
+ the microphone-permission flow, and all overlays, and reaches back in through
+ the closure seams below. Collaborates with `CaptureEngine`, which owns the
+ capture session and its outputs/queues.
+ */
+class RecordingPipeline {
+
+    /// The capture session, outputs, queues and aspect-ratio config live on the engine.
+    private let engine: CaptureEngine
+
+    // MARK: - UI/actor seams
+
+    /// Relays actor messages (`StartRecordingVideoAck`, `StopRecordingVideoResp`,
+    /// `SendVideoResource`) — the pipeline never touches the actor system directly.
+    var sendMessage: ((Actor.Message) -> Void)?
+    /// Recording actually began (first frames written). Main thread. The ack to the
+    /// monitor is sent through `sendMessage` right after this fires.
+    var onRecordingStarted: ((Date) -> Void)?
+    /// Recording is stopping — clear the timer display. Main thread.
+    var onRecordingStopped: (() -> Void)?
+    /// Chrome update: `idle == true` → idle mode, else video-recording mode. Main thread.
+    var onModeChanged: ((_ idle: Bool) -> Void)?
+    /// Unrecoverable start failure ("Unable to start recording").
+    var onError: ((String) -> Void)?
+    /// Photos-library access denied while saving the finished movie. Main thread.
+    var onPhotosAccessDenied: (() -> Void)?
+
+    // MARK: - Recording state
+    // Mutated on writingQueue and the capture queues, read from main — same
+    // (unsynchronized) behavior as before the extraction; the single-owned-queue
+    // fix is a queued follow-up.
+
+    private(set) var isRecording: Bool = false
+    private(set) var recordingWillBeStarted: Bool = false
+    private(set) var recordingWillBeStopped: Bool = false
+    private var readyToRecordVideo: Bool = false
+    private var readyToRecordAudio: Bool = false
+
+    var assetWriter: AVAssetWriter?
+    var pixelBufferAdaptor: AVAssetWriterInputPixelBufferAdaptor?
+    var cachedVideoCropRect: CGRect? // Computed once at recording start, reused per frame
+
+    let videoCropContext = CIContext(options: [.useSoftwareRenderer: false])
+
+    private let writingQueue = DispatchQueue(label: "asset recorder writing queue", attributes: [], target: nil)
+
+    private var videoInput: AVAssetWriterInput!
+    private var audioInput: AVAssetWriterInput!
+
+    init(engine: CaptureEngine) {
+        self.engine = engine
+    }
+
+    // MARK: - Start / stop
+
+    /// Adds the audio input/output to the capture session and starts recording.
+    /// The caller (the VC) remains the audio sample-buffer delegate.
+    func startRecording(audioSampleBufferDelegate: AVCaptureAudioDataOutputSampleBufferDelegate) {
+        writingQueue.async { [weak self] in
+            guard let self = self else { return }
+            if self.recordingWillBeStarted || self.isRecording {
+                return
+            }
+
+            // Setup audio input for video recording
+            do {
+                let audioDevice = AVCaptureDevice.default(for: .audio)
+                let audioDeviceInput = try AVCaptureDeviceInput(device: audioDevice!)
+
+                self.engine.captureSession.beginConfiguration()
+
+                if self.engine.captureSession.canAddInput(audioDeviceInput) {
+                    self.engine.captureSession.addInput(audioDeviceInput)
+                } else {
+                    print("Could not add audio device input to the session")
+                }
+
+                if self.engine.captureSession.canAddOutput(self.engine.audioDataOutput) {
+                    self.engine.captureSession.addOutput(self.engine.audioDataOutput)
+                    self.engine.audioDataOutput.setSampleBufferDelegate(audioSampleBufferDelegate, queue: self.engine.audioDataOutputQueue)
+                }
+
+                self.engine.captureSession.commitConfiguration()
+
+                // Restore the user's torch preference — iOS resets the torch on commitConfiguration.
+                self.engine.applyDesiredTorch()
+
+                // Update audio connection
+                self.engine.audioConnection = self.engine.audioDataOutput.connection(with: .audio)
+
+                self.startVideoRecordingProcess()
+
+            } catch {
+                print("Error setting up audio for video recording: \(error)")
+                // Start recording without audio
+                self.startVideoRecordingWithoutAudio()
+            }
+        }
+    }
+
+    private func startVideoRecordingWithoutAudio() {
+        writingQueue.async { [weak self] in
+            self?.startVideoRecordingProcess()
+        }
+    }
+
+    private func startVideoRecordingProcess() {
+        if self.recordingWillBeStarted || self.isRecording {
+            return
+        }
+
+        self.recordingWillBeStarted = true
+
+        // Remove the file if one with the same name already exists
+        let outputFilePath = movieUrl()
+        cleanupFileAt(outputFilePath)
+        // Create an asset writer
+        do {
+            self.assetWriter = try AVAssetWriter(outputURL: outputFilePath, fileType: .mov)
+        } catch {
+            onError?(NSLocalizedString("Unable to start recording", comment: ""))
+        }
+        OperationQueue.main.addOperation { [weak self] in
+            guard let self = self else { return }
+            self.onModeChanged?(!self.recordingWillBeStarted && !self.isRecording)
+        }
+    }
+
+    func stopRecording(_ shouldSendVideo: Bool) {
+        writingQueue.async { [weak self] in
+            guard let self = self else { return }
+            if self.recordingWillBeStopped || !self.isRecording {
+                return
+            }
+            self.isRecording = false
+            self.recordingWillBeStopped = true
+
+            // Stop recording timer
+            DispatchQueue.main.async { [weak self] in
+                self?.onRecordingStopped?()
+            }
+            self.assetWriter?.finishWriting { [weak self] in
+                self?.assetWriter = nil
+                self?.pixelBufferAdaptor = nil
+                self?.cachedVideoCropRect = nil
+                self?.readyToRecordVideo = false
+                self?.readyToRecordAudio = false
+                self?.recordingWillBeStopped = false
+                self?.saveMovieToPhotosAppAndRemotePeer(shouldSendVideo)
+            }
+            OperationQueue.main.addOperation { [weak self] in
+                guard let self = self else { return }
+                self.onModeChanged?(self.recordingWillBeStopped && !self.isRecording)
+            }
+        }
+    }
+
+    // MARK: - Saving / sending the finished movie
+
+    private func saveMovieToPhotosAppAndRemotePeer(_ sendVideoToPeer: Bool) {
+        let outputFileURL = movieUrl()
+
+        // Send video to the monitor using resource transfer if requested
+        if sendVideoToPeer {
+            sendVideoAsResource(outputFileURL)
+        } else {
+            // Send empty response when not sending video
+            sendMessage?(RemoteCmd.StopRecordingVideoResp(sender: nil, pic: nil, error: nil))
+        }
+
+        // Check the authorization status.
+        PHPhotoLibrary.requestAuthorization { [weak self] status in
+            if status == .authorized {
+                // Save the movie file to the photo library and cleanup.
+                PHPhotoLibrary.shared().performChanges({
+                    let options = PHAssetResourceCreationOptions()
+                    options.shouldMoveFile = true
+                    let creationRequest = PHAssetCreationRequest.forAsset()
+                    creationRequest.addResource(with: .video, fileURL: outputFileURL, options: options)
+                }, completionHandler: { success, error in
+                    if !success {
+                        print("AVCam couldn't save the movie to your photo library: \(String(describing: error))")
+                    }
+                    cleanupFileAt(outputFileURL)
+                }
+                )
+            } else {
+                DispatchQueue.main.async {
+                    self?.onPhotosAccessDenied?()
+                }
+                cleanupFileAt(outputFileURL)
+            }
+        }
+    }
+
+    private func sendVideoAsResource(_ videoURL: URL) {
+        // Send message to RemoteCamSession actor to handle video resource transfer
+        let sendVideoMsg = UICmd.SendVideoResource(
+            videoURL: videoURL,
+            peers: [], // Will be populated by the actor from its session
+            shouldSendToPeer: true,
+            sender: nil
+        )
+
+        sendMessage?(sendVideoMsg)
+        print("📤 DEBUG: Sent SendVideoResource message to actor system")
+    }
+
+    // MARK: - Asset writer inputs
+
+    func setupAssetWriterVideoInput(_ formatDescription: CMVideoFormatDescription,
+                                    assetWriter: AVAssetWriter) -> Bool {
+        var videoSettings = self.engine.videoDataOutput.recommendedVideoSettingsForAssetWriter(writingTo: .mov)
+        videoSettings?[AVVideoCodecKey] = AVVideoCodecType.hevc
+
+        let dims = CMVideoFormatDescriptionGetDimensions(formatDescription)
+        let sourceWidth = CGFloat(dims.width)
+        let sourceHeight = CGFloat(dims.height)
+
+        // Compute and cache the crop rect once — reused for every frame
+        let needsCrop = engine.currentAspectRatio != .sixteenNine
+        if needsCrop, let rawRect = CaptureEngine.cropRect(sourceWidth: sourceWidth, sourceHeight: sourceHeight, aspectRatio: engine.currentAspectRatio) {
+            // Round to even for codec compatibility
+            let evenRect = CGRect(
+                x: floor(rawRect.origin.x / 2) * 2,
+                y: floor(rawRect.origin.y / 2) * 2,
+                width: floor(rawRect.width / 2) * 2,
+                height: floor(rawRect.height / 2) * 2
+            )
+            cachedVideoCropRect = evenRect
+
+            if var settings = videoSettings {
+                settings[AVVideoWidthKey] = Int(evenRect.width)
+                settings[AVVideoHeightKey] = Int(evenRect.height)
+                videoSettings = settings
+            }
+        } else {
+            cachedVideoCropRect = nil
+        }
+
+        if assetWriter.canApply(outputSettings: videoSettings, forMediaType: .video) {
+            videoInput = AVAssetWriterInput(
+                mediaType: .video,
+                outputSettings: videoSettings)
+            videoInput.expectsMediaDataInRealTime = true
+
+            if cachedVideoCropRect != nil {
+                // Pool attributes match output dimensions — avoids per-frame CVPixelBufferCreate
+                let poolAttrs: [String: Any] = [
+                    kCVPixelBufferWidthKey as String: Int(cachedVideoCropRect!.width),
+                    kCVPixelBufferHeightKey as String: Int(cachedVideoCropRect!.height),
+                    kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA)
+                ]
+                pixelBufferAdaptor = AVAssetWriterInputPixelBufferAdaptor(
+                    assetWriterInput: videoInput,
+                    sourcePixelBufferAttributes: poolAttrs)
+            } else {
+                pixelBufferAdaptor = nil
+            }
+
+            if assetWriter.canAdd(videoInput) {
+                assetWriter.add(videoInput)
+            } else {
+                return false
+            }
+        } else {
+            return false
+        }
+        return true
+    }
+
+    func setupAssetWriterAudioInput(_ formatDescription: CMFormatDescription,
+                                    assetWriter: AVAssetWriter) -> Bool {
+        let audioSettings = [AVFormatIDKey: kAudioFormatMPEG4AAC]
+        if assetWriter.canApply(outputSettings: audioSettings, forMediaType: .audio) {
+            audioInput = AVAssetWriterInput(mediaType: .audio, outputSettings: audioSettings, sourceFormatHint: formatDescription)
+            audioInput.expectsMediaDataInRealTime = true
+
+            if assetWriter.canAdd(audioInput) {
+                assetWriter.add(audioInput)
+            } else {
+                print("Cannot add audio input to asset writer")
+                return false
+            }
+        } else {
+            print("Cannot apply audio settings to asset writer")
+            return false
+        }
+        return true
+    }
+
+    // MARK: - Per-frame path
+
+    func processFrame(_ captureOutput: AVCaptureOutput,
+                      didOutput sampleBuffer: CMSampleBuffer,
+                      from connection: AVCaptureConnection) {
+
+        if let assetWriter = self.assetWriter {
+            let wasReadyToRecord = (readyToRecordAudio && readyToRecordVideo)
+            if connection == self.engine.videoConnection {
+                if let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer), !readyToRecordVideo {
+                    readyToRecordVideo = self.setupAssetWriterVideoInput(formatDescription, assetWriter: assetWriter)
+                }
+
+                if readyToRecordVideo && readyToRecordAudio {
+                    self.writeSampleBuffer(sampleBuffer: sampleBuffer, ofType: .video)
+                }
+            } else if connection == self.engine.audioConnection {
+                if let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer), !readyToRecordAudio {
+                    readyToRecordAudio = self.setupAssetWriterAudioInput(formatDescription,
+                                                                         assetWriter: assetWriter)
+                }
+
+                if readyToRecordAudio && readyToRecordVideo {
+                    self.writeSampleBuffer(sampleBuffer: sampleBuffer, ofType: .audio)
+                }
+            }
+            let isReadyToRecord = readyToRecordAudio && readyToRecordVideo
+            if !wasReadyToRecord && isReadyToRecord {
+                recordingWillBeStarted = false
+                self.isRecording = true
+
+                // Start recording timer and notify monitor
+                DispatchQueue.main.async { [weak self] in
+                    guard let self = self else { return }
+                    let startTime = Date()
+                    self.onRecordingStarted?(startTime)
+
+                    // Send recording start time to monitor for synchronization
+                    self.sendMessage?(RemoteCmd.StartRecordingVideoAck(sender: nil, recordingStartTime: startTime))
+                }
+            }
+        }
+    }
+
+    func writeSampleBuffer(sampleBuffer: CMSampleBuffer,
+                           ofType mediaType: AVMediaType) {
+        if !isRecording {
+            return
+        }
+        writingQueue.async { [weak self] in
+            guard let self = self else { return }
+            guard let assetWriter = self.assetWriter else {
+                return
+            }
+            if assetWriter.status == .unknown {
+                if assetWriter.startWriting() {
+                    assetWriter.startSession(atSourceTime: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
+                } else {
+                    // TODO: Show error
+                }
+            }
+
+            if mediaType == .video, let adaptor = self.pixelBufferAdaptor,
+               self.engine.currentAspectRatio != .sixteenNine {
+                // Crop video frame for non-16:9 aspect ratios
+                if self.videoInput.isReadyForMoreMediaData,
+                   let croppedBuffer = self.cropSampleBuffer(sampleBuffer) {
+                    let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+                    adaptor.append(croppedBuffer, withPresentationTime: pts)
+                }
+            } else if let input = (mediaType == .video) ? self.videoInput : self.audioInput {
+                if input.isReadyForMoreMediaData {
+                    input.append(sampleBuffer)
+                }
+            }
+        }
+    }
+
+    /// Crops a video frame using the cached crop rect and the adaptor's pixel buffer pool.
+    /// Called on every video frame during recording — must be fast.
+    private func cropSampleBuffer(_ sampleBuffer: CMSampleBuffer) -> CVPixelBuffer? {
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return nil }
+
+        // No crop needed — pass through the original buffer
+        guard let cropRect = cachedVideoCropRect,
+              let pool = pixelBufferAdaptor?.pixelBufferPool else {
+            return pixelBuffer
+        }
+
+        // Get a buffer from the pool (reuses memory, no per-frame allocation)
+        var outputBuffer: CVPixelBuffer?
+        let status = CVPixelBufferPoolCreatePixelBuffer(nil, pool, &outputBuffer)
+        guard status == kCVReturnSuccess, let output = outputBuffer else { return nil }
+
+        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+            .cropped(to: cropRect)
+            .transformed(by: CGAffineTransform(translationX: -cropRect.origin.x, y: -cropRect.origin.y))
+        videoCropContext.render(ciImage, to: output)
+        return output
+    }
+}

--- a/RemoteCam/RecordingPipeline.swift
+++ b/RemoteCam/RecordingPipeline.swift
@@ -35,7 +35,8 @@ class RecordingPipeline {
     var onRecordingStopped: (() -> Void)?
     /// Chrome update: `idle == true` → idle mode, else video-recording mode. Main thread.
     var onModeChanged: ((_ idle: Bool) -> Void)?
-    /// Unrecoverable start failure ("Unable to start recording").
+    /// Unrecoverable start failure ("Unable to start recording"). Fires on the
+    /// writing queue — hop to main before touching UIKit.
     var onError: ((String) -> Void)?
     /// Photos-library access denied while saving the finished movie. Main thread.
     var onPhotosAccessDenied: (() -> Void)?
@@ -51,11 +52,11 @@ class RecordingPipeline {
     private var readyToRecordVideo: Bool = false
     private var readyToRecordAudio: Bool = false
 
-    var assetWriter: AVAssetWriter?
-    var pixelBufferAdaptor: AVAssetWriterInputPixelBufferAdaptor?
-    var cachedVideoCropRect: CGRect? // Computed once at recording start, reused per frame
+    private var assetWriter: AVAssetWriter?
+    private(set) var pixelBufferAdaptor: AVAssetWriterInputPixelBufferAdaptor?
+    private(set) var cachedVideoCropRect: CGRect? // Computed once at recording start, reused per frame
 
-    let videoCropContext = CIContext(options: [.useSoftwareRenderer: false])
+    private let videoCropContext = CIContext(options: [.useSoftwareRenderer: false])
 
     private let writingQueue = DispatchQueue(label: "asset recorder writing queue", attributes: [], target: nil)
 
@@ -79,8 +80,12 @@ class RecordingPipeline {
 
             // Setup audio input for video recording
             do {
-                let audioDevice = AVCaptureDevice.default(for: .audio)
-                let audioDeviceInput = try AVCaptureDeviceInput(device: audioDevice!)
+                // No microphone (simulator, some iPads) — record without audio.
+                guard let audioDevice = AVCaptureDevice.default(for: .audio) else {
+                    self.startVideoRecordingProcess()
+                    return
+                }
+                let audioDeviceInput = try AVCaptureDeviceInput(device: audioDevice)
 
                 self.engine.captureSession.beginConfiguration()
 
@@ -137,7 +142,8 @@ class RecordingPipeline {
         }
         OperationQueue.main.addOperation { [weak self] in
             guard let self = self else { return }
-            self.onModeChanged?(!self.recordingWillBeStarted && !self.isRecording)
+            let idle = !self.recordingWillBeStarted && !self.isRecording
+            self.onModeChanged?(idle)
         }
     }
 
@@ -165,7 +171,8 @@ class RecordingPipeline {
             }
             OperationQueue.main.addOperation { [weak self] in
                 guard let self = self else { return }
-                self.onModeChanged?(self.recordingWillBeStopped && !self.isRecording)
+                let idle = self.recordingWillBeStopped && !self.isRecording
+                self.onModeChanged?(idle)
             }
         }
     }
@@ -218,7 +225,6 @@ class RecordingPipeline {
         )
 
         sendMessage?(sendVideoMsg)
-        print("📤 DEBUG: Sent SendVideoResource message to actor system")
     }
 
     // MARK: - Asset writer inputs
@@ -348,8 +354,8 @@ class RecordingPipeline {
         }
     }
 
-    func writeSampleBuffer(sampleBuffer: CMSampleBuffer,
-                           ofType mediaType: AVMediaType) {
+    private func writeSampleBuffer(sampleBuffer: CMSampleBuffer,
+                                   ofType mediaType: AVMediaType) {
         if !isRecording {
             return
         }
@@ -362,7 +368,7 @@ class RecordingPipeline {
                 if assetWriter.startWriting() {
                     assetWriter.startSession(atSourceTime: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
                 } else {
-                    // TODO: Show error
+                    self.onError?(NSLocalizedString("Unable to start recording", comment: ""))
                 }
             }
 

--- a/RemoteCamTests/LoopbackSessionTests.swift
+++ b/RemoteCamTests/LoopbackSessionTests.swift
@@ -462,7 +462,7 @@ final class LoopbackFakeCamera: FakeWatchCameraController {
     override func startRecordingVideo() {
         super.startRecordingVideo()
         // The real pipeline sends this to the local session once the writer
-        // produces its first frames (CameraViewController.processFrame).
+        // produces its first frames (RecordingPipeline.processFrame).
         if let sessionRef {
             sessionRef ! RemoteCmd.StartRecordingVideoAck(sender: nil, recordingStartTime: Date())
         }

--- a/RemoteCamTests/RecordingPipelineTests.swift
+++ b/RemoteCamTests/RecordingPipelineTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+import AVFoundation
+@testable import RemoteShutter
+
+/// Exercises the device-free surface of `RecordingPipeline`: asset-writer input
+/// setup (including the even-rounded crop rect for non-16:9 aspect ratios) and
+/// the stop-while-idle guard. The live capture path needs a real device and
+/// stays covered by the loopback round-trip tests against the fake camera.
+final class RecordingPipelineTests: XCTestCase {
+
+    private func makeWriter() throws -> AVAssetWriter {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RecordingPipelineTests-\(UUID().uuidString).mov")
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return try AVAssetWriter(outputURL: url, fileType: .mov)
+    }
+
+    private func makeVideoFormatDescription(width: Int32, height: Int32) throws -> CMVideoFormatDescription {
+        var formatDescription: CMVideoFormatDescription?
+        let status = CMVideoFormatDescriptionCreate(
+            allocator: kCFAllocatorDefault,
+            codecType: kCVPixelFormatType_32BGRA,
+            width: width,
+            height: height,
+            extensions: nil,
+            formatDescriptionOut: &formatDescription)
+        XCTAssertEqual(status, noErr)
+        return formatDescription!
+    }
+
+    func testVideoInputFourThreeCachesEvenCropRectAndAdaptor() throws {
+        let engine = CaptureEngine()
+        _ = engine.setAspectRatio(.fourThree)
+        let pipeline = RecordingPipeline(engine: engine)
+        let writer = try makeWriter()
+
+        let didSetup = pipeline.setupAssetWriterVideoInput(
+            try makeVideoFormatDescription(width: 1920, height: 1080),
+            assetWriter: writer)
+
+        XCTAssertTrue(didSetup)
+        let cropRect = try XCTUnwrap(pipeline.cachedVideoCropRect)
+        // 4:3 of 1080p → 1440x1080, centered at x=240; all dimensions even.
+        XCTAssertEqual(cropRect, CGRect(x: 240, y: 0, width: 1440, height: 1080))
+        XCTAssertEqual(Int(cropRect.width) % 2, 0)
+        XCTAssertEqual(Int(cropRect.origin.x) % 2, 0)
+        // Cropping goes through the pixel-buffer adaptor pool.
+        XCTAssertNotNil(pipeline.pixelBufferAdaptor)
+        XCTAssertEqual(writer.inputs.count, 1)
+        XCTAssertEqual(writer.inputs.first?.mediaType, .video)
+    }
+
+    func testVideoInputSixteenNineNeedsNoCropOrAdaptor() throws {
+        let engine = CaptureEngine()
+        let pipeline = RecordingPipeline(engine: engine)
+        let writer = try makeWriter()
+
+        let didSetup = pipeline.setupAssetWriterVideoInput(
+            try makeVideoFormatDescription(width: 1920, height: 1080),
+            assetWriter: writer)
+
+        XCTAssertTrue(didSetup)
+        XCTAssertNil(pipeline.cachedVideoCropRect)
+        XCTAssertNil(pipeline.pixelBufferAdaptor)
+        XCTAssertEqual(writer.inputs.count, 1)
+    }
+
+    func testAudioInputSetup() throws {
+        let engine = CaptureEngine()
+        let pipeline = RecordingPipeline(engine: engine)
+        let writer = try makeWriter()
+
+        var asbd = AudioStreamBasicDescription(
+            mSampleRate: 44100, mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kAudioFormatFlagIsSignedInteger, mBytesPerPacket: 2,
+            mFramesPerPacket: 1, mBytesPerFrame: 2, mChannelsPerFrame: 1,
+            mBitsPerChannel: 16, mReserved: 0)
+        var formatDescription: CMAudioFormatDescription?
+        XCTAssertEqual(CMAudioFormatDescriptionCreate(
+            allocator: kCFAllocatorDefault, asbd: &asbd, layoutSize: 0, layout: nil,
+            magicCookieSize: 0, magicCookie: nil, extensions: nil,
+            formatDescriptionOut: &formatDescription), noErr)
+
+        XCTAssertTrue(pipeline.setupAssetWriterAudioInput(formatDescription!, assetWriter: writer))
+        XCTAssertEqual(writer.inputs.count, 1)
+        XCTAssertEqual(writer.inputs.first?.mediaType, .audio)
+    }
+
+    func testStopWhileIdleSendsNothingAndStaysIdle() {
+        let engine = CaptureEngine()
+        let pipeline = RecordingPipeline(engine: engine)
+        var sentMessages: [Actor.Message] = []
+        pipeline.sendMessage = { sentMessages.append($0) }
+        var stoppedFired = false
+        pipeline.onRecordingStopped = { stoppedFired = true }
+
+        pipeline.stopRecording(true)
+
+        // stopRecording hops to the writing queue — give it time to (not) act.
+        let quiesce = expectation(description: "writing queue drained")
+        quiesce.isInverted = true
+        wait(for: [quiesce], timeout: 0.3)
+
+        XCTAssertFalse(pipeline.isRecording)
+        XCTAssertFalse(pipeline.recordingWillBeStopped)
+        XCTAssertTrue(sentMessages.isEmpty)
+        XCTAssertFalse(stoppedFired)
+    }
+}

--- a/RemoteCamTests/RecordingPipelineTests.swift
+++ b/RemoteCamTests/RecordingPipelineTests.swift
@@ -25,7 +25,7 @@ final class RecordingPipelineTests: XCTestCase {
             extensions: nil,
             formatDescriptionOut: &formatDescription)
         XCTAssertEqual(status, noErr)
-        return formatDescription!
+        return try XCTUnwrap(formatDescription)
     }
 
     func testVideoInputFourThreeCachesEvenCropRectAndAdaptor() throws {
@@ -80,8 +80,9 @@ final class RecordingPipelineTests: XCTestCase {
             allocator: kCFAllocatorDefault, asbd: &asbd, layoutSize: 0, layout: nil,
             magicCookieSize: 0, magicCookie: nil, extensions: nil,
             formatDescriptionOut: &formatDescription), noErr)
+        let audioFormat = try XCTUnwrap(formatDescription)
 
-        XCTAssertTrue(pipeline.setupAssetWriterAudioInput(formatDescription!, assetWriter: writer))
+        XCTAssertTrue(pipeline.setupAssetWriterAudioInput(audioFormat, assetWriter: writer))
         XCTAssertEqual(writer.inputs.count, 1)
         XCTAssertEqual(writer.inputs.first?.mediaType, .audio)
     }

--- a/RemoteShutter.xcodeproj/project.pbxproj
+++ b/RemoteShutter.xcodeproj/project.pbxproj
@@ -118,6 +118,8 @@
 		8F558AB2F4887617AF3E8FCD /* RemoteShutterWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92E4A9C10FB90A6F07DB857 /* RemoteShutterWatchApp.swift */; };
 		8FC594E5A315D918BE429895 /* MonitorActorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B23042ABDA0FD46696039B /* MonitorActorTests.swift */; };
 		9667E6BB6F62D30AB6928304 /* CaptureEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F7C7180B3B581F22EF07350 /* CaptureEngine.swift */; };
+		AB12CD34EF5601789ABC0DE2 /* RecordingPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DE1 /* RecordingPipeline.swift */; };
+		AB12CD34EF5601789ABC0DE4 /* RecordingPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DE3 /* RecordingPipelineTests.swift */; };
 		99F50887F138FD71CF957A08 /* CameraControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A0B888B31311AE2BB5EB70 /* CameraControlling.swift */; };
 		A0C6EAACDA1985B1DD5E8EC0 /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50951447985E618A5F3818CD /* WatchConnectivity.framework */; };
 		A31965B5A3A1F59F96002E63 /* RemoteShutterWatch.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 36D2A99A351652C2D0C29B95 /* RemoteShutterWatch.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -323,6 +325,8 @@
 		0ACB2DA94752BB4E9C4CE461 /* CountdownTimer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CountdownTimer.swift; sourceTree = "<group>"; };
 		0EA55AF5BAC44DD4E4BCB3E3 /* Stack.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Stack.swift; sourceTree = "<group>"; };
 		0F7C7180B3B581F22EF07350 /* CaptureEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CaptureEngine.swift; sourceTree = "<group>"; };
+		AB12CD34EF5601789ABC0DE1 /* RecordingPipeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecordingPipeline.swift; sourceTree = "<group>"; };
+		AB12CD34EF5601789ABC0DE3 /* RecordingPipelineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecordingPipelineTests.swift; sourceTree = "<group>"; };
 		148A312CF1B445C71094EF0E /* WatchSessionManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RemoteCam/WatchSessionManager.swift; sourceTree = SOURCE_ROOT; };
 		1681D37E731D371A697244F7 /* Try.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Try.swift; sourceTree = "<group>"; };
 		1B28B6F9DA6B3E3677C5C532 /* RemoteCmdFlatBuffers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RemoteCmdFlatBuffers.swift; sourceTree = "<group>"; };
@@ -547,6 +551,7 @@
 				35D7D050D0AB3D3E4F07879D /* ScannerLobby.swift */,
 				A8A0B888B31311AE2BB5EB70 /* CameraControlling.swift */,
 				0F7C7180B3B581F22EF07350 /* CaptureEngine.swift */,
+				AB12CD34EF5601789ABC0DE1 /* RecordingPipeline.swift */,
 			);
 			path = RemoteCam;
 			sourceTree = "<group>";
@@ -572,6 +577,7 @@
 				47C3D2AB20DA09223CE0EF3D /* ControllerWiringTests.swift */,
 				58B23042ABDA0FD46696039B /* MonitorActorTests.swift */,
 				A342ACE91A767718D76C4C60 /* CaptureEngineTests.swift */,
+				AB12CD34EF5601789ABC0DE3 /* RecordingPipelineTests.swift */,
 			);
 			path = RemoteCamTests;
 			sourceTree = "<group>";
@@ -1170,6 +1176,7 @@
 				4259A755DF0013E098FD3CCC /* ScannerLobby.swift in Sources */,
 				99F50887F138FD71CF957A08 /* CameraControlling.swift in Sources */,
 				9667E6BB6F62D30AB6928304 /* CaptureEngine.swift in Sources */,
+				AB12CD34EF5601789ABC0DE2 /* RecordingPipeline.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1194,6 +1201,7 @@
 				531BD3C020987337266B50EC /* ControllerWiringTests.swift in Sources */,
 				8FC594E5A315D918BE429895 /* MonitorActorTests.swift in Sources */,
 				E1660E880D768347CB5B3297 /* CaptureEngineTests.swift in Sources */,
+				AB12CD34EF5601789ABC0DE4 /* RecordingPipelineTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Summary

PR 9 of the [UI modernization series](Docs/UI_MODERNIZATION.md): the recording/sample-buffer pipeline moves out of `CameraViewController` into a new non-UI `RecordingPipeline`, following the exact playbook of PR 8's `CaptureEngine` extraction — **mechanical move, no behavior or threading changes**, closure seams back to the VC, full suite green as the gate.

`CameraViewController` drops from **962 → 632 lines**. With capture (PR 8) and recording (this PR) both out, what remains is real UI plus the frame streamers — the runway for the PR 10 SwiftUI chrome.

## What moved

`RecordingPipeline` (407 lines, zero UIKit) now owns:

- The **asset writer** and its video/audio inputs, the pixel-buffer adaptor, and the writing queue
- The **six-boolean recording state machine** (`isRecording`, `recordingWillBeStarted/Stopped`, `readyToRecordVideo/Audio`) — moved intact, not redesigned; the redesign stays queued behind the single-owned-queue threading fix
- **Per-frame writing and cropping**, including the cached even-rounded crop rect for non-16:9 aspect ratios
- **Saving/sending the finished movie** (Photos library save, stop response, video resource transfer)

## What stayed in the VC — and why

- **The sample-buffer delegate role**: `captureOutput` fans out to two consumers — frame streaming (live preview, not recording) and the recording path. The VC keeps the delegate and forwards recording frames to `pipeline.processFrame`; the audio delegate is passed into `pipeline.startRecording(audioSampleBufferDelegate:)` the same way PR 8 passes it into `engine.setupCamera`.
- **The microphone-permission flow** (prompt UI) — the pipeline is only invoked once permission is granted.
- Timer/progress overlays, preview layer, lifecycle — unchanged.

## Seams

- `sendMessage` — a single actor relay for the start ack, stop response, and video resource. It captures the `session` ref (not the VC), carrying over PR 8's teardown-safety guarantee: an in-flight recording still reaches the actor if the VC deallocates. It also made the pipeline's no-op guards directly assertable (inject a recorder, assert nothing was sent).
- `onRecordingStarted/Stopped` (timer overlay), `onModeChanged` (idle vs recording chrome), `onError`, `onPhotosAccessDenied`.

## Tests

**385/385 green** (381 existing + 4 new). The loopback video round-trips — including the 3-step stop protocol and the start-ack forwarding fixed in PR 8 — passed **unchanged** across the move, which is the point of the safety net.

New device-free `RecordingPipelineTests`:
- 4:3 video input setup caches the even-rounded crop rect (1920×1080 → 1440×1080 at x=240) and creates the adaptor — the "dimensions must be even for the codec" rounding had never been asserted anywhere
- 16:9 needs no crop rect and no adaptor
- Audio input setup from a bare format description
- Stop-while-idle is a strict no-op: no state change, no messages, no callbacks

## Explicitly deferred (unchanged from the queued list)

Single owned serial queue (threading fix), `RotationCoordinator` (iOS 17) / `maxPhotoDimensions` (iOS 16) migrations, frame-streaming extraction, SwiftUI chrome (PR 10+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)