### PR TITLE
Extract FrameStreamingCoordinator from CameraViewController (UI modernization PR 10)

### DIFF
--- a/Docs/UI_MODERNIZATION.md
+++ b/Docs/UI_MODERNIZATION.md
@@ -152,7 +152,7 @@ Still queued for follow-ups: single owned serial queue (threading fix),
 `RotationCoordinator` (iOS 17) and `maxPhotoDimensions` (iOS 16) migrations,
 recording pipeline extraction.
 
-### PR 9: Extract RecordingPipeline (video recording) — **this PR**
+### PR 9: Extract RecordingPipeline (video recording)
 Same playbook as PR 8 — mechanical move, no behavior/threading changes:
 `RecordingPipeline` (non-UI) owns the asset writer and its inputs, the
 recording state machine, the writing queue, per-frame write/crop, and
@@ -166,10 +166,24 @@ chrome), `onError`, `onPhotosAccessDenied`. Still queued for follow-ups:
 single owned serial queue (threading fix), `RotationCoordinator` (iOS 17)
 and `maxPhotoDimensions` (iOS 16) migrations, frame-streaming extraction.
 
-### PR 10+: Camera SwiftUI chrome
-With capture and recording out, the VC is real UI plus the frame streamers:
-SwiftUI chrome around a `UIViewRepresentable` preview layer.
-`WatchRemoteCameraController` follows.
+### PR 10: Extract FrameStreamingCoordinator (live preview fan-out) — **this PR**
+The last capture code leaves the VC: `FrameStreamingCoordinator` is now the
+capture session's sample-buffer delegate, fanning frames out to the monitor
+`FrameStreamer`, the `WatchPreviewStreamer` (with its HEIC/JPEG encoder
+chain), and — while recording — `pipeline.processFrame`. The VC injects the
+actor sink (`frameSink`, capturing the FrameSender ref) and two providers
+(`orientationProvider`, `isWatchRemoteMode`) so the coordinator never stores
+copies of UI state; `acknowledgeWatchPreview` stays on the VC as a one-line
+`CameraControlling` forwarder. The VC now holds zero capture logic: preview
+layer, overlays, permissions UI, lifecycle, and protocol forwarders only.
+Still queued for follow-ups: single owned serial queue (threading fix),
+`RotationCoordinator` (iOS 17) and `maxPhotoDimensions` (iOS 16) migrations.
+
+### PR 11+: Camera SwiftUI chrome
+With capture, recording and streaming out, the VC is pure UI: SwiftUI chrome
+around a `UIViewRepresentable` preview layer. The natural place for the
+`RotationCoordinator` migration, which also collapses the orientation cache
+shared between VC and engine. `WatchRemoteCameraController` follows.
 
 ## Worklog (blog raw material)
 
@@ -318,3 +332,22 @@ SwiftUI chrome around a `UIViewRepresentable` preview layer.
   for the codec" rounding had never been asserted anywhere.
 - 385/385 green (381 + 4 pipeline tests); the loopback video round-trips —
   including the 3-step stop protocol — passed unchanged across the move.
+
+### PR 10 — FrameStreamingCoordinator extraction
+- The smallest of the three capture extractions (VC 631 → 570 lines,
+  coordinator 122) and the one that retires the milestone: the VC now holds
+  zero capture logic. Three classes, one seam each: engine (session + stills),
+  pipeline (recording), coordinator (the sample-buffer delegate + preview
+  fan-out).
+- Provider closures beat property mirroring: instead of the coordinator
+  keeping its own `orientation`/`isWatchRemoteMode` copies (orientation
+  already lives in two places), it reads the VC's through injected closures —
+  the same cross-thread reads the code did before the move, minus a third
+  copy to keep in sync.
+- No new unit tests, deliberately: the coordinator's fan-out has no
+  device-free surface worth faking (frame routing needs real
+  `AVCaptureConnection`s), and the loopback suite + watch ack path already
+  pin its behavior. 385/385 green, unchanged.
+- Incidental finds: the VC's `import Combine` and `import Photos` had both
+  been freeloading for years — each extraction PR has shed an import the
+  remaining code never used.

--- a/RemoteCam/CameraViewController.swift
+++ b/RemoteCam/CameraViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 import AVFoundation
 import StoreKit
 import SwiftUI
-import Combine
 
 /**
 Default fps, it would be neat if we would adjust this based on network conditions.
@@ -29,12 +28,21 @@ public class CameraViewController: UIViewController {
     }
 
     /// Owns the capture session, still-photo capture and all camera configuration.
-    /// This VC keeps the preview layer, the frame streamers, and the UI/lifecycle glue.
+    /// This VC keeps the preview layer and the UI/lifecycle glue.
     let engine = CaptureEngine()
 
     /// Owns the asset writer, recording state machine and per-frame writing.
-    /// The VC stays the sample-buffer delegate and forwards recording frames.
     lazy var pipeline = RecordingPipeline(engine: engine)
+
+    /// The capture session's sample-buffer delegate: routes frames to the
+    /// preview streamers and, while recording, to the pipeline. The providers
+    /// read UI state owned here; the sink captures the actor ref, not the VC.
+    lazy var streamingCoordinator = FrameStreamingCoordinator(
+        engine: engine,
+        pipeline: pipeline,
+        orientationProvider: { [weak self] in self?.orientation ?? .portrait },
+        isWatchRemoteMode: { [weak self] in self?.isWatchRemoteMode ?? false },
+        frameSink: { [frameSender] frame in frameSender ! frame })
 
     var isRecording: Bool { pipeline.isRecording }
 
@@ -49,32 +57,6 @@ public class CameraViewController: UIViewController {
     /// Suppresses MultipeerConnectivity-related actor messages (BecomeCamera/UnbecomeCamera).
     var isWatchRemoteMode = false
 
-    /// Dedicated context for the tiny Apple Watch preview, kept off the recording
-    /// pipeline's crop context to avoid cross-queue contention.
-    private let watchPreviewContext = CIContext(options: [.useSoftwareRenderer: false])
-    /// Streams preview frames to the Apple Watch with ack back-pressure and lazy encoding.
-    /// Runs on `videoDataOutputQueue`, where the capture callback hands it sample buffers.
-    private lazy var watchPreviewStreamer = WatchPreviewStreamer(
-        queue: engine.videoDataOutputQueue,
-        maxInFlight: StreamingConfig.default.watchPreviewMaxInFlight,
-        ackTimeout: StreamingConfig.default.watchPreviewAckTimeout)
-    /// Streams preview frames to the phone monitor: paces, encodes (HEIC with
-    /// JPEG fallback), and hands frames to the FrameSender actor.
-    /// Runs on `videoDataOutputQueue`.
-    private lazy var frameStreamer = FrameStreamer { [frameSender] frame in frameSender ! frame }
-    /// Encoder chain for the Watch preview (HEIC with permanent JPEG fallback).
-    /// Runs on `videoDataOutputQueue` via `watchPreviewStreamer.offer`.
-    private lazy var watchFrameEncoders: [FrameEncoding] = {
-        let config = StreamingConfig.default
-        return [
-            HEICFrameEncoder(context: watchPreviewContext,
-                             maxLongEdge: config.watchMaxLongEdge,
-                             quality: config.watchHEICQuality),
-            JPEGFrameEncoder(context: watchPreviewContext,
-                             maxLongEdge: config.watchMaxLongEdge,
-                             quality: config.watchJPEGQuality)
-        ]
-    }()
     // MARK: - Recording Timer Properties
     private var recordingStartTime: Date?
     private var recordingTimerController: CameraRecordingTimerViewController?
@@ -420,7 +402,7 @@ public class CameraViewController: UIViewController {
     func setupCamera() {
         // The engine configures and starts the session; the preview layer and its
         // orientation stay here because the engine must not touch views/layers.
-        guard engine.setupCamera(sampleBufferDelegate: self) else { return }
+        guard engine.setupCamera(sampleBufferDelegate: streamingCoordinator) else { return }
 
         self.captureVideoPreviewLayer = AVCaptureVideoPreviewLayer(session: engine.captureSession)
         self.captureVideoPreviewLayer!.videoGravity = AVLayerVideoGravity.resizeAspect
@@ -523,8 +505,7 @@ extension CameraViewController {
             DispatchQueue.main.async {
                 guard let self = self else { return }
                 if granted {
-                    // The VC stays the audio sample-buffer delegate (captureOutput below).
-                    self.pipeline.startRecording(audioSampleBufferDelegate: self)
+                    self.pipeline.startRecording(audioSampleBufferDelegate: self.streamingCoordinator)
                 } else {
                     // Microphone denied - show prompt and send error to remote
                     self.handleMicrophoneDenied()
@@ -581,51 +562,9 @@ extension CameraViewController {
     }
 }
 
-extension CameraViewController: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAudioDataOutputSampleBufferDelegate {
-    public func captureOutput(_ captureOutput: AVCaptureOutput,
-                              didOutput sampleBuffer: CMSampleBuffer,
-                              from connection: AVCaptureConnection) {
-        if connection == engine.videoConnection {
-            sendFrameToMonitor(captureOutput, didOutput: sampleBuffer, from: connection)
-        }
-        if (pipeline.recordingWillBeStarted || pipeline.isRecording) && !pipeline.recordingWillBeStopped {
-            pipeline.processFrame(captureOutput, didOutput: sampleBuffer, from: connection)
-        }
-    }
-
-    public func sendFrameToMonitor(_ captureOutput: AVCaptureOutput,
-                              didOutput sampleBuffer: CMSampleBuffer,
-                              from connection: AVCaptureConnection) {
-        // Watch Remote mode has no MultipeerConnectivity peer — the iPhone is the camera
-        // and the only consumer is the Apple Watch. The streamer applies ack back-pressure
-        // and only invokes the encode when it's actually ready to send.
-        if isWatchRemoteMode {
-            watchPreviewStreamer.offer { [weak self] in self?.watchPreviewImageData(from: sampleBuffer) }
-            return
-        }
-
-        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer),
-              let device = self.engine.videoDeviceInput?.device else { return }
-        frameStreamer.handle(pixelBuffer: pixelBuffer,
-                             position: device.position,
-                             orientation: self.orientation,
-                             fps: fps)
-    }
-
-    /// Builds a compact still of the current frame for the Apple Watch live
-    /// preview: long edge ~320 px (matching the Watch screen width), HEIC when
-    /// the hardware supports it (~half the bytes of JPEG, so roughly double the
-    /// frame rate over the WCSession pipe), JPEG otherwise. The Watch decodes
-    /// either transparently via UIImage(data:). The sample buffer is already
-    /// oriented by `videoConnection.videoOrientation`, so it renders upright.
-    private func watchPreviewImageData(from sampleBuffer: CMSampleBuffer) -> Data? {
-        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return nil }
-        return encodeWithFallback(&watchFrameEncoders, pixelBuffer: pixelBuffer)
-    }
-
+extension CameraViewController {
     /// The Watch acked the in-flight preview frame — let the streamer send the next.
     func acknowledgeWatchPreview() {
-        watchPreviewStreamer.acknowledge()
+        streamingCoordinator.acknowledgeWatchPreview()
     }
-
 }

--- a/RemoteCam/FrameStreamingCoordinator.swift
+++ b/RemoteCam/FrameStreamingCoordinator.swift
@@ -1,0 +1,122 @@
+//
+//  FrameStreamingCoordinator.swift
+//  RemoteShutter
+//
+//  Copyright © 2026 Security Union LLC. All rights reserved.
+//
+
+import Foundation
+import AVFoundation
+import CoreImage
+import UIKit
+
+/**
+ The capture session's sample-buffer delegate: fans every frame out to the
+ live-preview streamers (phone monitor or Apple Watch) and, while recording,
+ to the `RecordingPipeline`. Non-UI — its only UIKit dependency is
+ `UIInterfaceOrientation` for the frame streamer.
+
+ Owned by `CameraViewController`, which injects the actor sink and two
+ providers instead of the coordinator keeping its own copies of UI state.
+ */
+final class FrameStreamingCoordinator: NSObject {
+
+    private let engine: CaptureEngine
+    private let pipeline: RecordingPipeline
+    /// Feeds encoded monitor frames to the FrameSender actor.
+    private let frameSink: FrameStreamer.Send
+    /// Reads the VC's orientation. Called on the capture queue — the same
+    /// cross-thread property read this code did before the extraction.
+    private let orientationProvider: () -> UIInterfaceOrientation
+    /// True when the Apple Watch is the remote (no MultipeerConnectivity peer).
+    private let isWatchRemoteMode: () -> Bool
+
+    /// Dedicated context for the tiny Apple Watch preview, kept off the recording
+    /// pipeline's crop context to avoid cross-queue contention.
+    private let watchPreviewContext = CIContext(options: [.useSoftwareRenderer: false])
+    /// Streams preview frames to the Apple Watch with ack back-pressure and lazy encoding.
+    /// Runs on `videoDataOutputQueue`, where the capture callback hands it sample buffers.
+    private lazy var watchPreviewStreamer = WatchPreviewStreamer(
+        queue: engine.videoDataOutputQueue,
+        maxInFlight: StreamingConfig.default.watchPreviewMaxInFlight,
+        ackTimeout: StreamingConfig.default.watchPreviewAckTimeout)
+    /// Streams preview frames to the phone monitor: paces, encodes (HEIC with
+    /// JPEG fallback), and hands frames to the FrameSender actor.
+    /// Runs on `videoDataOutputQueue`.
+    private lazy var frameStreamer = FrameStreamer(send: frameSink)
+    /// Encoder chain for the Watch preview (HEIC with permanent JPEG fallback).
+    /// Runs on `videoDataOutputQueue` via `watchPreviewStreamer.offer`.
+    private lazy var watchFrameEncoders: [FrameEncoding] = {
+        let config = StreamingConfig.default
+        return [
+            HEICFrameEncoder(context: watchPreviewContext,
+                             maxLongEdge: config.watchMaxLongEdge,
+                             quality: config.watchHEICQuality),
+            JPEGFrameEncoder(context: watchPreviewContext,
+                             maxLongEdge: config.watchMaxLongEdge,
+                             quality: config.watchJPEGQuality)
+        ]
+    }()
+
+    init(engine: CaptureEngine,
+         pipeline: RecordingPipeline,
+         orientationProvider: @escaping () -> UIInterfaceOrientation,
+         isWatchRemoteMode: @escaping () -> Bool,
+         frameSink: @escaping FrameStreamer.Send) {
+        self.engine = engine
+        self.pipeline = pipeline
+        self.orientationProvider = orientationProvider
+        self.isWatchRemoteMode = isWatchRemoteMode
+        self.frameSink = frameSink
+    }
+
+    /// The Watch acked the in-flight preview frame — let the streamer send the next.
+    func acknowledgeWatchPreview() {
+        watchPreviewStreamer.acknowledge()
+    }
+}
+
+extension FrameStreamingCoordinator: AVCaptureVideoDataOutputSampleBufferDelegate,
+                                     AVCaptureAudioDataOutputSampleBufferDelegate {
+
+    func captureOutput(_ captureOutput: AVCaptureOutput,
+                       didOutput sampleBuffer: CMSampleBuffer,
+                       from connection: AVCaptureConnection) {
+        if connection == engine.videoConnection {
+            sendFrameToMonitor(captureOutput, didOutput: sampleBuffer, from: connection)
+        }
+        if (pipeline.recordingWillBeStarted || pipeline.isRecording) && !pipeline.recordingWillBeStopped {
+            pipeline.processFrame(captureOutput, didOutput: sampleBuffer, from: connection)
+        }
+    }
+
+    func sendFrameToMonitor(_ captureOutput: AVCaptureOutput,
+                            didOutput sampleBuffer: CMSampleBuffer,
+                            from connection: AVCaptureConnection) {
+        // Watch Remote mode has no MultipeerConnectivity peer — the iPhone is the camera
+        // and the only consumer is the Apple Watch. The streamer applies ack back-pressure
+        // and only invokes the encode when it's actually ready to send.
+        if isWatchRemoteMode() {
+            watchPreviewStreamer.offer { [weak self] in self?.watchPreviewImageData(from: sampleBuffer) }
+            return
+        }
+
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer),
+              let device = self.engine.videoDeviceInput?.device else { return }
+        frameStreamer.handle(pixelBuffer: pixelBuffer,
+                             position: device.position,
+                             orientation: orientationProvider(),
+                             fps: fps)
+    }
+
+    /// Builds a compact still of the current frame for the Apple Watch live
+    /// preview: long edge ~320 px (matching the Watch screen width), HEIC when
+    /// the hardware supports it (~half the bytes of JPEG, so roughly double the
+    /// frame rate over the WCSession pipe), JPEG otherwise. The Watch decodes
+    /// either transparently via UIImage(data:). The sample buffer is already
+    /// oriented by `videoConnection.videoOrientation`, so it renders upright.
+    private func watchPreviewImageData(from sampleBuffer: CMSampleBuffer) -> Data? {
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return nil }
+        return encodeWithFallback(&watchFrameEncoders, pixelBuffer: pixelBuffer)
+    }
+}

--- a/RemoteShutter.xcodeproj/project.pbxproj
+++ b/RemoteShutter.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		8FC594E5A315D918BE429895 /* MonitorActorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B23042ABDA0FD46696039B /* MonitorActorTests.swift */; };
 		9667E6BB6F62D30AB6928304 /* CaptureEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F7C7180B3B581F22EF07350 /* CaptureEngine.swift */; };
 		AB12CD34EF5601789ABC0DE2 /* RecordingPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DE1 /* RecordingPipeline.swift */; };
+		AB12CD34EF5601789ABC0DE6 /* FrameStreamingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DE5 /* FrameStreamingCoordinator.swift */; };
 		AB12CD34EF5601789ABC0DE4 /* RecordingPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DE3 /* RecordingPipelineTests.swift */; };
 		99F50887F138FD71CF957A08 /* CameraControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A0B888B31311AE2BB5EB70 /* CameraControlling.swift */; };
 		A0C6EAACDA1985B1DD5E8EC0 /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50951447985E618A5F3818CD /* WatchConnectivity.framework */; };
@@ -326,6 +327,7 @@
 		0EA55AF5BAC44DD4E4BCB3E3 /* Stack.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Stack.swift; sourceTree = "<group>"; };
 		0F7C7180B3B581F22EF07350 /* CaptureEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CaptureEngine.swift; sourceTree = "<group>"; };
 		AB12CD34EF5601789ABC0DE1 /* RecordingPipeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecordingPipeline.swift; sourceTree = "<group>"; };
+		AB12CD34EF5601789ABC0DE5 /* FrameStreamingCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FrameStreamingCoordinator.swift; sourceTree = "<group>"; };
 		AB12CD34EF5601789ABC0DE3 /* RecordingPipelineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecordingPipelineTests.swift; sourceTree = "<group>"; };
 		148A312CF1B445C71094EF0E /* WatchSessionManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RemoteCam/WatchSessionManager.swift; sourceTree = SOURCE_ROOT; };
 		1681D37E731D371A697244F7 /* Try.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Try.swift; sourceTree = "<group>"; };
@@ -552,6 +554,7 @@
 				A8A0B888B31311AE2BB5EB70 /* CameraControlling.swift */,
 				0F7C7180B3B581F22EF07350 /* CaptureEngine.swift */,
 				AB12CD34EF5601789ABC0DE1 /* RecordingPipeline.swift */,
+				AB12CD34EF5601789ABC0DE5 /* FrameStreamingCoordinator.swift */,
 			);
 			path = RemoteCam;
 			sourceTree = "<group>";
@@ -1177,6 +1180,7 @@
 				99F50887F138FD71CF957A08 /* CameraControlling.swift in Sources */,
 				9667E6BB6F62D30AB6928304 /* CaptureEngine.swift in Sources */,
 				AB12CD34EF5601789ABC0DE2 /* RecordingPipeline.swift in Sources */,
+				AB12CD34EF5601789ABC0DE6 /* FrameStreamingCoordinator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Summary

PR 10 of the [UI modernization series](Docs/UI_MODERNIZATION.md), and the one that retires the milestone: **`CameraViewController` now holds zero capture logic.** The last piece — the sample-buffer delegate and the live-preview frame fan-out — moves into `FrameStreamingCoordinator`, completing the three-class capture split:

| Class | Owns |
|---|---|
| `CaptureEngine` (PR 8) | capture session, stills, configuration |
| `RecordingPipeline` (PR 9) | asset writer, recording state, per-frame writing |
| `FrameStreamingCoordinator` (this PR) | sample-buffer delegate, preview fan-out |

Same playbook as PRs 8 and 9: **mechanical move, no behavior or threading changes**, full suite green as the gate. `CameraViewController`: 631 → 570 lines — preview layer, overlays, permissions UI, lifecycle, and protocol forwarders only. That's the runway for the PR 11 SwiftUI chrome, which can now be a pure-UI diff.

## What moved

`FrameStreamingCoordinator` (122 lines) becomes the `AVCaptureVideoDataOutput`/`AVCaptureAudioDataOutput` sample-buffer delegate and takes over:

- `captureOutput` — the per-frame fan-out: video frames to the monitor/watch preview path, and (while the recording flags say so) to `pipeline.processFrame`, byte-for-byte the same routing
- `sendFrameToMonitor` with the watch-remote short-circuit, `watchPreviewImageData`, `acknowledgeWatchPreview`
- The `FrameStreamer` and `WatchPreviewStreamer` instances, the HEIC/JPEG watch encoder chain, and the dedicated watch-preview `CIContext`

## Design notes

- **Providers over property mirroring.** Orientation already lives in two places (VC for preview/UI, engine cache for output connections — flagged since PR 8). Rather than adding a third stored copy, the coordinator reads the VC's `orientation` and `isWatchRemoteMode` through injected closures — the same cross-thread property reads this code performed before the move, minus a copy to keep in sync.
- **The actor sink captures the ref, not the VC.** `frameSink: { [frameSender] frame in frameSender ! frame }` follows the teardown-safety pattern established in PRs 8/9.
- **`acknowledgeWatchPreview` stays on the VC** as a one-line forwarder — it's a `CameraControlling` protocol requirement, and the protocol surface doesn't move.
- Incidental find: the VC's `import Combine` was unused (as `import Photos` was in PR 9) — each extraction has shed an import the remaining code never needed.

## Tests

**385/385 green, unchanged.** No new unit tests, deliberately: the coordinator's fan-out has no honest device-free surface (frame routing compares real `AVCaptureConnection`s), and its behavior is already pinned by the loopback round-trips and the watch preview ack path. Faking `RecordingPipeline` behind a protocol just to unit-test the routing would be scope creep beyond a mechanical move.

## Explicitly deferred

Single owned serial queue (threading fix), `RotationCoordinator` (iOS 17) / `maxPhotoDimensions` (iOS 16) migrations — the latter now naturally paired with the PR 11 SwiftUI chrome, which also collapses the two-place orientation cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)