### PR TITLE
Post a coverage report comment on every PR CI run

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, develop, master ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     name: Build and Test
@@ -66,36 +70,22 @@ jobs:
           -configuration Debug \
           test \
           -enableCodeCoverage YES \
+          -resultBundlePath TestResults.xcresult \
           CODE_SIGNING_REQUIRED=NO \
           CODE_SIGNING_ALLOWED=NO
 
-    - name: Code Coverage Report
+    - name: Generate Coverage Report
       if: success()
       run: |
-        RESULT_PATH=$(find ~/Library/Developer/Xcode/DerivedData \
-          -name "*.xcresult" -type d 2>/dev/null | sort | tail -1)
+        python3 scripts/coverage_report.py TestResults.xcresult coverage.md
+        cat coverage.md >> "$GITHUB_STEP_SUMMARY"
 
-        if [ -z "$RESULT_PATH" ]; then
-          echo "No xcresult bundle found" >> $GITHUB_STEP_SUMMARY
-          exit 0
-        fi
-
-        echo "## Code Coverage Report" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "| File | Functions | Coverage |" >> $GITHUB_STEP_SUMMARY
-        echo "|------|-----------|----------|" >> $GITHUB_STEP_SUMMARY
-
-        xcrun xccov view --report "$RESULT_PATH" \
-          --files-for-target RemoteShutter.app \
-        | tail -n +4 \
-        | awk 'NF >= 5 {
-            file = $2;
-            funcs = $(NF-2);
-            cov = $(NF-1) " " $NF;
-            n = split(file, parts, "/");
-            fname = parts[n];
-            if (length(fname) > 0) print "| `" fname "` | " funcs " | " cov " |";
-          }' >> $GITHUB_STEP_SUMMARY
+    - name: Post Coverage Comment
+      if: success() && github.event_name == 'pull_request'
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: coverage
+        path: coverage.md
 
     - name: Archive for Release (if main branch)
       if: github.ref == 'refs/heads/main'

--- a/scripts/coverage_report.py
+++ b/scripts/coverage_report.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Generate a markdown coverage report from an xcresult bundle.
+
+Usage: coverage_report.py <path.xcresult> <output.md>
+
+Reads line-coverage via `xccov` and the test tally via `xcresulttool`,
+then emits a PR-comment-ready markdown report: overall bar, app-code
+metric (excluding generated + vendored sources), a spotlight on the
+capture/session core, and a collapsible per-file table.
+"""
+import json
+import os
+import subprocess
+import sys
+
+BAR_WIDTH = 20
+
+# Generated or vendored code — shown in the full table but excluded from
+# the "app code" headline metric.
+EXCLUDED_SUBSTRINGS = ("FlatBufferSchemas_generated.swift", "/Theater/")
+
+# The load-bearing core: the capture stack and the actor/session layer.
+SPOTLIGHT = [
+    "CaptureEngine.swift",
+    "RecordingPipeline.swift",
+    "FrameStreamingCoordinator.swift",
+    "CameraViewController.swift",
+    "RemoteCamSession.swift",
+    "MonitorActor.swift",
+    "FrameStreamer.swift",
+    "RemoteCmdFlatBuffers.swift",
+]
+
+
+def bar(fraction):
+    filled = round(fraction * BAR_WIDTH)
+    return "█" * filled + "░" * (BAR_WIDTH - filled)
+
+
+def dot(fraction):
+    if fraction >= 0.8:
+        return "🟢"
+    if fraction >= 0.5:
+        return "🟡"
+    return "🔴"
+
+
+def pct(fraction):
+    return f"{fraction * 100:.1f}%"
+
+
+def test_tally(xcresult):
+    """Best-effort test counts; xcresulttool interfaces vary by Xcode."""
+    try:
+        raw = subprocess.check_output(
+            ["xcrun", "xcresulttool", "get", "test-results", "summary",
+             "--path", xcresult, "--compact"],
+            stderr=subprocess.DEVNULL)
+        summary = json.loads(raw)
+        total = summary.get("totalTestCount")
+        passed = summary.get("passedTests")
+        failed = summary.get("failedTests", 0)
+        skipped = summary.get("skippedTests", 0)
+        if total is None or passed is None:
+            return None
+        return total, passed, failed, skipped
+    except (subprocess.CalledProcessError, json.JSONDecodeError, OSError):
+        return None
+
+
+def main():
+    xcresult, out_path = sys.argv[1], sys.argv[2]
+
+    report = json.loads(subprocess.check_output(
+        ["xcrun", "xccov", "view", "--report", "--json", xcresult]))
+
+    app = next((t for t in report.get("targets", [])
+                if t.get("name", "").endswith(".app")), None)
+    if app is None:
+        sys.exit("No .app target found in coverage report")
+
+    files = sorted(app.get("files", []),
+                   key=lambda f: f.get("lineCoverage", 0), reverse=True)
+
+    app_files = [f for f in files
+                 if not any(s in f.get("path", "") for s in EXCLUDED_SUBSTRINGS)]
+    covered = sum(f.get("coveredLines", 0) for f in app_files)
+    executable = sum(f.get("executableLines", 0) for f in app_files)
+    app_fraction = covered / executable if executable else 0.0
+    overall = app.get("lineCoverage", 0.0)
+
+    lines = []
+    lines.append("## 📊 Test Coverage Report")
+    lines.append("")
+
+    tally = test_tally(xcresult)
+    if tally:
+        total, passed, failed, skipped = tally
+        badge = "✅" if failed == 0 else "❌"
+        tally_text = f"{badge} **{passed}/{total} tests passed**"
+        if failed:
+            tally_text += f" · 🔻 {failed} failed"
+        if skipped:
+            tally_text += f" · ⏭️ {skipped} skipped"
+        lines.append(tally_text)
+        lines.append("")
+
+    lines.append("| Metric | Coverage | |")
+    lines.append("|---|---|---|")
+    lines.append(f"| **App code** (excl. generated + vendored Theater) "
+                 f"| `{bar(app_fraction)}` **{pct(app_fraction)}** | {dot(app_fraction)} |")
+    lines.append(f"| Whole target | `{bar(overall)}` {pct(overall)} | {dot(overall)} |")
+    lines.append("")
+
+    lines.append("### 🎥 Capture & session core")
+    lines.append("")
+    lines.append("| File | Coverage | Lines | |")
+    lines.append("|---|---|---|---|")
+    by_name = {f.get("name"): f for f in files}
+    for name in SPOTLIGHT:
+        f = by_name.get(name)
+        if not f:
+            continue
+        frac = f.get("lineCoverage", 0.0)
+        lines.append(f"| `{name}` | `{bar(frac)}` {pct(frac)} "
+                     f"| {f.get('coveredLines', 0)}/{f.get('executableLines', 0)} "
+                     f"| {dot(frac)} |")
+    lines.append("")
+
+    lines.append("<details>")
+    lines.append(f"<summary>📁 Full report — {len(files)} files</summary>")
+    lines.append("")
+    lines.append("| File | Coverage | Lines | |")
+    lines.append("|---|---|---|---|")
+    for f in files:
+        frac = f.get("lineCoverage", 0.0)
+        name = f.get("name", "?")
+        excluded = any(s in f.get("path", "") for s in EXCLUDED_SUBSTRINGS)
+        suffix = " *(excluded from app-code metric)*" if excluded else ""
+        lines.append(f"| `{name}`{suffix} | `{bar(frac)}` {pct(frac)} "
+                     f"| {f.get('coveredLines', 0)}/{f.get('executableLines', 0)} "
+                     f"| {dot(frac)} |")
+    lines.append("")
+    lines.append("</details>")
+    lines.append("")
+
+    sha = os.environ.get("GITHUB_SHA", "")[:7]
+    server = os.environ.get("GITHUB_SERVER_URL", "")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    if sha and repo and run_id:
+        lines.append(f"_Generated from `{sha}` · "
+                     f"[workflow run]({server}/{repo}/actions/runs/{run_id})_")
+        lines.append("")
+
+    with open(out_path, "w") as handle:
+        handle.write("\n".join(lines))
+    print(f"Wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Every PR now gets a **coverage report comment** at the end of the CI run — posted once and updated in place on subsequent pushes (sticky comment, no spam). The same report lands in the workflow step summary.

## What it looks like

- ✅ **Test tally** (passed/failed/skipped) pulled from the xcresult
- **Two headline metrics** with progress bars and traffic lights: *app code* (excluding the generated FlatBuffers file and vendored Theater) and the whole target
- 🎥 **Capture & session core spotlight** — `CaptureEngine`, `RecordingPipeline`, `FrameStreamingCoordinator`, `RemoteCamSession`, `MonitorActor`, the FlatBuffers codec — the files this modernization series lives in
- 📁 A collapsible **full per-file table** (90 files), sorted by coverage

Sample rows from a local run:

```
✅ 385/385 tests passed
App code   ███████░░░░░░░░░░░░░  37.5% 🔴
RemoteCmdFlatBuffers.swift  ███████████████████░ 96.4% 🟢
MonitorStates.swift         ████████████████████ 97.7% 🟢
CaptureEngine.swift         █░░░░░░░░░░░░░░░░░░░  6.6% 🔴  (device-only code)
```

## How

- `Run Tests` now writes a deterministic `-resultBundlePath TestResults.xcresult` (replacing the fragile find-latest-in-DerivedData) and keeps `-enableCodeCoverage YES`
- New `scripts/coverage_report.py` parses `xccov --json` + `xcresulttool test-results summary` (best-effort, degrades gracefully) and emits the markdown
- `marocchino/sticky-pull-request-comment@v2` posts/updates the comment (`pull-requests: write` permission added, `contents` stays read-only)

This PR's own CI run should post the first comment below. 👇

🤖 Generated with [Claude Code](https://claude.com/claude-code)