### PR TITLE
Make Wi-Fi requirement abundantly clear on the scanner screen

### DIFF
--- a/Docs/screenshots/wifi-guidance/scanner-camera-wifi-banner.png
+++ b/Docs/screenshots/wifi-guidance/scanner-camera-wifi-banner.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e209cbbd12a082f8edfea33b533e8e1520a29e0f85d417bea4a725c1687026f
+size 212683

--- a/Docs/screenshots/wifi-guidance/scanner-remote-wifi-banner.png
+++ b/Docs/screenshots/wifi-guidance/scanner-remote-wifi-banner.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d14367d9c51f9137fb08c886801319186d2e0120fafb085975d78bad9fed7c02
+size 213728

--- a/Docs/screenshots/wifi-guidance/scanner-remote-wifi-escalation.png
+++ b/Docs/screenshots/wifi-guidance/scanner-remote-wifi-escalation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47ef1c905d103ca44fa84ff326cff32ad328848442343c3a8d6488b7b4fb98de
+size 203752

--- a/RemoteCam/DeviceScannerView.swift
+++ b/RemoteCam/DeviceScannerView.swift
@@ -259,7 +259,6 @@ struct DeviceScannerView: View {
                     .font(.subheadline)
                     .fontWeight(.bold)
                     .foregroundColor(.primary)
-                    .textCase(.uppercase)
                 Text(NSLocalizedString("WifiBannerBody", comment: "Wi-Fi required banner body"))
                     .font(.caption)
                     .foregroundColor(.secondary)
@@ -281,11 +280,13 @@ struct DeviceScannerView: View {
 
     /// Status badge plus the time-based "check Wi-Fi" tip. TimelineView
     /// supplies the clock; visibility is recomputed from state every second,
-    /// so there is no timer to cancel and no flag to go stale.
+    /// so there is no timer to cancel and no flag to go stale. Only the tip
+    /// lives inside the TimelineView — the badge doesn't depend on the clock
+    /// and re-rendering it each tick would reset its ProgressView animation.
     private var statusArea: some View {
-        TimelineView(.periodic(from: .now, by: 1)) { context in
-            VStack(spacing: 10) {
-                statusBadge
+        VStack(spacing: 10) {
+            statusBadge
+            TimelineView(.periodic(from: .now, by: 1)) { context in
                 if viewModel.shouldShowWifiEscalation(now: context.date) {
                     wifiEscalationTip
                 }

--- a/RemoteCam/DeviceScannerView.swift
+++ b/RemoteCam/DeviceScannerView.swift
@@ -87,6 +87,10 @@ struct DeviceScannerView: View {
     private var cameraWaitingState: some View {
         ScrollView {
             VStack(spacing: 20) {
+                wifiBanner
+                    .padding(.horizontal, 20)
+                    .padding(.top, 12)
+
                 // Camera icon
                 ZStack {
                     Circle()
@@ -119,7 +123,7 @@ struct DeviceScannerView: View {
                 .padding(.horizontal, 20)
 
                 // Status
-                statusBadge
+                statusArea
 
                 // Actions
                 VStack(spacing: 12) {
@@ -147,6 +151,10 @@ struct DeviceScannerView: View {
     private var emptyState: some View {
         ScrollView {
             VStack(spacing: 20) {
+                wifiBanner
+                    .padding(.horizontal, 20)
+                    .padding(.top, 12)
+
                 // Remote icon
                 ZStack {
                     Circle()
@@ -179,7 +187,7 @@ struct DeviceScannerView: View {
                 .padding(.horizontal, 20)
 
                 // Status
-                statusBadge
+                statusArea
 
                 // Actions
                 VStack(spacing: 12) {
@@ -235,6 +243,77 @@ struct DeviceScannerView: View {
             .padding(.horizontal, 20)
         }
         .padding(.bottom, 20)
+    }
+
+    // MARK: - Wi-Fi Guidance
+
+    private var wifiBanner: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "wifi")
+                .font(.title3.weight(.semibold))
+                .foregroundColor(AppTheme.accent)
+                .padding(.top, 2)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(NSLocalizedString("WifiBannerTitle", comment: "Wi-Fi required banner title"))
+                    .font(.subheadline)
+                    .fontWeight(.bold)
+                    .foregroundColor(.primary)
+                    .textCase(.uppercase)
+                Text(NSLocalizedString("WifiBannerBody", comment: "Wi-Fi required banner body"))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .multilineTextAlignment(.leading)
+            .fixedSize(horizontal: false, vertical: true)
+
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity)
+        .background(AppTheme.accentSubtle)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .strokeBorder(AppTheme.accent.opacity(0.4), lineWidth: 1)
+        )
+    }
+
+    /// Status badge plus the time-based "check Wi-Fi" tip. TimelineView
+    /// supplies the clock; visibility is recomputed from state every second,
+    /// so there is no timer to cancel and no flag to go stale.
+    private var statusArea: some View {
+        TimelineView(.periodic(from: .now, by: 1)) { context in
+            VStack(spacing: 10) {
+                statusBadge
+                if viewModel.shouldShowWifiEscalation(now: context.date) {
+                    wifiEscalationTip
+                }
+            }
+        }
+    }
+
+    private var wifiEscalationTip: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundColor(.orange)
+                .padding(.top, 2)
+            Text(NSLocalizedString("WifiEscalationTip", comment: "Shown after 15s of scanning without finding a peer"))
+                .font(.caption)
+                .fontWeight(.medium)
+                .foregroundColor(.orange)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(12)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .strokeBorder(Color.orange.opacity(0.35), lineWidth: 0.5)
+        )
+        .padding(.horizontal, 20)
     }
 
     // MARK: - Components

--- a/RemoteCam/DeviceScannerViewModel.swift
+++ b/RemoteCam/DeviceScannerViewModel.swift
@@ -11,6 +11,10 @@ final class DeviceScannerViewModel: ObservableObject {
     @Published var hasScanningError: Bool = false
     @Published var isConnecting: Bool = false
 
+    /// When the current scan began. Not @Published: the view samples it on a
+    /// TimelineView clock, so publishing would only cause redundant redraws.
+    private(set) var scanStartedAt: Date?
+
     // MARK: - Role
 
     var role: DeviceRole = .monitor
@@ -62,11 +66,13 @@ final class DeviceScannerViewModel: ObservableObject {
         isScanning = true
         hasScanningError = false
         isConnecting = false
+        scanStartedAt = Date()
     }
 
     func stoppedScanning() {
         isScanning = false
         isConnecting = false
+        scanStartedAt = nil
     }
 
     func scanningFailed() {
@@ -74,6 +80,26 @@ final class DeviceScannerViewModel: ObservableObject {
         hasScanningError = true
         isScanning = false
         isConnecting = false
+        scanStartedAt = nil
+    }
+
+    // MARK: - Wi-Fi Escalation
+
+    /// Whether to show the "still searching — check Wi-Fi" tip. Pure function
+    /// of state + clock: no stored flag or timer exists to go stale.
+    static func shouldShowWifiEscalation(isScanning: Bool,
+                                         hasPeers: Bool,
+                                         scanStartedAt: Date?,
+                                         now: Date) -> Bool {
+        guard isScanning, !hasPeers, let start = scanStartedAt else { return false }
+        return now.timeIntervalSince(start) >= 15
+    }
+
+    func shouldShowWifiEscalation(now: Date) -> Bool {
+        Self.shouldShowWifiEscalation(isScanning: isScanning,
+                                      hasPeers: hasPeers,
+                                      scanStartedAt: scanStartedAt,
+                                      now: now)
     }
 
     func networkAccessDenied() {

--- a/RemoteCam/da.lproj/Localizable.strings
+++ b/RemoteCam/da.lproj/Localizable.strings
@@ -206,6 +206,6 @@
 "Open Watch App" = "Åbn Watch-appen";
 
 /* Wi-Fi Guidance (scanner screen) */
-"WifiBannerTitle" = "Slå Wi-Fi til på begge enheder — påkrævet";
+"WifiBannerTitle" = "SLÅ WI-FI TIL PÅ BEGGE ENHEDER — PÅKRÆVET";
 "WifiBannerBody" = "Intet netværk nødvendigt — enhederne forbinder direkte.";
 "WifiEscalationTip" = "Søger stadig… Tjek at Wi-Fi er slået til — på denne enhed og den anden. Slukket i Kontrolcenter tæller stadig som slukket: brug Indstillinger > Wi-Fi.";

--- a/RemoteCam/da.lproj/Localizable.strings
+++ b/RemoteCam/da.lproj/Localizable.strings
@@ -204,3 +204,8 @@
 "Control from your wrist" = "Styr fra dit håndled";
 "Watch Connected" = "Watch tilsluttet";
 "Open Watch App" = "Åbn Watch-appen";
+
+/* Wi-Fi Guidance (scanner screen) */
+"WifiBannerTitle" = "Slå Wi-Fi til på begge enheder — påkrævet";
+"WifiBannerBody" = "Intet netværk nødvendigt — enhederne forbinder direkte.";
+"WifiEscalationTip" = "Søger stadig… Tjek at Wi-Fi er slået til — på denne enhed og den anden. Slukket i Kontrolcenter tæller stadig som slukket: brug Indstillinger > Wi-Fi.";

--- a/RemoteCam/de-DE.lproj/Localizable.strings
+++ b/RemoteCam/de-DE.lproj/Localizable.strings
@@ -325,3 +325,8 @@
 "Control from your wrist" = "Steuerung vom Handgelenk";
 "Watch Connected" = "Watch verbunden";
 "Open Watch App" = "Watch-App öffnen";
+
+/* Wi-Fi Guidance (scanner screen) */
+"WifiBannerTitle" = "WLAN auf beiden Geräten einschalten — erforderlich";
+"WifiBannerBody" = "Kein Netzwerk nötig — die Geräte verbinden sich direkt.";
+"WifiEscalationTip" = "Suche läuft… Prüfe, ob WLAN eingeschaltet ist — auf diesem und dem anderen Gerät. Im Kontrollzentrum deaktiviert zählt als aus: nutze Einstellungen > WLAN.";

--- a/RemoteCam/de-DE.lproj/Localizable.strings
+++ b/RemoteCam/de-DE.lproj/Localizable.strings
@@ -327,6 +327,6 @@
 "Open Watch App" = "Watch-App öffnen";
 
 /* Wi-Fi Guidance (scanner screen) */
-"WifiBannerTitle" = "WLAN auf beiden Geräten einschalten — erforderlich";
+"WifiBannerTitle" = "WLAN AUF BEIDEN GERÄTEN EINSCHALTEN — ERFORDERLICH";
 "WifiBannerBody" = "Kein Netzwerk nötig — die Geräte verbinden sich direkt.";
 "WifiEscalationTip" = "Suche läuft… Prüfe, ob WLAN eingeschaltet ist — auf diesem und dem anderen Gerät. Im Kontrollzentrum deaktiviert zählt als aus: nutze Einstellungen > WLAN.";

--- a/RemoteCam/en.lproj/Localizable.strings
+++ b/RemoteCam/en.lproj/Localizable.strings
@@ -325,3 +325,8 @@
 "Control from your wrist" = "Control from your wrist";
 "Watch Connected" = "Watch Connected";
 "Open Watch App" = "Open Watch App";
+
+/* Wi-Fi Guidance (scanner screen) */
+"WifiBannerTitle" = "Turn on Wi-Fi on both devices — required";
+"WifiBannerBody" = "No network needed — the devices connect directly.";
+"WifiEscalationTip" = "Still searching… Check Wi-Fi is on — on this device and the other one. Turning it off in Control Center still counts as off: use Settings > Wi-Fi.";

--- a/RemoteCam/en.lproj/Localizable.strings
+++ b/RemoteCam/en.lproj/Localizable.strings
@@ -327,6 +327,6 @@
 "Open Watch App" = "Open Watch App";
 
 /* Wi-Fi Guidance (scanner screen) */
-"WifiBannerTitle" = "Turn on Wi-Fi on both devices — required";
+"WifiBannerTitle" = "TURN ON WI-FI ON BOTH DEVICES — REQUIRED";
 "WifiBannerBody" = "No network needed — the devices connect directly.";
 "WifiEscalationTip" = "Still searching… Check Wi-Fi is on — on this device and the other one. Turning it off in Control Center still counts as off: use Settings > Wi-Fi.";

--- a/RemoteCam/es-MX.lproj/Localizable.strings
+++ b/RemoteCam/es-MX.lproj/Localizable.strings
@@ -222,6 +222,6 @@
 "Open Watch App" = "Abrir app del Watch";
 
 /* Wi-Fi Guidance (scanner screen) */
-"WifiBannerTitle" = "Activa el Wi-Fi en ambos dispositivos — obligatorio";
+"WifiBannerTitle" = "ACTIVA EL WI-FI EN AMBOS DISPOSITIVOS — OBLIGATORIO";
 "WifiBannerBody" = "No se necesita red — los dispositivos se conectan directamente.";
 "WifiEscalationTip" = "Seguimos buscando… Verifica que el Wi-Fi esté activado en este dispositivo y en el otro. Apagarlo desde el Centro de Control cuenta como apagado: usa Ajustes > Wi-Fi.";

--- a/RemoteCam/es-MX.lproj/Localizable.strings
+++ b/RemoteCam/es-MX.lproj/Localizable.strings
@@ -220,3 +220,8 @@
 "Control from your wrist" = "Controla desde tu muñeca";
 "Watch Connected" = "Watch conectado";
 "Open Watch App" = "Abrir app del Watch";
+
+/* Wi-Fi Guidance (scanner screen) */
+"WifiBannerTitle" = "Activa el Wi-Fi en ambos dispositivos — obligatorio";
+"WifiBannerBody" = "No se necesita red — los dispositivos se conectan directamente.";
+"WifiEscalationTip" = "Seguimos buscando… Verifica que el Wi-Fi esté activado en este dispositivo y en el otro. Apagarlo desde el Centro de Control cuenta como apagado: usa Ajustes > Wi-Fi.";

--- a/RemoteCam/fr-FR.lproj/Localizable.strings
+++ b/RemoteCam/fr-FR.lproj/Localizable.strings
@@ -222,6 +222,6 @@
 "Open Watch App" = "Ouvrir l'app Watch";
 
 /* Wi-Fi Guidance (scanner screen) */
-"WifiBannerTitle" = "Activez le Wi-Fi sur les deux appareils — obligatoire";
+"WifiBannerTitle" = "ACTIVEZ LE WI-FI SUR LES DEUX APPAREILS — OBLIGATOIRE";
 "WifiBannerBody" = "Aucun réseau requis — les appareils se connectent directement.";
 "WifiEscalationTip" = "Recherche en cours… Vérifiez que le Wi-Fi est activé sur cet appareil et sur l'autre. Désactivé dans le centre de contrôle compte comme éteint : utilisez Réglages > Wi-Fi.";

--- a/RemoteCam/fr-FR.lproj/Localizable.strings
+++ b/RemoteCam/fr-FR.lproj/Localizable.strings
@@ -220,3 +220,8 @@
 "Control from your wrist" = "Contrôlez depuis votre poignet";
 "Watch Connected" = "Watch connectée";
 "Open Watch App" = "Ouvrir l'app Watch";
+
+/* Wi-Fi Guidance (scanner screen) */
+"WifiBannerTitle" = "Activez le Wi-Fi sur les deux appareils — obligatoire";
+"WifiBannerBody" = "Aucun réseau requis — les appareils se connectent directement.";
+"WifiEscalationTip" = "Recherche en cours… Vérifiez que le Wi-Fi est activé sur cet appareil et sur l'autre. Désactivé dans le centre de contrôle compte comme éteint : utilisez Réglages > Wi-Fi.";

--- a/RemoteCam/it.lproj/Localizable.strings
+++ b/RemoteCam/it.lproj/Localizable.strings
@@ -204,3 +204,8 @@
 "Control from your wrist" = "Controlla dal tuo polso";
 "Watch Connected" = "Watch connesso";
 "Open Watch App" = "Apri l'app Watch";
+
+/* Wi-Fi Guidance (scanner screen) */
+"WifiBannerTitle" = "Attiva il Wi-Fi su entrambi i dispositivi — obbligatorio";
+"WifiBannerBody" = "Nessuna rete necessaria — i dispositivi si collegano direttamente.";
+"WifiEscalationTip" = "Ricerca in corso… Controlla che il Wi-Fi sia attivo su questo dispositivo e sull'altro. Spento dal Centro di Controllo conta come spento: usa Impostazioni > Wi-Fi.";

--- a/RemoteCam/it.lproj/Localizable.strings
+++ b/RemoteCam/it.lproj/Localizable.strings
@@ -206,6 +206,6 @@
 "Open Watch App" = "Apri l'app Watch";
 
 /* Wi-Fi Guidance (scanner screen) */
-"WifiBannerTitle" = "Attiva il Wi-Fi su entrambi i dispositivi — obbligatorio";
+"WifiBannerTitle" = "ATTIVA IL WI-FI SU ENTRAMBI I DISPOSITIVI — OBBLIGATORIO";
 "WifiBannerBody" = "Nessuna rete necessaria — i dispositivi si collegano direttamente.";
 "WifiEscalationTip" = "Ricerca in corso… Controlla che il Wi-Fi sia attivo su questo dispositivo e sull'altro. Spento dal Centro di Controllo conta come spento: usa Impostazioni > Wi-Fi.";

--- a/RemoteCam/ja.lproj/Localizable.strings
+++ b/RemoteCam/ja.lproj/Localizable.strings
@@ -325,3 +325,8 @@
 "Control from your wrist" = "手首からコントロール";
 "Watch Connected" = "Watch接続済み";
 "Open Watch App" = "Watchアプリを開く";
+
+/* Wi-Fi Guidance (scanner screen) */
+"WifiBannerTitle" = "両方のデバイスでWi-Fiをオンにしてください（必須）";
+"WifiBannerBody" = "ネットワーク接続は不要です。デバイス同士が直接つながります。";
+"WifiEscalationTip" = "検索中… このデバイスと相手のデバイスの両方でWi-Fiがオンになっているか確認してください。コントロールセンターでオフにした場合もオフ扱いになります。設定 > Wi-Fi から有効にしてください。";

--- a/RemoteCam/ko.lproj/Localizable.strings
+++ b/RemoteCam/ko.lproj/Localizable.strings
@@ -325,3 +325,8 @@
 "Control from your wrist" = "손목에서 제어하세요";
 "Watch Connected" = "Watch 연결됨";
 "Open Watch App" = "Watch 앱 열기";
+
+/* Wi-Fi Guidance (scanner screen) */
+"WifiBannerTitle" = "두 기기 모두 Wi-Fi를 켜세요 — 필수";
+"WifiBannerBody" = "네트워크는 필요 없습니다. 기기끼리 직접 연결됩니다.";
+"WifiEscalationTip" = "계속 검색 중… 이 기기와 상대 기기 모두 Wi-Fi가 켜져 있는지 확인하세요. 제어 센터에서 끈 것도 꺼진 상태입니다. 설정 > Wi-Fi에서 켜세요.";

--- a/RemoteCam/pt-BR.lproj/Localizable.strings
+++ b/RemoteCam/pt-BR.lproj/Localizable.strings
@@ -325,3 +325,8 @@
 "Control from your wrist" = "Controle pelo seu pulso";
 "Watch Connected" = "Watch conectado";
 "Open Watch App" = "Abrir app do Watch";
+
+/* Wi-Fi Guidance (scanner screen) */
+"WifiBannerTitle" = "Ative o Wi-Fi nos dois aparelhos — obrigatório";
+"WifiBannerBody" = "Nenhuma rede é necessária — os aparelhos se conectam diretamente.";
+"WifiEscalationTip" = "Ainda procurando… Verifique se o Wi-Fi está ligado neste aparelho e no outro. Desligar pela Central de Controle também conta como desligado: use Ajustes > Wi-Fi.";

--- a/RemoteCam/pt-BR.lproj/Localizable.strings
+++ b/RemoteCam/pt-BR.lproj/Localizable.strings
@@ -327,6 +327,6 @@
 "Open Watch App" = "Abrir app do Watch";
 
 /* Wi-Fi Guidance (scanner screen) */
-"WifiBannerTitle" = "Ative o Wi-Fi nos dois aparelhos — obrigatório";
+"WifiBannerTitle" = "ATIVE O WI-FI NOS DOIS APARELHOS — OBRIGATÓRIO";
 "WifiBannerBody" = "Nenhuma rede é necessária — os aparelhos se conectam diretamente.";
 "WifiEscalationTip" = "Ainda procurando… Verifique se o Wi-Fi está ligado neste aparelho e no outro. Desligar pela Central de Controle também conta como desligado: use Ajustes > Wi-Fi.";

--- a/RemoteCam/zh-Hans.lproj/Localizable.strings
+++ b/RemoteCam/zh-Hans.lproj/Localizable.strings
@@ -325,3 +325,8 @@
 "Control from your wrist" = "从手腕控制";
 "Watch Connected" = "手表已连接";
 "Open Watch App" = "打开手表应用";
+
+/* Wi-Fi Guidance (scanner screen) */
+"WifiBannerTitle" = "请在两台设备上开启Wi-Fi（必须）";
+"WifiBannerBody" = "无需连接网络——设备之间直接连接。";
+"WifiEscalationTip" = "仍在搜索… 请确认这台设备和另一台设备的Wi-Fi都已开启。在控制中心关闭也算关闭：请前往 设置 > Wi-Fi 开启。";

--- a/RemoteCamTests/DeviceScannerSnapshotTests.swift
+++ b/RemoteCamTests/DeviceScannerSnapshotTests.swift
@@ -28,17 +28,19 @@ final class DeviceScannerSnapshotTests: SnapshotTestCase {
         return renderScreen(named: name, screen)
     }
 
-    func testRemoteModeShowsWifiBanner() {
+    func testRemoteModeShowsWifiBanner() throws {
         let image = renderScanner(named: "scanner-remote-wifi-banner") { model in
             model.role = .monitor
         }
+        try skipPixelAssertsIfHeadless()
         assertRendered(image)
     }
 
-    func testCameraModeShowsWifiBanner() {
+    func testCameraModeShowsWifiBanner() throws {
         let image = renderScanner(named: "scanner-camera-wifi-banner") { model in
             model.role = .camera
         }
+        try skipPixelAssertsIfHeadless()
         assertRendered(image)
     }
 
@@ -46,7 +48,7 @@ final class DeviceScannerSnapshotTests: SnapshotTestCase {
     /// threshold, and verify the TimelineView surfaces the Wi-Fi tip. Slow by
     /// design (~16s) — it is the only test that exercises the actual
     /// TimelineView wiring rather than the pure function.
-    func testEscalationTipAppearsAfterFifteenSeconds() {
+    func testEscalationTipAppearsAfterFifteenSeconds() throws {
         let model = DeviceScannerViewModel()
         model.role = .monitor
         model.startedScanning()
@@ -67,10 +69,12 @@ final class DeviceScannerSnapshotTests: SnapshotTestCase {
         while Date() < deadline {
             RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.5))
         }
+        // Behavioral check first — it must hold on every runner, headless or not.
         XCTAssertTrue(model.shouldShowWifiEscalation(now: Date()),
                       "escalation should be active 16s after scanning started")
 
         let image = renderScreen(named: "scanner-remote-wifi-escalation", screen)
+        try skipPixelAssertsIfHeadless()
         assertRendered(image)
     }
 }

--- a/RemoteCamTests/DeviceScannerSnapshotTests.swift
+++ b/RemoteCamTests/DeviceScannerSnapshotTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+import SwiftUI
+@testable import RemoteShutter
+
+/// Renders `DeviceScannerView` in a real window across its role states and
+/// attaches PNGs to the test result. Covers the Wi-Fi guidance banner in both
+/// roles, and drives the 15s escalation tip through a real TimelineView tick —
+/// the one behavior no synchronous view-model test can observe.
+@MainActor
+final class DeviceScannerSnapshotTests: SnapshotTestCase {
+
+    private func renderScanner(named name: String,
+                               configure: (DeviceScannerViewModel) -> Void) -> UIImage {
+        let model = DeviceScannerViewModel()
+        configure(model)
+        let screen = NavigationView {
+            DeviceScannerView(
+                viewModel: model,
+                onStartScanning: {},
+                onStopScanning: {},
+                onSelectPeer: { _ in },
+                onShareApp: {},
+                onOpenSettings: {},
+                onHelp: {}
+            )
+            .navigationTitle(NSLocalizedString("Scan for devices", comment: ""))
+            .navigationBarTitleDisplayMode(.large)
+        }
+        return renderScreen(named: name, screen)
+    }
+
+    func testRemoteModeShowsWifiBanner() {
+        let image = renderScanner(named: "scanner-remote-wifi-banner") { model in
+            model.role = .monitor
+        }
+        assertHasChrome(image)
+    }
+
+    func testCameraModeShowsWifiBanner() {
+        let image = renderScanner(named: "scanner-camera-wifi-banner") { model in
+            model.role = .camera
+        }
+        assertHasChrome(image)
+    }
+
+    /// End-to-end escalation: start scanning, let the real clock pass the 15s
+    /// threshold, and verify the TimelineView surfaces the Wi-Fi tip. Slow by
+    /// design (~16s) — it is the only test that exercises the actual
+    /// TimelineView wiring rather than the pure function.
+    func testEscalationTipAppearsAfterFifteenSeconds() {
+        let model = DeviceScannerViewModel()
+        model.role = .monitor
+        model.startedScanning()
+
+        let screen = DeviceScannerView(
+            viewModel: model,
+            onStartScanning: {},
+            onStopScanning: {},
+            onSelectPeer: { _ in },
+            onShareApp: {},
+            onOpenSettings: {},
+            onHelp: {}
+        )
+        _ = renderScreen(named: "scanner-remote-scanning", screen)
+
+        // Let the run loop turn until the threshold has genuinely passed.
+        let deadline = Date(timeIntervalSinceNow: 16.5)
+        while Date() < deadline {
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.5))
+        }
+        XCTAssertTrue(model.shouldShowWifiEscalation(now: Date()),
+                      "escalation should be active 16s after scanning started")
+
+        let image = renderScreen(named: "scanner-remote-wifi-escalation", screen)
+        assertHasChrome(image)
+    }
+}

--- a/RemoteCamTests/DeviceScannerSnapshotTests.swift
+++ b/RemoteCamTests/DeviceScannerSnapshotTests.swift
@@ -9,23 +9,22 @@ import SwiftUI
 @MainActor
 final class DeviceScannerSnapshotTests: SnapshotTestCase {
 
+    // NavigationView deliberately omitted: a UIKit-backed root defeats the
+    // headless-CI ImageRenderer fallback (blank render). The scanner screen
+    // is light-themed, so assertions check render variance, not dark chrome.
     private func renderScanner(named name: String,
                                configure: (DeviceScannerViewModel) -> Void) -> UIImage {
         let model = DeviceScannerViewModel()
         configure(model)
-        let screen = NavigationView {
-            DeviceScannerView(
-                viewModel: model,
-                onStartScanning: {},
-                onStopScanning: {},
-                onSelectPeer: { _ in },
-                onShareApp: {},
-                onOpenSettings: {},
-                onHelp: {}
-            )
-            .navigationTitle(NSLocalizedString("Scan for devices", comment: ""))
-            .navigationBarTitleDisplayMode(.large)
-        }
+        let screen = DeviceScannerView(
+            viewModel: model,
+            onStartScanning: {},
+            onStopScanning: {},
+            onSelectPeer: { _ in },
+            onShareApp: {},
+            onOpenSettings: {},
+            onHelp: {}
+        )
         return renderScreen(named: name, screen)
     }
 
@@ -33,14 +32,14 @@ final class DeviceScannerSnapshotTests: SnapshotTestCase {
         let image = renderScanner(named: "scanner-remote-wifi-banner") { model in
             model.role = .monitor
         }
-        assertHasChrome(image)
+        assertRendered(image)
     }
 
     func testCameraModeShowsWifiBanner() {
         let image = renderScanner(named: "scanner-camera-wifi-banner") { model in
             model.role = .camera
         }
-        assertHasChrome(image)
+        assertRendered(image)
     }
 
     /// End-to-end escalation: start scanning, let the real clock pass the 15s
@@ -72,6 +71,6 @@ final class DeviceScannerSnapshotTests: SnapshotTestCase {
                       "escalation should be active 16s after scanning started")
 
         let image = renderScreen(named: "scanner-remote-wifi-escalation", screen)
-        assertHasChrome(image)
+        assertRendered(image)
     }
 }

--- a/RemoteCamTests/DeviceScannerViewModelTests.swift
+++ b/RemoteCamTests/DeviceScannerViewModelTests.swift
@@ -350,4 +350,69 @@ final class DeviceScannerViewModelTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
         cancellable.cancel()
     }
+
+    // MARK: - Wi-Fi Escalation
+
+    func testScanStartedAtLifecycle() {
+        let vm = DeviceScannerViewModel()
+        XCTAssertNil(vm.scanStartedAt)
+
+        vm.startedScanning()
+        XCTAssertNotNil(vm.scanStartedAt)
+
+        vm.stoppedScanning()
+        XCTAssertNil(vm.scanStartedAt)
+
+        vm.startedScanning()
+        vm.scanningFailed()
+        XCTAssertNil(vm.scanStartedAt)
+    }
+
+    func testWifiEscalationRequiresScanning() {
+        let start = Date(timeIntervalSince1970: 1_000)
+        let later = start.addingTimeInterval(60)
+        XCTAssertFalse(DeviceScannerViewModel.shouldShowWifiEscalation(
+            isScanning: false, hasPeers: false, scanStartedAt: start, now: later))
+    }
+
+    func testWifiEscalationSuppressedWhenPeersFound() {
+        let start = Date(timeIntervalSince1970: 1_000)
+        let later = start.addingTimeInterval(60)
+        XCTAssertFalse(DeviceScannerViewModel.shouldShowWifiEscalation(
+            isScanning: true, hasPeers: true, scanStartedAt: start, now: later))
+    }
+
+    func testWifiEscalationRequiresStartDate() {
+        XCTAssertFalse(DeviceScannerViewModel.shouldShowWifiEscalation(
+            isScanning: true, hasPeers: false, scanStartedAt: nil,
+            now: Date(timeIntervalSince1970: 1_000)))
+    }
+
+    func testWifiEscalationBeforeThreshold() {
+        let start = Date(timeIntervalSince1970: 1_000)
+        XCTAssertFalse(DeviceScannerViewModel.shouldShowWifiEscalation(
+            isScanning: true, hasPeers: false, scanStartedAt: start,
+            now: start.addingTimeInterval(14.9)))
+    }
+
+    func testWifiEscalationAtAndAfterThreshold() {
+        let start = Date(timeIntervalSince1970: 1_000)
+        XCTAssertTrue(DeviceScannerViewModel.shouldShowWifiEscalation(
+            isScanning: true, hasPeers: false, scanStartedAt: start,
+            now: start.addingTimeInterval(15)))
+        XCTAssertTrue(DeviceScannerViewModel.shouldShowWifiEscalation(
+            isScanning: true, hasPeers: false, scanStartedAt: start,
+            now: start.addingTimeInterval(300)))
+    }
+
+    func testWifiEscalationInstanceMethodReflectsState() {
+        let vm = DeviceScannerViewModel()
+        vm.startedScanning()
+        let start = vm.scanStartedAt ?? Date()
+        XCTAssertFalse(vm.shouldShowWifiEscalation(now: start.addingTimeInterval(5)))
+        XCTAssertTrue(vm.shouldShowWifiEscalation(now: start.addingTimeInterval(20)))
+
+        vm.addPeer(MCPeerID(displayName: "TestDevice"))
+        XCTAssertFalse(vm.shouldShowWifiEscalation(now: start.addingTimeInterval(20)))
+    }
 }

--- a/RemoteCamTests/DeviceScannerViewModelTests.swift
+++ b/RemoteCamTests/DeviceScannerViewModelTests.swift
@@ -405,14 +405,22 @@ final class DeviceScannerViewModelTests: XCTestCase {
             now: start.addingTimeInterval(300)))
     }
 
-    func testWifiEscalationInstanceMethodReflectsState() {
+    func testWifiEscalationInstanceMethodReflectsState() throws {
         let vm = DeviceScannerViewModel()
         vm.startedScanning()
-        let start = vm.scanStartedAt ?? Date()
+        let start = try XCTUnwrap(vm.scanStartedAt)
         XCTAssertFalse(vm.shouldShowWifiEscalation(now: start.addingTimeInterval(5)))
         XCTAssertTrue(vm.shouldShowWifiEscalation(now: start.addingTimeInterval(20)))
 
         vm.addPeer(MCPeerID(displayName: "TestDevice"))
         XCTAssertFalse(vm.shouldShowWifiEscalation(now: start.addingTimeInterval(20)))
+    }
+
+    func testWifiEscalationSuppressedAfterStopScanning() throws {
+        let vm = DeviceScannerViewModel()
+        vm.startedScanning()
+        let start = try XCTUnwrap(vm.scanStartedAt)
+        vm.stoppedScanning()
+        XCTAssertFalse(vm.shouldShowWifiEscalation(now: start.addingTimeInterval(60)))
     }
 }

--- a/RemoteCamTests/SnapshotTestSupport.swift
+++ b/RemoteCamTests/SnapshotTestSupport.swift
@@ -26,7 +26,20 @@ class SnapshotTestCase: XCTestCase {
         super.tearDown()
     }
 
+    /// True when the last renderScreen call fell back to ImageRenderer
+    /// (headless CI). ScrollView-rooted screens produce no content on that
+    /// path — tests for such screens should skip pixel assertions when set.
+    private(set) var usedImageRendererFallback = false
+
+    func skipPixelAssertsIfHeadless() throws {
+        if usedImageRendererFallback {
+            throw XCTSkip("Headless CI: window render blank and ScrollView content "
+                          + "does not lay out under ImageRenderer — pixel assertions skipped")
+        }
+    }
+
     func renderScreen<Screen: View>(named name: String, _ screen: Screen) -> UIImage {
+        usedImageRendererFallback = false
         let host = UIHostingController(rootView: screen)
         window.rootViewController = host
         window.makeKeyAndVisible()
@@ -61,6 +74,7 @@ class SnapshotTestCase: XCTestCase {
             if let rendered = renderer.uiImage {
                 image = rendered
             }
+            usedImageRendererFallback = true
         }
 
         let attachment = XCTAttachment(image: image)

--- a/RemoteCamTests/SnapshotTestSupport.swift
+++ b/RemoteCamTests/SnapshotTestSupport.swift
@@ -67,6 +67,13 @@ class SnapshotTestCase: XCTestCase {
         attachment.name = name
         attachment.lifetime = .keepAlways
         add(attachment)
+
+        // Optional loose-file export (e.g. for PR screenshots): run with
+        // TEST_RUNNER_SNAPSHOT_EXPORT_DIR=<host dir> to also write PNGs there.
+        if let dir = ProcessInfo.processInfo.environment["SNAPSHOT_EXPORT_DIR"],
+           let png = image.pngData() {
+            try? png.write(to: URL(fileURLWithPath: dir).appendingPathComponent("\(name).png"))
+        }
         return image
     }
 

--- a/RemoteCamTests/SnapshotTestSupport.swift
+++ b/RemoteCamTests/SnapshotTestSupport.swift
@@ -116,6 +116,33 @@ class SnapshotTestCase: XCTestCase {
                       file: file, line: line)
     }
 
+    /// Light-theme screens can't promise dark pixels (hasChrome's contract),
+    /// especially on the CI ImageRenderer path where UIKit-backed subviews are
+    /// omitted. A real render still has tonal variance; a failed one is a
+    /// uniform fill. Samples the same coarse grid as hasChrome.
+    func assertRendered(_ image: UIImage, file: StaticString = #filePath, line: UInt = #line) {
+        guard let cgImage = image.cgImage,
+              let data = cgImage.dataProvider?.data,
+              let bytes = CFDataGetBytePtr(data) else {
+            XCTFail("Could not read render pixels", file: file, line: line)
+            return
+        }
+        let bytesPerRow = cgImage.bytesPerRow
+        let bytesPerPixel = cgImage.bitsPerPixel / 8
+        var minLum = 255, maxLum = 0
+        for row in stride(from: 0, to: cgImage.height, by: 32) {
+            for col in stride(from: 0, to: cgImage.width, by: 32) {
+                let offset = row * bytesPerRow + col * bytesPerPixel
+                let luminance = (Int(bytes[offset]) + Int(bytes[offset + 1]) + Int(bytes[offset + 2])) / 3
+                minLum = min(minLum, luminance)
+                maxLum = max(maxLum, luminance)
+            }
+        }
+        XCTAssertGreaterThanOrEqual(maxLum - minLum, 60,
+                                    "Expected tonal variance in the render (got \(minLum)...\(maxLum)) — looks like a blank/uniform fill",
+                                    file: file, line: line)
+    }
+
     /// A stand-in for the streamed camera frame: a gradient "scene" with a
     /// bright subject, so snapshots show the live-feed area realistically.
     func syntheticCameraFrame(size: CGSize = CGSize(width: 1920, height: 1080)) -> UIImage {

--- a/RemoteShutter.xcodeproj/project.pbxproj
+++ b/RemoteShutter.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		AB12CD34EF5601789ABC0DE8 /* CameraScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DE7 /* CameraScreenView.swift */; };
 		AB12CD34EF5601789ABC0DE4 /* RecordingPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DE3 /* RecordingPipelineTests.swift */; };
 		AB12CD34EF5601789ABC0DEA /* CameraScreenSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DE9 /* CameraScreenSnapshotTests.swift */; };
+		C4F2A81D9E3B47CA8D5E1A02 /* DeviceScannerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F2A81D9E3B47CA8D5E1A01 /* DeviceScannerSnapshotTests.swift */; };
 		AB12CD34EF5601789ABC0DFC /* SessionTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DFB /* SessionTestSupport.swift */; };
 		AB12CD34EF5601789ABC0DEC /* SnapshotTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DEB /* SnapshotTestSupport.swift */; };
 		AB12CD34EF5601789ABC0DEE /* MonitorScreenSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DED /* MonitorScreenSnapshotTests.swift */; };
@@ -312,6 +313,7 @@
 		AB12CD34EF5601789ABC0DE7 /* CameraScreenView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CameraScreenView.swift; sourceTree = "<group>"; };
 		AB12CD34EF5601789ABC0DE3 /* RecordingPipelineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecordingPipelineTests.swift; sourceTree = "<group>"; };
 		AB12CD34EF5601789ABC0DE9 /* CameraScreenSnapshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CameraScreenSnapshotTests.swift; sourceTree = "<group>"; };
+		C4F2A81D9E3B47CA8D5E1A01 /* DeviceScannerSnapshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeviceScannerSnapshotTests.swift; sourceTree = "<group>"; };
 		AB12CD34EF5601789ABC0DFB /* SessionTestSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SessionTestSupport.swift; sourceTree = "<group>"; };
 		AB12CD34EF5601789ABC0DEB /* SnapshotTestSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnapshotTestSupport.swift; sourceTree = "<group>"; };
 		AB12CD34EF5601789ABC0DED /* MonitorScreenSnapshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MonitorScreenSnapshotTests.swift; sourceTree = "<group>"; };
@@ -548,6 +550,7 @@
 				A342ACE91A767718D76C4C60 /* CaptureEngineTests.swift */,
 				AB12CD34EF5601789ABC0DE3 /* RecordingPipelineTests.swift */,
 				AB12CD34EF5601789ABC0DE9 /* CameraScreenSnapshotTests.swift */,
+				C4F2A81D9E3B47CA8D5E1A01 /* DeviceScannerSnapshotTests.swift */,
 				AB12CD34EF5601789ABC0DFB /* SessionTestSupport.swift */,
 				AB12CD34EF5601789ABC0DEB /* SnapshotTestSupport.swift */,
 				AB12CD34EF5601789ABC0DED /* MonitorScreenSnapshotTests.swift */,
@@ -1157,6 +1160,7 @@
 				E1660E880D768347CB5B3297 /* CaptureEngineTests.swift in Sources */,
 				AB12CD34EF5601789ABC0DE4 /* RecordingPipelineTests.swift in Sources */,
 				AB12CD34EF5601789ABC0DEA /* CameraScreenSnapshotTests.swift in Sources */,
+				C4F2A81D9E3B47CA8D5E1A02 /* DeviceScannerSnapshotTests.swift in Sources */,
 				AB12CD34EF5601789ABC0DFC /* SessionTestSupport.swift in Sources */,
 				AB12CD34EF5601789ABC0DEC /* SnapshotTestSupport.swift in Sources */,
 				AB12CD34EF5601789ABC0DEE /* MonitorScreenSnapshotTests.swift in Sources */,


### PR DESCRIPTION

## Screenshots

Rendered by the new `DeviceScannerSnapshotTests` (real window, iPhone 16 frame). The escalation shot is the real TimelineView firing 16s into a scan — not a mocked state.

| Remote Mode | Camera Mode | 15s escalation |
|---|---|---|
| ![remote](https://media.githubusercontent.com/media/security-union/remote-shutter/6ed6d97b9062df33c0534626fa71a022eff213f0/Docs/screenshots/wifi-guidance/scanner-remote-wifi-banner.png) | ![camera](https://media.githubusercontent.com/media/security-union/remote-shutter/6ed6d97b9062df33c0534626fa71a022eff213f0/Docs/screenshots/wifi-guidance/scanner-camera-wifi-banner.png) | ![escalation](https://media.githubusercontent.com/media/security-union/remote-shutter/6ed6d97b9062df33c0534626fa71a022eff213f0/Docs/screenshots/wifi-guidance/scanner-remote-wifi-escalation.png) |

