### PR TITLE
macOS support: full Mac Catalyst app with N-camera selection

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -62,6 +62,12 @@ jobs:
           CODE_SIGNING_ALLOWED=NO
           
     - name: Run Tests
+      # xcodebuild only forwards TEST_RUNNER_-prefixed variables into the
+      # test process (prefix stripped), so plain CI=true never reaches the
+      # tests. CaptureIntegrationTests reads CI to skip before touching TCC —
+      # a headless runner can never answer the camera prompt and would hang.
+      env:
+        TEST_RUNNER_CI: 'true'
       run: |
         xcodebuild \
           -workspace RemoteShutter.xcworkspace \

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -106,4 +106,30 @@ jobs:
         name: build-logs
         path: |
           ~/Library/Developer/Xcode/DerivedData/**/Logs/**
-        retention-days: 5 
+        retention-days: 5
+
+  build-mac-catalyst:
+    name: Build Mac Catalyst
+    runs-on: macos-26
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        lfs: true
+
+    - name: Setup Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '26.2'
+
+    - name: Build for Mac Catalyst
+      run: |
+        xcodebuild \
+          -workspace RemoteShutter.xcworkspace \
+          -scheme RemoteCam \
+          -destination 'platform=macOS,variant=Mac Catalyst' \
+          -configuration Debug \
+          build \
+          CODE_SIGNING_REQUIRED=NO \
+          CODE_SIGNING_ALLOWED=NO 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Remote Shutter is an iOS app (Swift, UIKit + SwiftUI) that turns two Apple devices into a remote-controlled camera system via peer-to-peer connectivity. One device acts as the **camera**, the other as the **monitor** (remote control). Published on the App Store.
+Remote Shutter is an iOS + Mac Catalyst app (Swift, UIKit + SwiftUI) that turns two Apple devices into a remote-controlled camera system via peer-to-peer connectivity. One device acts as the **camera**, the other as the **monitor** (remote control). A Mac can take either role; it selects among N attached cameras (built-in, Continuity, USB) rather than front/back. Published on the App Store (iOS).
 
 ## Build & Run
 
@@ -21,11 +21,17 @@ xcodebuild -workspace RemoteShutter.xcworkspace -scheme RemoteCam \
   -configuration Debug test \
   CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 
+# Build for Mac Catalyst (build-only in CI; tests run on the iOS Simulator)
+xcodebuild -workspace RemoteShutter.xcworkspace -scheme RemoteCam \
+  -destination 'platform=macOS,variant=Mac Catalyst' \
+  -configuration Debug build \
+  CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+
 # Release (via fastlane)
 fastlane release
 ```
 
-Always use `RemoteShutter.xcworkspace` (not `.xcodeproj`) due to CocoaPods. The scheme is `RemoteCam`. Minimum deployment target is iOS 15.0.
+Always use `RemoteShutter.xcworkspace` (not `.xcodeproj`) due to CocoaPods. The scheme is `RemoteCam`. Minimum deployment target is iOS 15.0; the same target builds for Mac Catalyst ("Optimize for Mac" idiom, device family `1,2,6`).
 
 ## Deployment
 
@@ -94,6 +100,17 @@ Uses Apple's **MultipeerConnectivity** framework (service type: `"RemoteCam"`), 
 - **FlatBuffers** (local podspec) — Wire-protocol serialization (iOS + watchOS targets)
 
 The session uses Swift's native `actor` for concurrency (see `Docs/ARCHITECTURE.md`).
+
+### macOS (Mac Catalyst)
+
+The Mac build is the same app target. Rules that matter when touching platform-y code:
+- Camera identity is `uniqueID`-based (`CameraDeviceDescriptor`, `CameraControlling.selectCameraDevice`); Mac cameras report `.unspecified` position, which serializes as `Back + has_unspecified_position` on the wire.
+- A monitor may only send `RemoteCmd.SelectCameraDevice` to a peer whose capabilities carried a non-empty `camera_devices` list — old decoders read unknown command actions as `TakePicture`. The gate lives in `SessionCoordinator` and is pinned by a loopback test.
+- WatchConnectivity does not exist on Catalyst: `WatchSessionManager` has a stub branch; keep new Watch code behind it.
+- Macs don't rotate: `getOrientation()` returns `.landscapeRight` on Catalyst; don't add rotation handling outside the `#if !targetEnvironment(macCatalyst)` paths.
+- Platform shims (sleep, System Settings deep links) use `#if targetEnvironment(macCatalyst)` — extend those branches rather than adding UIKit-only calls.
+- Preview frames are ALWAYS sent `.unreliable` (never `.reliable` — live preview drops, never queues); MC's datagram channel is warmed with a no-op ping at peer connect. Frame durations must be clamped into the `AVFrameRateRange`'s own CMTimes (`CaptureEngine.resolveFrameRate`), never rebuilt as `CMTimeMake(1, fps)`.
+- Hardware integration tests (real cameras, skip on simulator/CI): `xcodebuild test … -destination 'platform=macOS,variant=Mac Catalyst' -only-testing:RemoteShutterTests/CaptureIntegrationTests`.
 
 ### Feature Flags
 

--- a/Docs/ARCHITECTURE.md
+++ b/Docs/ARCHITECTURE.md
@@ -156,6 +156,52 @@ pushes a full **state snapshot** after every change (readiness, mode, zoom, lens
 countdown, events). Snapshots-not-events means a Watch that misses a message is
 corrected by the next push.
 
+## macOS (Mac Catalyst)
+
+The same app target builds for Mac Catalyst (`platform=macOS,variant=Mac
+Catalyst`); a Mac is a first-class peer in either role. What differs from iOS:
+
+- **Camera identity is a device list, not front/back.** Macs expose N cameras
+  (built-in, Continuity, USB) identified by `uniqueID`
+  (`CameraDeviceDescriptor`); external cameras report `.unspecified` position.
+  Capabilities advertise the list (`camera_devices` on the wire) and
+  `SelectCameraDevice` switches by ID — a monitor may only send it to peers
+  that advertised the list, because old decoders read unknown command actions
+  as TakePicture. The flip button on a Mac camera cycles through devices.
+- **Pickers.** The camera screen shows a local device-picker menu
+  (`FeatureFlags.ENABLE_LOCAL_CAMERA_PICKER`, Catalyst-only); the monitor's
+  flip button grows a long-press device menu when the peer advertised devices.
+- **No WatchConnectivity.** `WatchSessionManager` compiles as a stub on
+  Catalyst (`watchPaired` stays false), so the Watch role never surfaces and
+  the coordinator's watch states never fire.
+- **Fixed orientation.** Macs don't rotate: `getOrientation()` reports
+  `.landscapeRight`, window resizes are not treated as rotations, and streamed
+  frames stay landscape-native.
+- **Shims.** Display sleep is held off via a `ProcessInfo` activity, and
+  settings deep links open System Settings privacy panes.
+
+### Capture invariants (hard-won on real Mac hardware)
+
+- **Frames are always sent `.unreliable`** — a live viewfinder drops stale
+  frames, it never queues them. MC's datagram channel negotiates for ~10s
+  after "Connected" and drops sends until ready, so `peerDidConnect` warms it
+  with one unreliable no-op `RequestFrame` (a stray one is a harmless credit
+  ack) — negotiation overlaps role selection.
+- **Frame durations come from the chosen `AVFrameRateRange`'s own CMTimes,**
+  never `CMTimeMake(1, fps)`: a UVC camera's "60 fps" is really 60.00024,
+  and integer durations throw on DAL hardware and silently wedge software
+  cameras (`CaptureEngine.resolveFrameRate` + duration clamp).
+- **A session that starts on a never-delivering source wedges** (running,
+  valid graph, zero buffers) and an input swap alone does not revive it —
+  the rig's first-frame watchdog falls back to a healthy device and bounces
+  the session (`CaptureEngine.restartSession`). Runtime errors and ended
+  interruptions resume via the same AVCam-style restart path.
+- The rig-level hardware integration suite is a local/manual gate (CI
+  runners have no cameras; the tests skip themselves):
+  `xcodebuild test -workspace RemoteShutter.xcworkspace -scheme RemoteCam
+  -destination 'platform=macOS,variant=Mac Catalyst'
+  -only-testing:RemoteShutterTests/CaptureIntegrationTests`
+
 ## Testing in one line each
 
 - **`LoopbackSessionTests`** — two real coordinators wired through an in-process

--- a/RemoteCam/AppDelegate.swift
+++ b/RemoteCam/AppDelegate.swift
@@ -9,13 +9,33 @@
 import UIKit
 import Photos
 
+/// Keeps the display awake while the app runs — a camera/monitor session dies
+/// if the screen sleeps. iOS: the idle timer. Catalyst: a ProcessInfo
+/// activity (the idle timer is a no-op on the Mac).
+enum SleepPreventer {
+    #if targetEnvironment(macCatalyst)
+    private static var activity: NSObjectProtocol?
+    #endif
+
+    static func preventDisplaySleep() {
+        #if targetEnvironment(macCatalyst)
+        guard activity == nil else { return }
+        activity = ProcessInfo.processInfo.beginActivity(
+            options: [.idleDisplaySleepDisabled, .userInitiated],
+            reason: "Remote Shutter keeps the display awake during camera sessions")
+        #else
+        UIApplication.shared.isIdleTimerDisabled = true
+        #endif
+    }
+}
+
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         Task { await StoreManager.shared.loadProducts() }
 
-        UIApplication.shared.isIdleTimerDisabled = true
+        SleepPreventer.preventDisplaySleep()
         WatchSessionManager.shared.activate()
 
         return true

--- a/RemoteCam/CameraControlling.swift
+++ b/RemoteCam/CameraControlling.swift
@@ -36,6 +36,18 @@ protocol CameraControlling: AnyObject {
     func toggleFlash() async throws -> AVCaptureDevice.FlashMode
     func toggleTorch() async throws -> AVCaptureDevice.TorchMode
     func toggleCamera() async throws -> (AVCaptureDevice.FlashMode?, AVCaptureDevice.Position)
+    /// All selectable local cameras, in stable discovery order (a Mac exposes
+    /// N devices; an iPhone its front/back pair).
+    func availableCameraDevices() async -> [CameraDeviceDescriptor]
+    /// The active device, or nil before setup completes.
+    func currentCameraDevice() async -> CameraDeviceDescriptor?
+    /// Switches capture to the device with this uniqueID, falling back to a
+    /// same-position or first-available device if it vanished (unplugged).
+    func selectCameraDevice(uniqueID: String) async throws -> CameraSelectionResult
+    /// Whether a video frame arrives within `timeout` from now. A camera can
+    /// accept the input swap and still never deliver (a wedged virtual
+    /// camera) — switch responses are only successful once this confirms.
+    func awaitFrameDelivery(timeout: TimeInterval) async -> Bool
     func setTorchMode(mode: AVCaptureDevice.TorchMode) async throws -> AVCaptureDevice.TorchMode
     func setVideoQuality(resolution: VideoResolution, frameRate: VideoFrameRate) async -> (VideoResolution, VideoFrameRate)?
     func setPhotoQuality(format: PhotoFormat, hdrMode: HDRMode) async -> (PhotoFormat, HDRMode)?

--- a/RemoteCam/CameraDeviceDescriptor.swift
+++ b/RemoteCam/CameraDeviceDescriptor.swift
@@ -1,0 +1,90 @@
+//
+//  CameraDeviceDescriptor.swift
+//  RemoteShutter
+//
+//  Copyright © 2026 Security Union. All rights reserved.
+//
+
+import Foundation
+import AVFoundation
+
+/// One selectable physical camera, as the session and UI see it. Macs expose
+/// N cameras (built-in, Continuity, Desk View, external) rather than a
+/// front/back pair, so devices are identified by `uniqueID`; `position` is
+/// `.unspecified` when the hardware has no front/back identity.
+struct CameraDeviceDescriptor: Equatable {
+    let uniqueID: String
+    let localizedName: String
+    let position: AVCaptureDevice.Position
+    let deviceType: AVCaptureDevice.DeviceType
+    /// Connected but delivering no frames (a Mac's built-in camera in
+    /// clamshell mode). Shown grayed out in pickers; excluded from selection.
+    var isSuspended: Bool = false
+}
+
+extension CameraDeviceDescriptor {
+    init(device: AVCaptureDevice) {
+        self.init(
+            uniqueID: device.uniqueID,
+            localizedName: device.localizedName,
+            position: device.position,
+            deviceType: device.deviceType,
+            isSuspended: device.isSuspended)
+    }
+
+    /// Which device the front/back flip lands on. iOS flips position
+    /// (`flipPosition: true`); a Mac has no front/back, so the flip cycles
+    /// through the devices in list order. Suspended devices are skipped —
+    /// they are connected but deliver no frames.
+    static func nextToggleSelection(
+        currentID: String?,
+        available: [CameraDeviceDescriptor],
+        flipPosition: Bool
+    ) -> CameraDeviceDescriptor? {
+        let eligible = available.filter { !$0.isSuspended }
+        guard !eligible.isEmpty else { return nil }
+        if flipPosition {
+            guard let current = available.first(where: { $0.uniqueID == currentID }) else {
+                return nil
+            }
+            let target: AVCaptureDevice.Position = current.position == .back ? .front : .back
+            return eligible.first { $0.position == target }
+        }
+        guard let currentID,
+              let index = eligible.firstIndex(where: { $0.uniqueID == currentID }) else {
+            return eligible.first
+        }
+        return eligible[(index + 1) % eligible.count]
+    }
+
+    /// Which device a selection request should land on when the requested one
+    /// may have vanished (unplugged mid-request): exact ID match, else a
+    /// device at the same position, else the first available, else nil.
+    /// Suspended devices are never eligible — a suspended camera is
+    /// connected but delivers no frames.
+    static func resolveSelection(
+        requestedID: String,
+        available: [CameraDeviceDescriptor],
+        fallbackPosition: AVCaptureDevice.Position
+    ) -> CameraDeviceDescriptor? {
+        let eligible = available.filter { !$0.isSuspended }
+        if let exact = eligible.first(where: { $0.uniqueID == requestedID }) {
+            return exact
+        }
+        if let samePosition = eligible.first(where: { $0.position == fallbackPosition }) {
+            return samePosition
+        }
+        return eligible.first
+    }
+}
+
+/// What a completed device selection reports back to the session and UI: the
+/// new device plus the capture facts the monitor needs to refresh its controls.
+struct CameraSelectionResult {
+    let device: CameraDeviceDescriptor
+    /// nil when the device has no flash (every Mac camera).
+    let flashMode: AVCaptureDevice.FlashMode?
+    let availableLensTypes: [CameraLensType]
+    let zoomRange: RemoteCmd.ZoomRange
+    let currentZoom: CGFloat
+}

--- a/RemoteCam/CameraHostController.swift
+++ b/RemoteCam/CameraHostController.swift
@@ -21,7 +21,11 @@ final class CameraHostController: UIHostingController<CameraScreenView> {
 
     init(rig: CameraRig) {
         self.rig = rig
-        super.init(rootView: CameraScreenView(viewModel: rig.cameraViewModel))
+        super.init(rootView: CameraScreenView(
+            viewModel: rig.cameraViewModel,
+            onSelectCameraDevice: { [weak rig] uniqueID in
+                rig?.selectCameraDeviceLocally(uniqueID: uniqueID)
+            }))
     }
 
     @available(*, unavailable)
@@ -104,6 +108,11 @@ final class CameraHostController: UIHostingController<CameraScreenView> {
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
+        #if targetEnvironment(macCatalyst)
+        // Window resizes reach here on the Mac, but there is no device
+        // rotation — the capture orientation stays fixed (getOrientation()).
+        return
+        #else
         coordinator.animate(alongsideTransition: { [weak self] _ in
             guard let self else { return }
             // Mid-transition the window scene already reports the TARGET
@@ -119,6 +128,7 @@ final class CameraHostController: UIHostingController<CameraScreenView> {
             // torch state.
             self?.rig.restoreTorchAfterRotation()
         })
+        #endif
     }
 
     // MARK: - Permissions UI

--- a/RemoteCam/CameraRig.swift
+++ b/RemoteCam/CameraRig.swift
@@ -137,7 +137,108 @@ final class CameraRig {
         pipeline.onPhotosAccessDenied = { [weak self] in
             self?.onPhotosAccessDenied?()
         }
+        engine.onCameraDevicesChanged = { [weak self] in
+            // Hot-plug (fires on the session queue): refresh the picker and,
+            // when a monitor is connected, re-advertise capabilities.
+            Task { [weak self] in
+                guard let self else { return }
+                await self.refreshCameraDeviceList()
+                if !self.isWatchRemoteMode {
+                    self.session ! RemoteCmd.RequestCameraCapabilities()
+                }
+            }
+        }
     }
+
+    // MARK: - First-frame watchdog
+
+    /// A camera can be connected yet never deliver a frame (suspended
+    /// clamshell built-in, stalled virtual camera). Without a watchdog that
+    /// is an infinite spinner with no error. Armed after every session start
+    /// and device switch; on stall it falls back to the next healthy device
+    /// once, then surfaces an error.
+    private let watchdogGeneration = Locked(0)
+    private static let firstFrameTimeout: TimeInterval = 5
+
+    func armFirstFrameWatchdog(allowFallback: Bool = true) {
+        var generation = 0
+        watchdogGeneration.mutate { $0 += 1; generation = $0 }
+        let armedAt = Date().timeIntervalSinceReferenceDate
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(
+            deadline: .now() + Self.firstFrameTimeout
+        ) { [weak self] in
+            guard let self,
+                  self.watchdogGeneration.value == generation,
+                  self.streamingCoordinator.lastVideoFrameAt.value < armedAt else { return }
+            self.handleFrameStall(allowFallback: allowFallback)
+        }
+    }
+
+    /// Cancels any armed watchdog (screen teardown).
+    private func disarmFirstFrameWatchdog() {
+        watchdogGeneration.mutate { $0 += 1 }
+    }
+
+    private func handleFrameStall(allowFallback: Bool) {
+        Task { [weak self] in
+            guard let self else { return }
+            let current = await self.currentCameraDevice()
+            debugLog("CameraRig: no frames from \(current?.localizedName ?? "unknown camera") within \(Self.firstFrameTimeout)s")
+            let devices = await self.availableCameraDevices()
+            let next = devices.first { !$0.isSuspended && $0.uniqueID != current?.uniqueID }
+            guard allowFallback, let next,
+                  (try? await self.selectCameraDevice(uniqueID: next.uniqueID)) != nil else {
+                showError(NSLocalizedString("Camera is not delivering video", comment: ""))
+                return
+            }
+            debugLog("CameraRig: fell back to \(next.localizedName)")
+            // A session that started on the dead source can stay wedged
+            // (running, valid graph, no buffers) — bounce it to revive
+            // delivery on the fallback device.
+            self.engine.restartSession()
+            // One fallback attempt per stall — a second stall is an error.
+            self.armFirstFrameWatchdog(allowFallback: false)
+            if !self.isWatchRemoteMode {
+                self.session ! RemoteCmd.RequestCameraCapabilities()
+            }
+        }
+    }
+
+    // MARK: - Local camera-device picker
+
+    /// Publishes the selectable-device list + active device on the view model
+    /// (drives the camera screen's picker chrome).
+    func refreshCameraDeviceList() async {
+        let devices = await engine.availableCameraDevices()
+        let active = await engine.currentCameraDevice()
+        cameraViewModel.updateCameraDevices(devices, activeID: active?.uniqueID)
+    }
+
+    /// Device selection from the camera screen's own picker: switches the
+    /// device, confirms frames actually flow, then pushes fresh capabilities
+    /// to a connected monitor so its controls stay in sync. A camera that
+    /// accepts the swap but never delivers gets a visible error (the
+    /// watchdog restores a working device underneath).
+    func selectCameraDeviceLocally(uniqueID: String) {
+        Task { [weak self] in
+            guard let self else { return }
+            guard let result = try? await self.selectCameraDevice(uniqueID: uniqueID) else { return }
+            if await !self.awaitFrameDelivery(timeout: Self.frameConfirmTimeout) {
+                showError(String(
+                    format: NSLocalizedString("%@ is not delivering video", comment: "dead camera"),
+                    result.device.localizedName))
+            }
+            if !self.isWatchRemoteMode {
+                // The coordinator's camera state answers this by broadcasting
+                // capabilities — the same path a monitor's request takes.
+                self.session ! RemoteCmd.RequestCameraCapabilities()
+            }
+        }
+    }
+
+    /// Shorter than the watchdog (5s), longer than any healthy camera's
+    /// first frame (Continuity ≈ 2.6s measured).
+    static let frameConfirmTimeout: TimeInterval = 4
 
     /// Photos-library access denied while saving a finished video. Main thread.
     var onPhotosAccessDenied: (() -> Void)?
@@ -148,24 +249,41 @@ final class CameraRig {
 
     /// Configures and starts the capture session once (on the engine's session
     /// queue); safe to call on every appearance. The busy spinner shows while
-    /// the engine works — and now actually renders, since setup is off main.
+    /// the engine works.
+    ///
+    /// AVCam's ordering: the preview layer attaches to the (idle) session
+    /// BEFORE configuration, so the first rendered frame IS session start.
+    /// Attaching after `startRunning` mutates a live graph — trivial on an
+    /// iPhone, but a slow renegotiation on Mac hardware (UVC/Continuity),
+    /// which made the Mac preview lag iOS by seconds.
     func startCameraOnce() {
         guard !didInitializeCamera else { return }
         didInitializeCamera = true
         cameraViewModel.isBusy = true
-        engine.setupCamera(sampleBufferDelegate: streamingCoordinator) { [weak self] hasCamera in
-            // Completion arrives on main.
-            guard let self = self else { return }
-            self.cameraViewModel.isBusy = false
-            guard hasCamera else { return }
-            self.cameraViewModel.previewSession = self.engine.captureSession
-            self.sessionPublished.value = true
-            self.rotateCameraToOrientation(orientation: self.orientation)
+        cameraViewModel.previewSession = engine.captureSession
+        // Next main tick: the SwiftUI pass attaching the layer lands first,
+        // preserving AVCam's attach → configure → start happens-before.
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.engine.setupCamera(sampleBufferDelegate: self.streamingCoordinator) { [weak self] hasCamera in
+                // Completion arrives on main.
+                guard let self = self else { return }
+                self.cameraViewModel.isBusy = false
+                guard hasCamera else {
+                    self.cameraViewModel.previewSession = nil
+                    return
+                }
+                self.sessionPublished.value = true
+                self.rotateCameraToOrientation(orientation: self.orientation)
+                self.armFirstFrameWatchdog()
+                Task { await self.refreshCameraDeviceList() }
+            }
         }
     }
 
     /// Stops the capture session (screen teardown).
     func stopSession() {
+        disarmFirstFrameWatchdog()
         engine.stopSession()
     }
 
@@ -276,7 +394,40 @@ extension CameraRig: CameraControlling {
             // (also after a failed toggle, matching the previous behavior).
             rotateCameraToOrientation(orientation: orientation)
         }
-        return try await engine.toggleCamera(orientation: orientation)
+        let result = try await engine.toggleCamera(orientation: orientation)
+        armFirstFrameWatchdog()
+        await refreshCameraDeviceList()   // keep the local picker's checkmark honest
+        return result
+    }
+
+    func availableCameraDevices() async -> [CameraDeviceDescriptor] {
+        await engine.availableCameraDevices()
+    }
+
+    func awaitFrameDelivery(timeout: TimeInterval) async -> Bool {
+        let since = Date().timeIntervalSinceReferenceDate
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if streamingCoordinator.lastVideoFrameAt.value > since { return true }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        return false
+    }
+
+    func currentCameraDevice() async -> CameraDeviceDescriptor? {
+        await engine.currentCameraDevice()
+    }
+
+    func selectCameraDevice(uniqueID: String) async throws -> CameraSelectionResult {
+        let orientation = self.orientation
+        defer {
+            // Same post-swap preview rotation as toggleCamera.
+            rotateCameraToOrientation(orientation: orientation)
+        }
+        let result = try await engine.selectCameraDevice(uniqueID: uniqueID, orientation: orientation)
+        armFirstFrameWatchdog()
+        await refreshCameraDeviceList()   // keep the local picker's checkmark honest
+        return result
     }
 
     func toggleFlash() async throws -> AVCaptureDevice.FlashMode {

--- a/RemoteCam/CameraScreenView.swift
+++ b/RemoteCam/CameraScreenView.swift
@@ -16,6 +16,8 @@ import AVFoundation
 /// capture ownership and actor glue live on `CameraRig`.
 struct CameraScreenView: View {
     @ObservedObject var viewModel: CameraViewModel
+    /// Local device selection from the picker chrome (nil in previews/tests).
+    var onSelectCameraDevice: ((String) -> Void)?
 
     var body: some View {
         ZStack {
@@ -38,6 +40,20 @@ struct CameraScreenView: View {
             }
             .allowsHitTesting(false)
 
+            // Local camera-device picker, top leading — a Mac has N cameras.
+            if FeatureFlags.ENABLE_LOCAL_CAMERA_PICKER,
+               viewModel.availableCameraDevices.count > 1 {
+                VStack {
+                    HStack {
+                        cameraDevicePicker
+                        Spacer()
+                    }
+                    Spacer()
+                }
+                .padding(.top, 17)
+                .padding(.leading, 16)
+            }
+
             if viewModel.isBusy {
                 ProgressView()
                     .progressViewStyle(.circular)
@@ -50,6 +66,25 @@ struct CameraScreenView: View {
                 isRecording: viewModel.isRecordingTimerActive)
 
             CameraProgressOverlayView(viewModel: viewModel)
+        }
+    }
+
+    private var cameraDevicePicker: some View {
+        Menu {
+            ForEach(viewModel.availableCameraDevices, id: \.uniqueID) { device in
+                CameraDeviceMenuItem(
+                    name: device.localizedName,
+                    isActive: device.uniqueID == viewModel.activeCameraDeviceID,
+                    isSuspended: device.isSuspended,
+                    select: { onSelectCameraDevice?(device.uniqueID) })
+            }
+        } label: {
+            Image(systemName: "web.camera")
+                .font(.system(size: 20))
+                .foregroundColor(.white)
+                .frame(width: 44, height: 44)
+                .background(Color.black.opacity(0.4))
+                .clipShape(Circle())
         }
     }
 }
@@ -82,10 +117,13 @@ struct CameraPreviewView: UIViewRepresentable {
         if uiView.previewLayer.session !== session {
             uiView.previewLayer.session = session
         }
-        if let connection = uiView.previewLayer.connection,
-           connection.videoOrientation != videoOrientation {
-            connection.videoOrientation = videoOrientation
-        }
+        // Same policy as the capture connections (OrientationUtils): iOS
+        // rotates the preview to the interface; Mac cameras render native.
+        guard OrientationUtils.appliesInterfaceRotation,
+              let connection = uiView.previewLayer.connection,
+              connection.isVideoOrientationSupported,
+              connection.videoOrientation != videoOrientation else { return }
+        connection.videoOrientation = videoOrientation
     }
 }
 

--- a/RemoteCam/CameraViewModel.swift
+++ b/RemoteCam/CameraViewModel.swift
@@ -17,6 +17,24 @@ class CameraViewModel: ObservableObject {
     /// Spinner shown while the capture session is being configured.
     @Published var isBusy = false
 
+    // MARK: - Local Camera Devices (picker chrome; a Mac has N cameras)
+    @Published var availableCameraDevices: [CameraDeviceDescriptor] = []
+    @Published var activeCameraDeviceID: String?
+
+    func updateCameraDevices(_ devices: [CameraDeviceDescriptor], activeID: String?) {
+        DispatchQueue.main.async {
+            // Refreshes are frequent (Continuity cameras flap as the phone
+            // locks/idles); only publish real changes so the picker menu
+            // isn't rebuilt for identical content.
+            if self.availableCameraDevices != devices {
+                self.availableCameraDevices = devices
+            }
+            if self.activeCameraDeviceID != activeID {
+                self.activeCameraDeviceID = activeID
+            }
+        }
+    }
+
     // MARK: - Mode & Quality Status
     @Published var currentMode: RecordingMode = .Photo
     @Published var qualityInfo: String = "1080p 30fps"

--- a/RemoteCam/CaptureEngine.swift
+++ b/RemoteCam/CaptureEngine.swift
@@ -27,6 +27,11 @@ final class CaptureEngine: NSObject, AVCapturePhotoCaptureDelegate {
     override init() {
         super.init()
         sessionQueue.setSpecific(key: Self.sessionQueueKey, value: ())
+        observeDeviceConnections()
+    }
+
+    deinit {
+        deviceConnectionObservers.forEach(NotificationCenter.default.removeObserver)
     }
 
     /// Runs `body` on the session queue, inline when already there — so
@@ -54,6 +59,12 @@ final class CaptureEngine: NSObject, AVCapturePhotoCaptureDelegate {
     }
 
     let captureSession: AVCaptureSession = AVCaptureSession()
+
+    /// Whether the session is supposed to be running (between setup and
+    /// stopSession) — the reference for runtime-error recovery, per Apple's
+    /// AVCam resume pattern. sessionQueue-confined.
+    private var isExpectedToRun = false
+
     let audioDataOutput = AVCaptureAudioDataOutput()
 
     let videoDataOutput = AVCaptureVideoDataOutput()
@@ -131,10 +142,12 @@ final class CaptureEngine: NSObject, AVCapturePhotoCaptureDelegate {
         self.captureSession.beginConfiguration()
         self.captureSession.sessionPreset = .high
 
-        guard let videoDevice = preferredCamera(for: .back) ?? AVCaptureDevice.default(for: AVMediaType.video) else {
+        guard let videoDevice = initialCameraLocked() else {
             self.captureSession.commitConfiguration()
             return false
         }
+        refreshSuspensionObserversLocked()
+        lastNotifiedDevices = selectableDevicesLocked().map { CameraDeviceDescriptor(device: $0) }
         debugLog("🔍 SETUP CAMERA: using device=\(videoDevice.localizedName) type=\(videoDevice.deviceType.rawValue) isVirtual=\(!videoDevice.virtualDeviceSwitchOverVideoZoomFactors.isEmpty)")
 
         do {
@@ -143,9 +156,6 @@ final class CaptureEngine: NSObject, AVCapturePhotoCaptureDelegate {
             self.captureSession.addOutput(self.videoDataOutput)
 
             try self.setFrameRate(framerate: fpsSetting.value, videoDevice: videoDevice)
-
-            // Gather complete camera capabilities for both front and back cameras
-            self.gatherAllCameraCapabilitiesLocked()
 
             // Initialize current state
             self.updateAvailableLensTypes(for: videoDevice.position)
@@ -167,6 +177,13 @@ final class CaptureEngine: NSObject, AVCapturePhotoCaptureDelegate {
             self.captureSession.commitConfiguration()
             self.applyDesiredTorchLocked()   // commitConfiguration can reset the torch
             self.captureSession.startRunning()
+            self.isExpectedToRun = true
+
+            // Capability probing AFTER the session is live (AVCam configures
+            // minimally and probes nothing at setup): on a Mac this walks
+            // every attached camera's formats — including a wireless
+            // Continuity iPhone — and must never delay the first frame.
+            self.gatherAllCameraCapabilitiesLocked()
         } catch let error as NSError {
             print("error \(error)")
         }
@@ -211,6 +228,7 @@ final class CaptureEngine: NSObject, AVCapturePhotoCaptureDelegate {
     /// Stops the capture session (screen teardown).
     func stopSession() {
         sessionQueue.async {
+            self.isExpectedToRun = false
             if self.captureSession.isRunning {
                 self.captureSession.stopRunning()
             }
@@ -219,31 +237,115 @@ final class CaptureEngine: NSObject, AVCapturePhotoCaptureDelegate {
 
     func toggleCamera(orientation: UIInterfaceOrientation) async throws -> (AVCaptureDevice.FlashMode?, AVCaptureDevice.Position) {
         try await onSessionQueueThrowing {
-            let captureSession = self.captureSession
-            captureSession.beginConfiguration()
-            let device = self.videoDeviceInput?.device
-            let newPosition = device?.position.toggle().toOptional()
-            let newDevice = self.cameraForPosition(position: newPosition!)
-            let newInput = try AVCaptureDeviceInput(device: newDevice!)
-            captureSession.removeInput(self.videoDeviceInput)
-            captureSession.addInput(newInput)
-            self.videoDeviceInput = newInput
-            self.configSessionOutput()
-            try self.setFrameRate(framerate: fpsSetting.value, videoDevice: newDevice!)
-
-            // Update available lens types and zoom stops for new camera position
-            self.updateAvailableLensTypes(for: newPosition!)
-            self.zoomStops = self.discoverZoomStops(for: newDevice!)
-            self.currentPositionShared.value = newInput.device.position
-
-            self.rotateOutputsLocked(orientation: orientation)
-            let newFlashMode: AVCaptureDevice.FlashMode? = (newInput.device.hasFlash) ? self.cameraSettings.flashMode : nil
-            captureSession.commitConfiguration()
-            self.applyDesiredTorchLocked()   // restore torch onto the new camera (no-op if it has none)
-
+            guard let newDevice = self.nextToggleDeviceLocked() else {
+                throw NSError(domain: "Unable to find camera position", code: 0, userInfo: nil)
+            }
+            let result = try self.swapToDeviceLocked(newDevice, orientation: orientation)
             // Camera capabilities are sent via RemoteCmd.ToggleCameraResp in the camera state.
-            return (newFlashMode, newInput.device.position)
+            return (result.flashMode, result.device.position)
         }
+    }
+
+    /// The camera a fresh session starts on. iOS: the preferred (virtual)
+    /// back device. Mac: the system's preferred camera when healthy — it
+    /// tracks the user's choice across apps — else the first non-suspended
+    /// device (a clamshell MacBook's built-in camera is connected but
+    /// delivers no frames).
+    private func initialCameraLocked() -> AVCaptureDevice? {
+        dispatchPrecondition(condition: .onQueue(sessionQueue))
+        #if targetEnvironment(macCatalyst)
+        var candidates: [AVCaptureDevice] = []
+        if #available(macCatalyst 17.0, *), let system = AVCaptureDevice.systemPreferredCamera {
+            candidates.append(system)
+        }
+        if let systemDefault = AVCaptureDevice.default(for: .video) {
+            candidates.append(systemDefault)
+        }
+        candidates += selectableDevicesLocked()
+        return candidates.first { !$0.isSuspended }
+        #else
+        return preferredCamera(for: .back) ?? AVCaptureDevice.default(for: .video)
+        #endif
+    }
+
+    /// The device the front/back flip lands on. The decision is the pure
+    /// `CameraDeviceDescriptor.nextToggleSelection` (unit-tested): iOS flips
+    /// position, a Mac cycles the attached cameras skipping suspended ones —
+    /// an old-protocol monitor's flip button still does something sensible
+    /// against a Mac camera.
+    private func nextToggleDeviceLocked() -> AVCaptureDevice? {
+        dispatchPrecondition(condition: .onQueue(sessionQueue))
+        #if targetEnvironment(macCatalyst)
+        let flipPosition = false
+        #else
+        let flipPosition = true
+        #endif
+        let available = selectableDevicesLocked()
+        guard let next = CameraDeviceDescriptor.nextToggleSelection(
+                currentID: videoDeviceInput?.device.uniqueID,
+                available: available.map { CameraDeviceDescriptor(device: $0) },
+                flipPosition: flipPosition) else { return nil }
+        return available.first { $0.uniqueID == next.uniqueID }
+    }
+
+    /// Swaps the session input to `newDevice`, reapplying frame rate, lens
+    /// state, orientation and torch — the shared core of `toggleCamera` and
+    /// `selectCameraDevice`.
+    private func swapToDeviceLocked(_ newDevice: AVCaptureDevice,
+                                    orientation: UIInterfaceOrientation) throws -> CameraSelectionResult {
+        dispatchPrecondition(condition: .onQueue(sessionQueue))
+        let newInput = try AVCaptureDeviceInput(device: newDevice)
+        captureSession.beginConfiguration()
+        let previousInput = videoDeviceInput
+        if let previousInput {
+            captureSession.removeInput(previousInput)
+        }
+        guard captureSession.canAddInput(newInput) else {
+            // AVCam pattern: restore the previous input and report, instead
+            // of letting addInput raise an uncatchable ObjC exception (a
+            // device can reject the session's current preset).
+            if let previousInput, captureSession.canAddInput(previousInput) {
+                captureSession.addInput(previousInput)
+            }
+            captureSession.commitConfiguration()
+            throw NSError(
+                domain: "\(newDevice.localizedName) is not compatible with the current session",
+                code: 0, userInfo: nil)
+        }
+        captureSession.addInput(newInput)
+        videoDeviceInput = newInput
+        // AVCam's changeCamera keeps the outputs in place across an input
+        // swap — connections re-form automatically; only the cached refs
+        // need refreshing. (Removing/re-adding outputs here is gratuitous
+        // session churn and diverges from Apple's reference.)
+        videoConnection = videoDataOutput.connection(with: .video)
+        audioConnection = audioDataOutput.connection(with: .audio)
+        try setFrameRate(framerate: fpsSetting.value, videoDevice: newDevice)
+
+        updateAvailableLensTypes(for: newDevice)
+        zoomStops = discoverZoomStops(for: newDevice)
+        currentPositionShared.value = newDevice.position
+        currentZoomFactor = newDevice.videoZoomFactor
+        currentLensType = lensTypeForZoomFactor(currentZoomFactor, device: newDevice)
+
+        rotateOutputsLocked(orientation: orientation)
+        let newFlashMode: AVCaptureDevice.FlashMode? = newDevice.hasFlash ? cameraSettings.flashMode : nil
+        captureSession.commitConfiguration()
+        applyDesiredTorchLocked()   // restore torch onto the new camera (no-op if it has none)
+        // Swapping away from a dead device must also revive a session that a
+        // runtime error stopped — otherwise the new camera never delivers.
+        if isExpectedToRun && !captureSession.isRunning {
+            captureSession.startRunning()
+        }
+
+        return CameraSelectionResult(
+            device: CameraDeviceDescriptor(device: newDevice),
+            flashMode: newFlashMode,
+            availableLensTypes: availableLensTypes,
+            zoomRange: RemoteCmd.ZoomRange(
+                minZoom: newDevice.minAvailableVideoZoomFactor,
+                maxZoom: newDevice.maxAvailableVideoZoomFactor),
+            currentZoom: currentZoomFactor)
     }
 
     private func configSessionOutput() {
@@ -452,6 +554,200 @@ final class CaptureEngine: NSObject, AVCapturePhotoCaptureDelegate {
         return preferredCamera(for: position)
     }
 
+    // MARK: - Device Selection (uniqueID-based; a Mac has N cameras)
+
+    /// Every camera the user can select on this platform, in stable discovery
+    /// order. Catalyst enumerates all attached cameras (built-in, Continuity,
+    /// Desk View, external); iOS offers the preferred (virtual) device per
+    /// position — lens choice within a position stays the zoom/lens
+    /// machinery's job.
+    private func selectableDevicesLocked() -> [AVCaptureDevice] {
+        dispatchPrecondition(condition: .onQueue(sessionQueue))
+        #if targetEnvironment(macCatalyst)
+        var types: [AVCaptureDevice.DeviceType] = [.builtInWideAngleCamera]
+        if #available(macCatalyst 17.0, *) {
+            // Desk View has no Catalyst API; its feed arrives as a regular
+            // Continuity Camera device.
+            types += [.continuityCamera, .external]
+        }
+        return AVCaptureDevice.DiscoverySession(
+            deviceTypes: types, mediaType: .video, position: .unspecified).devices
+        #else
+        return [preferredCamera(for: .back), preferredCamera(for: .front)].compactMap { $0 }
+        #endif
+    }
+
+    func availableCameraDevices() async -> [CameraDeviceDescriptor] {
+        await onSessionQueue {
+            self.selectableDevicesLocked().map { CameraDeviceDescriptor(device: $0) }
+        }
+    }
+
+    func currentCameraDevice() async -> CameraDeviceDescriptor? {
+        await onSessionQueue {
+            (self.videoDeviceInput?.device).map { CameraDeviceDescriptor(device: $0) }
+        }
+    }
+
+    func selectCameraDevice(uniqueID: String, orientation: UIInterfaceOrientation) async throws -> CameraSelectionResult {
+        try await onSessionQueueThrowing {
+            let available = self.selectableDevicesLocked()
+            let descriptors = available.map { CameraDeviceDescriptor(device: $0) }
+            // Explicitly requesting a suspended camera is an error, not a
+            // silent switch to some other device (pickers gray these out;
+            // an old-protocol peer can still ask).
+            if let requested = descriptors.first(where: { $0.uniqueID == uniqueID }),
+               requested.isSuspended {
+                throw NSError(
+                    domain: "\(requested.localizedName) is unavailable (suspended)",
+                    code: 0, userInfo: nil)
+            }
+            let fallbackPosition = self.videoDeviceInput?.device.position ?? .unspecified
+            guard let resolved = CameraDeviceDescriptor.resolveSelection(
+                    requestedID: uniqueID, available: descriptors, fallbackPosition: fallbackPosition),
+                  let device = available.first(where: { $0.uniqueID == resolved.uniqueID }) else {
+                throw NSError(domain: "No camera device available", code: 0, userInfo: nil)
+            }
+            let result = try self.swapToDeviceLocked(device, orientation: orientation)
+            #if targetEnvironment(macCatalyst)
+            if #available(macCatalyst 17.0, *) {
+                // Apple's "manual mode": feed the system-wide preference so
+                // other apps and future launches respect the user's pick.
+                AVCaptureDevice.userPreferredCamera = device
+            }
+            #endif
+            return result
+        }
+    }
+
+    /// Platform-aware lens refresh: iOS keeps its position-based discovery;
+    /// Mac cameras have a single lens.
+    private func updateAvailableLensTypes(for device: AVCaptureDevice) {
+        #if targetEnvironment(macCatalyst)
+        availableLensTypes = [.wideAngle]
+        #else
+        updateAvailableLensTypes(for: device.position)
+        #endif
+    }
+
+    // MARK: - Device state (hot-plug, suspension, runtime errors)
+
+    /// Fired on the session queue whenever the set or health of attached
+    /// cameras changes: hot-plug, lid open/close (suspension), or a session
+    /// runtime error. Built-in iOS cameras never fire this.
+    var onCameraDevicesChanged: (() -> Void)?
+
+    private var deviceConnectionObservers: [NSObjectProtocol] = []
+    /// KVO on `isSuspended` per discovered device — there is no notification
+    /// for suspension; Apple documents key-value observing this property.
+    private var suspensionObservations: [NSKeyValueObservation] = []
+
+    fileprivate func observeDeviceConnections() {
+        let center = NotificationCenter.default
+        let handle = { [weak self] (note: Notification, disconnected: Bool) in
+            guard let device = note.object as? AVCaptureDevice, device.hasMediaType(.video) else { return }
+            self?.handleDeviceStateChange(disconnectedID: disconnected ? device.uniqueID : nil)
+        }
+        deviceConnectionObservers = [
+            center.addObserver(forName: AVCaptureDevice.wasConnectedNotification,
+                               object: nil, queue: nil) { handle($0, false) },
+            center.addObserver(forName: AVCaptureDevice.wasDisconnectedNotification,
+                               object: nil, queue: nil) { handle($0, true) },
+            center.addObserver(forName: .AVCaptureSessionRuntimeError,
+                               object: captureSession, queue: nil) { [weak self] note in
+                let error = note.userInfo?[AVCaptureSessionErrorKey] as? NSError
+                debugLog("CaptureEngine: session runtime error: \(error?.localizedDescription ?? "unknown")")
+                self?.resumeSessionIfNeeded()
+            },
+            center.addObserver(forName: .AVCaptureSessionWasInterrupted,
+                               object: captureSession, queue: nil) { [weak self] note in
+                debugLog("CaptureEngine: session interrupted (reason \(String(describing: note.userInfo?[AVCaptureSessionInterruptionReasonKey])))")
+                self?.handleDeviceStateChange()
+            },
+            center.addObserver(forName: .AVCaptureSessionInterruptionEnded,
+                               object: captureSession, queue: nil) { [weak self] _ in
+                debugLog("CaptureEngine: session interruption ended")
+                self?.resumeSessionIfNeeded()
+            }
+        ]
+    }
+
+    /// Full stop/start bounce. A session that begins on a source which never
+    /// produces a frame (sandboxed-out virtual camera) can stay wedged —
+    /// isRunning true, valid graph, zero buffers — even after the input is
+    /// swapped to a good device; only a restart revives delivery. Used by the
+    /// rig's first-frame watchdog after a stall-triggered fallback.
+    func restartSession() {
+        sessionQueue.async {
+            guard self.isExpectedToRun else { return }
+            if self.captureSession.isRunning {
+                self.captureSession.stopRunning()
+            }
+            self.captureSession.startRunning()
+        }
+    }
+
+    /// AVCam's resume pattern, shared by the runtime-error and
+    /// interruption-ended observers: both can leave the session stopped;
+    /// restart when it is supposed to be running, then run the normal
+    /// device-state refresh so both ends re-sync.
+    private func resumeSessionIfNeeded() {
+        sessionQueue.async {
+            if self.isExpectedToRun && !self.captureSession.isRunning {
+                self.captureSession.startRunning()
+            }
+        }
+        handleDeviceStateChange()
+    }
+
+    /// The device set as of the last state-change notification, so flapping
+    /// sources (a Continuity iPhone connects/disconnects as it locks and
+    /// idles) don't re-notify the rig — and rebuild both picker menus — for
+    /// an unchanged list. sessionQueue-confined.
+    private var lastNotifiedDevices: [CameraDeviceDescriptor] = []
+
+    /// One event path for every "the cameras changed" trigger: refresh the
+    /// suspension observers, move off a dead active device, and tell the rig
+    /// — but only when something observable actually changed.
+    private func handleDeviceStateChange(disconnectedID: String? = nil) {
+        sessionQueue.async {
+            let active = self.videoDeviceInput?.device
+            let activeIsGone = (disconnectedID != nil && active?.uniqueID == disconnectedID)
+                || (active?.isSuspended ?? false)
+            if activeIsGone {
+                self.fallBackToHealthyDeviceLocked()
+            }
+            let devices = self.selectableDevicesLocked().map { CameraDeviceDescriptor(device: $0) }
+            guard activeIsGone || devices != self.lastNotifiedDevices else { return }
+            self.lastNotifiedDevices = devices
+            self.refreshSuspensionObserversLocked()
+            self.onCameraDevicesChanged?()
+        }
+    }
+
+    private func refreshSuspensionObserversLocked() {
+        dispatchPrecondition(condition: .onQueue(sessionQueue))
+        suspensionObservations = selectableDevicesLocked().map { device in
+            device.observe(\.isSuspended) { [weak self] _, _ in
+                self?.handleDeviceStateChange()
+            }
+        }
+    }
+
+    /// The active camera was unplugged or suspended: land on the best healthy
+    /// device (same position first, then first available) instead of
+    /// freezing on a source that will never deliver a frame.
+    private func fallBackToHealthyDeviceLocked() {
+        dispatchPrecondition(condition: .onQueue(sessionQueue))
+        let available = selectableDevicesLocked().filter { $0.isConnected }
+        let descriptors = available.map { CameraDeviceDescriptor(device: $0) }
+        guard let resolved = CameraDeviceDescriptor.resolveSelection(
+                requestedID: "", available: descriptors,
+                fallbackPosition: currentPositionShared.value),
+              let device = available.first(where: { $0.uniqueID == resolved.uniqueID }) else { return }
+        _ = try? swapToDeviceLocked(device, orientation: orientation)
+    }
+
     func getAllDeviceTypes() -> [AVCaptureDevice.DeviceType] {
         var deviceTypes: [AVCaptureDevice.DeviceType] = [
             .builtInWideAngleCamera,
@@ -612,6 +908,7 @@ final class CaptureEngine: NSObject, AVCapturePhotoCaptureDelegate {
         debugLog("🔍 DEBUG: frontCameraInfo: \(frontCameraInfo != nil ? "available" : "nil")")
         debugLog("🔍 DEBUG: backCameraInfo: \(backCameraInfo != nil ? "available" : "nil")")
 
+        let (deviceEntries, activeDeviceID) = cameraDeviceEntriesLocked()
         let capabilities = RemoteCmd.CameraCapabilitiesResp(
             frontCamera: frontCameraInfo,
             backCamera: backCameraInfo,
@@ -622,11 +919,50 @@ final class CaptureEngine: NSObject, AVCapturePhotoCaptureDelegate {
             currentVideoFrameRate: currentVideoFrameRate,
             currentPhotoFormat: currentPhotoFormat,
             currentHDRMode: currentHDRMode,
+            cameraDevices: deviceEntries,
+            activeDeviceID: activeDeviceID,
             error: nil
         )
 
         debugLog("🔍 DEBUG: Created capabilities response successfully")
         return capabilities
+    }
+
+    /// The selectable-device list advertised in capabilities — the feature
+    /// gate that lets a monitor remote-select this device's cameras.
+    private func cameraDeviceEntriesLocked() -> ([RemoteCmd.CameraDeviceEntry], String?) {
+        dispatchPrecondition(condition: .onQueue(sessionQueue))
+        let activeID = videoDeviceInput?.device.uniqueID
+        let entries = selectableDevicesLocked().map { device in
+            RemoteCmd.CameraDeviceEntry(
+                uniqueID: device.uniqueID,
+                localizedName: device.localizedName,
+                positionRaw: device.position.rawValue,
+                isActive: device.uniqueID == activeID,
+                isSuspended: device.isSuspended,
+                info: deviceInfoLocked(for: device))
+        }
+        return (entries, activeID)
+    }
+
+    /// Per-device CameraInfo for the advertised list. iOS reuses the cached
+    /// position-based info; Mac cameras get a minimal single-lens profile.
+    private func deviceInfoLocked(for device: AVCaptureDevice) -> RemoteCmd.CameraInfo? {
+        #if targetEnvironment(macCatalyst)
+        return RemoteCmd.CameraInfo(
+            availableLenses: [.wideAngle],
+            hasFlash: device.hasFlash,
+            hasTorch: device.hasTorch,
+            zoomCapabilities: [.wideAngle: RemoteCmd.ZoomRange(
+                minZoom: device.minAvailableVideoZoomFactor,
+                maxZoom: device.maxAvailableVideoZoomFactor)])
+        #else
+        switch device.position {
+        case .front: return frontCameraInfo
+        case .back: return backCameraInfo
+        default: return nil
+        }
+        #endif
     }
 
     // MARK: - Enhanced Zoom Control Methods
@@ -787,22 +1123,68 @@ final class CaptureEngine: NSObject, AVCapturePhotoCaptureDelegate {
         self.orientation = orientation
         let o = OrientationUtils.transform(o: orientation)
         if let videoConnection = self.videoConnection {
-            videoConnection.videoOrientation = o
+            applyCaptureOrientationLocked(o, to: videoConnection)
         }
         if let photoConnection = self.photoOutput.connection(with: AVMediaType.video) {
-            photoConnection.videoOrientation = o
+            applyCaptureOrientationLocked(o, to: photoConnection)
             return true
         }
         return false
     }
 
+    /// The only place capture-connection orientation is ever written. The
+    /// pipeline invariant is that buffers leave the connection upright —
+    /// everything downstream (encoders, wire, monitor, Watch, recorder) is
+    /// orientation-preserving. iOS sensors are portrait-native and need the
+    /// interface-derived rotation; Mac cameras are landscape-native and
+    /// already upright, so `appliesInterfaceRotation` is false on Catalyst.
+    private func applyCaptureOrientationLocked(_ o: AVCaptureVideoOrientation,
+                                               to connection: AVCaptureConnection) {
+        dispatchPrecondition(condition: .onQueue(sessionQueue))
+        guard OrientationUtils.appliesInterfaceRotation,
+              connection.isVideoOrientationSupported else { return }
+        connection.videoOrientation = o
+    }
+
+    /// Chooses the frame-rate range closest to the request. Supported rates
+    /// form disjoint ranges (a Mac camera's format may support exactly
+    /// 60–60), and a rate outside every range raises an Objective-C exception
+    /// that Swift cannot catch — so the answer is always inside a range,
+    /// never merely below the maximum. Ties prefer the lower rate (don't
+    /// exceed the request unnecessarily); nil when no ranges are reported.
+    static func resolveFrameRate(requested: Int,
+                                 supportedRanges: [ClosedRange<Double>]) -> (fps: Int, rangeIndex: Int)? {
+        let requestedFPS = Double(requested)
+        let nearest = supportedRanges.enumerated()
+            .map { (index: $0.offset,
+                    fps: min(max(requestedFPS, $0.element.lowerBound), $0.element.upperBound)) }
+            .min { (abs($0.fps - requestedFPS), $0.fps) < (abs($1.fps - requestedFPS), $1.fps) }
+        return nearest.map { (fps: Int($0.fps), rangeIndex: $0.index) }
+    }
+
     func setFrameRate(framerate: Int, videoDevice: AVCaptureDevice) throws {
-        let maxFPS = Int(maxSupportedFPS(for: videoDevice))
-        let safeFPS = max(1, min(framerate, maxFPS))
+        let ranges = videoDevice.activeFormat.videoSupportedFrameRateRanges
+        guard let resolved = Self.resolveFrameRate(
+                requested: framerate,
+                supportedRanges: ranges.map { $0.minFrameRate...$0.maxFrameRate }) else {
+            return   // no ranges reported: leave the device's defaults alone
+        }
+        // Clamp the desired duration into the chosen range's OWN CMTimes —
+        // never rebuild from integers. A UVC camera's "60 fps" is often
+        // 59.99976 (1000000/60000240): an integer 1/60 falls outside the
+        // range, which throws on DAL hardware and silently wedges software
+        // cameras (OBS stopped delivering frames entirely).
+        let range = ranges[resolved.rangeIndex]
+        var duration = CMTimeMake(value: 1, timescale: Int32(max(1, resolved.fps)))
+        if CMTimeCompare(duration, range.minFrameDuration) < 0 { duration = range.minFrameDuration }
+        if CMTimeCompare(duration, range.maxFrameDuration) > 0 { duration = range.maxFrameDuration }
+
         try videoDevice.lockForConfiguration()
-        videoDevice.activeVideoMaxFrameDuration = CMTimeMake(value: 1, timescale: Int32(safeFPS))
-        videoDevice.activeVideoMinFrameDuration = CMTimeMake(value: 1, timescale: Int32(safeFPS))
+        videoDevice.activeVideoMaxFrameDuration = duration
+        videoDevice.activeVideoMinFrameDuration = duration
         videoDevice.unlockForConfiguration()
+
+        let safeFPS = resolved.fps
         if safeFPS != framerate {
             fpsSetting.value = safeFPS
             currentVideoFrameRate = VideoFrameRate.selectableCases.last(where: { $0.value <= safeFPS }) ?? .fps30

--- a/RemoteCam/DeviceScannerViewController.swift
+++ b/RemoteCam/DeviceScannerViewController.swift
@@ -301,10 +301,17 @@ public class DeviceScannerViewController: UIViewController {
     }
 
     func goToAppSettings() {
+        #if targetEnvironment(macCatalyst)
+        // Local-network permission lives in System Settings on the Mac.
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_LocalNetwork") {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+        #else
         if let bundleId = Bundle.main.bundleIdentifier,
            let url = URL(string: "\(UIApplication.openSettingsURLString)&path=LOCATION/\(bundleId)") {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }
+        #endif
     }
 
     func shareAppLink() {

--- a/RemoteCam/EnumExtensions.swift
+++ b/RemoteCam/EnumExtensions.swift
@@ -182,19 +182,6 @@ public enum AspectRatio: Int, CaseIterable, Codable {
     }
 }
 
-extension AVCaptureDevice.Position {
-    public func toggle() -> Try<AVCaptureDevice.Position> {
-        switch self {
-        case .back:
-            return Success(.front)
-        case .front:
-            return Success(.back)
-        default:
-            return Failure(error: NSError(domain: "Unable to find camera position", code: 0, userInfo: nil))
-        }
-    }
-}
-
 extension AVCaptureDevice.FlashMode {
     public func next() -> AVCaptureDevice.FlashMode {
         switch self {

--- a/RemoteCam/FeatureFlags.swift
+++ b/RemoteCam/FeatureFlags.swift
@@ -25,6 +25,15 @@ struct FeatureFlags {
     /// Enable Apple Watch companion app as standalone remote control
     static let ENABLE_WATCH_APP = true
 
+    /// Show the local camera-device picker on the camera screen. On for Mac
+    /// Catalyst only (a Mac has N cameras — built-in, Continuity, USB);
+    /// iPhone keeps its flip button.
+    #if targetEnvironment(macCatalyst)
+    static let ENABLE_LOCAL_CAMERA_PICKER = true
+    #else
+    static let ENABLE_LOCAL_CAMERA_PICKER = false
+    #endif
+
     // MARK: - Future Feature Flags
     // Add new feature flags here as needed
     // Example:

--- a/RemoteCam/FlatBufferSchemas.fbs
+++ b/RemoteCam/FlatBufferSchemas.fbs
@@ -27,7 +27,10 @@ enum CommandAction : byte {
     SetPhotoQuality = 15,
     TimerCountdown = 16,
     SyncMonitorSettings = 17,
-    SetAspectRatio = 18
+    SetAspectRatio = 18,
+    SelectCameraDevice = 19    // never sent to peers that did not advertise
+                               // camera_devices — old decoders read unknown
+                               // actions as TakePicture (the field default)
 }
 
 enum CameraPosition : byte {
@@ -128,6 +131,8 @@ table CommandParameters {
     countdown_value: int;
     recording_mode: RecordingModeEnum;
     aspect_ratio: AspectRatioEnum;
+    // Appended fields only below this line (FlatBuffers schema evolution).
+    device_unique_id: string;        // payload for SelectCameraDevice
 }
 
 // MARK: - Command Structure
@@ -176,6 +181,23 @@ table CameraInfo {
     wide_angle_zoom_factor: double;
 }
 
+// One selectable physical camera on the camera peer. `position` is Back when
+// the device has no front/back identity (Mac external/Continuity/Desk View
+// cameras); has_unspecified_position disambiguates for peers that understand
+// device selection.
+table CameraDeviceInfo {
+    unique_id: string;
+    localized_name: string;
+    position: CameraPosition;
+    has_unspecified_position: bool;
+    is_active: bool;
+    info: CameraInfo;
+    // Appended fields only below this line (FlatBuffers schema evolution).
+    // Connected but delivering no frames (Mac clamshell built-in camera):
+    // shown grayed out in pickers, excluded from selection.
+    is_suspended: bool;
+}
+
 table CameraState {
     current_camera: CameraPosition;
     current_lens: CameraLensType;
@@ -187,11 +209,18 @@ table CameraState {
     photo_format: PhotoFormat;
     hdr_mode: HDRMode;
     aspect_ratio: AspectRatioEnum;
+    // Appended fields only below this line (FlatBuffers schema evolution).
+    active_device_id: string;
 }
 
 table CameraCapabilities {
     front_camera: CameraInfo;
     back_camera: CameraInfo;
+    // Appended fields only below this line (FlatBuffers schema evolution).
+    // Empty/absent = peer predates camera-device selection; a monitor must
+    // not send SelectCameraDevice to such a peer.
+    camera_devices: [CameraDeviceInfo];
+    active_device_id: string;
 }
 
 // MARK: - Response Structure

--- a/RemoteCam/FlatBufferSchemas_generated.swift
+++ b/RemoteCam/FlatBufferSchemas_generated.swift
@@ -27,8 +27,9 @@ public enum RemoteShutter_CommandAction: Int8, Enum, Verifiable {
   case timercountdown = 16
   case syncmonitorsettings = 17
   case setaspectratio = 18
+  case selectcameradevice = 19
 
-  public static var max: RemoteShutter_CommandAction { return .setaspectratio }
+  public static var max: RemoteShutter_CommandAction { return .selectcameradevice }
   public static var min: RemoteShutter_CommandAction { return .takepicture }
 }
 
@@ -307,6 +308,7 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
     case countdownValue = 28
     case recordingMode = 30
     case aspectRatio = 32
+    case deviceUniqueId = 34
     var v: Int32 { Int32(self.rawValue) }
     var p: VOffset { self.rawValue }
   }
@@ -328,7 +330,9 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
   public var countdownValue: Int32 { let o = _accessor.offset(VTOFFSET.countdownValue.v); return o == 0 ? 0 : _accessor.readBuffer(of: Int32.self, at: o) }
   public var recordingMode: RemoteShutter_RecordingModeEnum { let o = _accessor.offset(VTOFFSET.recordingMode.v); return o == 0 ? .unknown : RemoteShutter_RecordingModeEnum(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .unknown }
   public var aspectRatio: RemoteShutter_AspectRatioEnum { let o = _accessor.offset(VTOFFSET.aspectRatio.v); return o == 0 ? .unknown : RemoteShutter_AspectRatioEnum(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .unknown }
-  public static func startCommandParameters(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 15) }
+  public var deviceUniqueId: String? { let o = _accessor.offset(VTOFFSET.deviceUniqueId.v); return o == 0 ? nil : _accessor.string(at: o) }
+  public var deviceUniqueIdSegmentArray: [UInt8]? { return _accessor.getVector(at: VTOFFSET.deviceUniqueId.v) }
+  public static func startCommandParameters(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 16) }
   public static func add(sendToRemote: Bool, _ fbb: inout FlatBufferBuilder) { fbb.add(element: sendToRemote, def: false,
    at: VTOFFSET.sendToRemote.p) }
   public static func add(zoomFactor: Double, _ fbb: inout FlatBufferBuilder) { fbb.add(element: zoomFactor, def: 0.0, at: VTOFFSET.zoomFactor.p) }
@@ -345,6 +349,7 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
   public static func add(countdownValue: Int32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: countdownValue, def: 0, at: VTOFFSET.countdownValue.p) }
   public static func add(recordingMode: RemoteShutter_RecordingModeEnum, _ fbb: inout FlatBufferBuilder) { fbb.add(element: recordingMode.rawValue, def: 0, at: VTOFFSET.recordingMode.p) }
   public static func add(aspectRatio: RemoteShutter_AspectRatioEnum, _ fbb: inout FlatBufferBuilder) { fbb.add(element: aspectRatio.rawValue, def: 0, at: VTOFFSET.aspectRatio.p) }
+  public static func add(deviceUniqueId: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: deviceUniqueId, at: VTOFFSET.deviceUniqueId.p) }
   public static func endCommandParameters(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createCommandParameters(
     _ fbb: inout FlatBufferBuilder,
@@ -362,7 +367,8 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
     hdrMode: RemoteShutter_HDRMode = .unknown,
     countdownValue: Int32 = 0,
     recordingMode: RemoteShutter_RecordingModeEnum = .unknown,
-    aspectRatio: RemoteShutter_AspectRatioEnum = .unknown
+    aspectRatio: RemoteShutter_AspectRatioEnum = .unknown,
+    deviceUniqueIdOffset deviceUniqueId: Offset = Offset()
   ) -> Offset {
     let __start = RemoteShutter_CommandParameters.startCommandParameters(&fbb)
     RemoteShutter_CommandParameters.add(sendToRemote: sendToRemote, &fbb)
@@ -380,6 +386,7 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
     RemoteShutter_CommandParameters.add(countdownValue: countdownValue, &fbb)
     RemoteShutter_CommandParameters.add(recordingMode: recordingMode, &fbb)
     RemoteShutter_CommandParameters.add(aspectRatio: aspectRatio, &fbb)
+    RemoteShutter_CommandParameters.add(deviceUniqueId: deviceUniqueId, &fbb)
     return RemoteShutter_CommandParameters.endCommandParameters(&fbb, start: __start)
   }
 
@@ -400,6 +407,7 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
     try _v.visit(field: VTOFFSET.countdownValue.p, fieldName: "countdownValue", required: false, type: Int32.self)
     try _v.visit(field: VTOFFSET.recordingMode.p, fieldName: "recordingMode", required: false, type: RemoteShutter_RecordingModeEnum.self)
     try _v.visit(field: VTOFFSET.aspectRatio.p, fieldName: "aspectRatio", required: false, type: RemoteShutter_AspectRatioEnum.self)
+    try _v.visit(field: VTOFFSET.deviceUniqueId.p, fieldName: "deviceUniqueId", required: false, type: ForwardOffset<String>.self)
     _v.finish()
   }
 }
@@ -766,6 +774,84 @@ public struct RemoteShutter_CameraInfo: FlatBufferObject, Verifiable {
   }
 }
 
+public struct RemoteShutter_CameraDeviceInfo: FlatBufferObject, Verifiable {
+
+  static func validateVersion() { FlatBuffersVersion_25_2_10() }
+  public var __buffer: ByteBuffer! { return _accessor.bb }
+  private var _accessor: Table
+
+  public static var id: String { "RCAM" } 
+  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset, prefix: Bool = false) { fbb.finish(offset: end, fileId: RemoteShutter_CameraDeviceInfo.id, addPrefix: prefix) }
+  private init(_ t: Table) { _accessor = t }
+  public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
+
+  private enum VTOFFSET: VOffset {
+    case uniqueId = 4
+    case localizedName = 6
+    case position = 8
+    case hasUnspecifiedPosition = 10
+    case isActive = 12
+    case info = 14
+    case isSuspended = 16
+    var v: Int32 { Int32(self.rawValue) }
+    var p: VOffset { self.rawValue }
+  }
+
+  public var uniqueId: String? { let o = _accessor.offset(VTOFFSET.uniqueId.v); return o == 0 ? nil : _accessor.string(at: o) }
+  public var uniqueIdSegmentArray: [UInt8]? { return _accessor.getVector(at: VTOFFSET.uniqueId.v) }
+  public var localizedName: String? { let o = _accessor.offset(VTOFFSET.localizedName.v); return o == 0 ? nil : _accessor.string(at: o) }
+  public var localizedNameSegmentArray: [UInt8]? { return _accessor.getVector(at: VTOFFSET.localizedName.v) }
+  public var position: RemoteShutter_CameraPosition { let o = _accessor.offset(VTOFFSET.position.v); return o == 0 ? .back : RemoteShutter_CameraPosition(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .back }
+  public var hasUnspecifiedPosition: Bool { let o = _accessor.offset(VTOFFSET.hasUnspecifiedPosition.v); return o == 0 ? false : _accessor.readBuffer(of: Bool.self, at: o) }
+  public var isActive: Bool { let o = _accessor.offset(VTOFFSET.isActive.v); return o == 0 ? false : _accessor.readBuffer(of: Bool.self, at: o) }
+  public var info: RemoteShutter_CameraInfo? { let o = _accessor.offset(VTOFFSET.info.v); return o == 0 ? nil : RemoteShutter_CameraInfo(_accessor.bb, o: _accessor.indirect(o + _accessor.position)) }
+  public var isSuspended: Bool { let o = _accessor.offset(VTOFFSET.isSuspended.v); return o == 0 ? false : _accessor.readBuffer(of: Bool.self, at: o) }
+  public static func startCameraDeviceInfo(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 7) }
+  public static func add(uniqueId: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: uniqueId, at: VTOFFSET.uniqueId.p) }
+  public static func add(localizedName: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: localizedName, at: VTOFFSET.localizedName.p) }
+  public static func add(position: RemoteShutter_CameraPosition, _ fbb: inout FlatBufferBuilder) { fbb.add(element: position.rawValue, def: 0, at: VTOFFSET.position.p) }
+  public static func add(hasUnspecifiedPosition: Bool, _ fbb: inout FlatBufferBuilder) { fbb.add(element: hasUnspecifiedPosition, def: false,
+   at: VTOFFSET.hasUnspecifiedPosition.p) }
+  public static func add(isActive: Bool, _ fbb: inout FlatBufferBuilder) { fbb.add(element: isActive, def: false,
+   at: VTOFFSET.isActive.p) }
+  public static func add(info: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: info, at: VTOFFSET.info.p) }
+  public static func add(isSuspended: Bool, _ fbb: inout FlatBufferBuilder) { fbb.add(element: isSuspended, def: false,
+   at: VTOFFSET.isSuspended.p) }
+  public static func endCameraDeviceInfo(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
+  public static func createCameraDeviceInfo(
+    _ fbb: inout FlatBufferBuilder,
+    uniqueIdOffset uniqueId: Offset = Offset(),
+    localizedNameOffset localizedName: Offset = Offset(),
+    position: RemoteShutter_CameraPosition = .back,
+    hasUnspecifiedPosition: Bool = false,
+    isActive: Bool = false,
+    infoOffset info: Offset = Offset(),
+    isSuspended: Bool = false
+  ) -> Offset {
+    let __start = RemoteShutter_CameraDeviceInfo.startCameraDeviceInfo(&fbb)
+    RemoteShutter_CameraDeviceInfo.add(uniqueId: uniqueId, &fbb)
+    RemoteShutter_CameraDeviceInfo.add(localizedName: localizedName, &fbb)
+    RemoteShutter_CameraDeviceInfo.add(position: position, &fbb)
+    RemoteShutter_CameraDeviceInfo.add(hasUnspecifiedPosition: hasUnspecifiedPosition, &fbb)
+    RemoteShutter_CameraDeviceInfo.add(isActive: isActive, &fbb)
+    RemoteShutter_CameraDeviceInfo.add(info: info, &fbb)
+    RemoteShutter_CameraDeviceInfo.add(isSuspended: isSuspended, &fbb)
+    return RemoteShutter_CameraDeviceInfo.endCameraDeviceInfo(&fbb, start: __start)
+  }
+
+  public static func verify<T>(_ verifier: inout Verifier, at position: Int, of type: T.Type) throws where T: Verifiable {
+    var _v = try verifier.visitTable(at: position)
+    try _v.visit(field: VTOFFSET.uniqueId.p, fieldName: "uniqueId", required: false, type: ForwardOffset<String>.self)
+    try _v.visit(field: VTOFFSET.localizedName.p, fieldName: "localizedName", required: false, type: ForwardOffset<String>.self)
+    try _v.visit(field: VTOFFSET.position.p, fieldName: "position", required: false, type: RemoteShutter_CameraPosition.self)
+    try _v.visit(field: VTOFFSET.hasUnspecifiedPosition.p, fieldName: "hasUnspecifiedPosition", required: false, type: Bool.self)
+    try _v.visit(field: VTOFFSET.isActive.p, fieldName: "isActive", required: false, type: Bool.self)
+    try _v.visit(field: VTOFFSET.info.p, fieldName: "info", required: false, type: ForwardOffset<RemoteShutter_CameraInfo>.self)
+    try _v.visit(field: VTOFFSET.isSuspended.p, fieldName: "isSuspended", required: false, type: Bool.self)
+    _v.finish()
+  }
+}
+
 public struct RemoteShutter_CameraState: FlatBufferObject, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_25_2_10() }
@@ -788,6 +874,7 @@ public struct RemoteShutter_CameraState: FlatBufferObject, Verifiable {
     case photoFormat = 18
     case hdrMode = 20
     case aspectRatio = 22
+    case activeDeviceId = 24
     var v: Int32 { Int32(self.rawValue) }
     var p: VOffset { self.rawValue }
   }
@@ -802,7 +889,9 @@ public struct RemoteShutter_CameraState: FlatBufferObject, Verifiable {
   public var photoFormat: RemoteShutter_PhotoFormat { let o = _accessor.offset(VTOFFSET.photoFormat.v); return o == 0 ? .unknown : RemoteShutter_PhotoFormat(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .unknown }
   public var hdrMode: RemoteShutter_HDRMode { let o = _accessor.offset(VTOFFSET.hdrMode.v); return o == 0 ? .unknown : RemoteShutter_HDRMode(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .unknown }
   public var aspectRatio: RemoteShutter_AspectRatioEnum { let o = _accessor.offset(VTOFFSET.aspectRatio.v); return o == 0 ? .unknown : RemoteShutter_AspectRatioEnum(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .unknown }
-  public static func startCameraState(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 10) }
+  public var activeDeviceId: String? { let o = _accessor.offset(VTOFFSET.activeDeviceId.v); return o == 0 ? nil : _accessor.string(at: o) }
+  public var activeDeviceIdSegmentArray: [UInt8]? { return _accessor.getVector(at: VTOFFSET.activeDeviceId.v) }
+  public static func startCameraState(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 11) }
   public static func add(currentCamera: RemoteShutter_CameraPosition, _ fbb: inout FlatBufferBuilder) { fbb.add(element: currentCamera.rawValue, def: 0, at: VTOFFSET.currentCamera.p) }
   public static func add(currentLens: RemoteShutter_CameraLensType, _ fbb: inout FlatBufferBuilder) { fbb.add(element: currentLens.rawValue, def: 0, at: VTOFFSET.currentLens.p) }
   public static func add(zoomFactor: Double, _ fbb: inout FlatBufferBuilder) { fbb.add(element: zoomFactor, def: 0.0, at: VTOFFSET.zoomFactor.p) }
@@ -813,6 +902,7 @@ public struct RemoteShutter_CameraState: FlatBufferObject, Verifiable {
   public static func add(photoFormat: RemoteShutter_PhotoFormat, _ fbb: inout FlatBufferBuilder) { fbb.add(element: photoFormat.rawValue, def: 0, at: VTOFFSET.photoFormat.p) }
   public static func add(hdrMode: RemoteShutter_HDRMode, _ fbb: inout FlatBufferBuilder) { fbb.add(element: hdrMode.rawValue, def: 0, at: VTOFFSET.hdrMode.p) }
   public static func add(aspectRatio: RemoteShutter_AspectRatioEnum, _ fbb: inout FlatBufferBuilder) { fbb.add(element: aspectRatio.rawValue, def: 0, at: VTOFFSET.aspectRatio.p) }
+  public static func add(activeDeviceId: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: activeDeviceId, at: VTOFFSET.activeDeviceId.p) }
   public static func endCameraState(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createCameraState(
     _ fbb: inout FlatBufferBuilder,
@@ -825,7 +915,8 @@ public struct RemoteShutter_CameraState: FlatBufferObject, Verifiable {
     videoFrameRate: RemoteShutter_VideoFrameRate = .unknown,
     photoFormat: RemoteShutter_PhotoFormat = .unknown,
     hdrMode: RemoteShutter_HDRMode = .unknown,
-    aspectRatio: RemoteShutter_AspectRatioEnum = .unknown
+    aspectRatio: RemoteShutter_AspectRatioEnum = .unknown,
+    activeDeviceIdOffset activeDeviceId: Offset = Offset()
   ) -> Offset {
     let __start = RemoteShutter_CameraState.startCameraState(&fbb)
     RemoteShutter_CameraState.add(currentCamera: currentCamera, &fbb)
@@ -838,6 +929,7 @@ public struct RemoteShutter_CameraState: FlatBufferObject, Verifiable {
     RemoteShutter_CameraState.add(photoFormat: photoFormat, &fbb)
     RemoteShutter_CameraState.add(hdrMode: hdrMode, &fbb)
     RemoteShutter_CameraState.add(aspectRatio: aspectRatio, &fbb)
+    RemoteShutter_CameraState.add(activeDeviceId: activeDeviceId, &fbb)
     return RemoteShutter_CameraState.endCameraState(&fbb, start: __start)
   }
 
@@ -853,6 +945,7 @@ public struct RemoteShutter_CameraState: FlatBufferObject, Verifiable {
     try _v.visit(field: VTOFFSET.photoFormat.p, fieldName: "photoFormat", required: false, type: RemoteShutter_PhotoFormat.self)
     try _v.visit(field: VTOFFSET.hdrMode.p, fieldName: "hdrMode", required: false, type: RemoteShutter_HDRMode.self)
     try _v.visit(field: VTOFFSET.aspectRatio.p, fieldName: "aspectRatio", required: false, type: RemoteShutter_AspectRatioEnum.self)
+    try _v.visit(field: VTOFFSET.activeDeviceId.p, fieldName: "activeDeviceId", required: false, type: ForwardOffset<String>.self)
     _v.finish()
   }
 }
@@ -871,24 +964,37 @@ public struct RemoteShutter_CameraCapabilities: FlatBufferObject, Verifiable {
   private enum VTOFFSET: VOffset {
     case frontCamera = 4
     case backCamera = 6
+    case cameraDevices = 8
+    case activeDeviceId = 10
     var v: Int32 { Int32(self.rawValue) }
     var p: VOffset { self.rawValue }
   }
 
   public var frontCamera: RemoteShutter_CameraInfo? { let o = _accessor.offset(VTOFFSET.frontCamera.v); return o == 0 ? nil : RemoteShutter_CameraInfo(_accessor.bb, o: _accessor.indirect(o + _accessor.position)) }
   public var backCamera: RemoteShutter_CameraInfo? { let o = _accessor.offset(VTOFFSET.backCamera.v); return o == 0 ? nil : RemoteShutter_CameraInfo(_accessor.bb, o: _accessor.indirect(o + _accessor.position)) }
-  public static func startCameraCapabilities(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 2) }
+  public var hasCameraDevices: Bool { let o = _accessor.offset(VTOFFSET.cameraDevices.v); return o == 0 ? false : true }
+  public var cameraDevicesCount: Int32 { let o = _accessor.offset(VTOFFSET.cameraDevices.v); return o == 0 ? 0 : _accessor.vector(count: o) }
+  public func cameraDevices(at index: Int32) -> RemoteShutter_CameraDeviceInfo? { let o = _accessor.offset(VTOFFSET.cameraDevices.v); return o == 0 ? nil : RemoteShutter_CameraDeviceInfo(_accessor.bb, o: _accessor.indirect(_accessor.vector(at: o) + index * 4)) }
+  public var activeDeviceId: String? { let o = _accessor.offset(VTOFFSET.activeDeviceId.v); return o == 0 ? nil : _accessor.string(at: o) }
+  public var activeDeviceIdSegmentArray: [UInt8]? { return _accessor.getVector(at: VTOFFSET.activeDeviceId.v) }
+  public static func startCameraCapabilities(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 4) }
   public static func add(frontCamera: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: frontCamera, at: VTOFFSET.frontCamera.p) }
   public static func add(backCamera: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: backCamera, at: VTOFFSET.backCamera.p) }
+  public static func addVectorOf(cameraDevices: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: cameraDevices, at: VTOFFSET.cameraDevices.p) }
+  public static func add(activeDeviceId: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: activeDeviceId, at: VTOFFSET.activeDeviceId.p) }
   public static func endCameraCapabilities(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createCameraCapabilities(
     _ fbb: inout FlatBufferBuilder,
     frontCameraOffset frontCamera: Offset = Offset(),
-    backCameraOffset backCamera: Offset = Offset()
+    backCameraOffset backCamera: Offset = Offset(),
+    cameraDevicesVectorOffset cameraDevices: Offset = Offset(),
+    activeDeviceIdOffset activeDeviceId: Offset = Offset()
   ) -> Offset {
     let __start = RemoteShutter_CameraCapabilities.startCameraCapabilities(&fbb)
     RemoteShutter_CameraCapabilities.add(frontCamera: frontCamera, &fbb)
     RemoteShutter_CameraCapabilities.add(backCamera: backCamera, &fbb)
+    RemoteShutter_CameraCapabilities.addVectorOf(cameraDevices: cameraDevices, &fbb)
+    RemoteShutter_CameraCapabilities.add(activeDeviceId: activeDeviceId, &fbb)
     return RemoteShutter_CameraCapabilities.endCameraCapabilities(&fbb, start: __start)
   }
 
@@ -896,6 +1002,8 @@ public struct RemoteShutter_CameraCapabilities: FlatBufferObject, Verifiable {
     var _v = try verifier.visitTable(at: position)
     try _v.visit(field: VTOFFSET.frontCamera.p, fieldName: "frontCamera", required: false, type: ForwardOffset<RemoteShutter_CameraInfo>.self)
     try _v.visit(field: VTOFFSET.backCamera.p, fieldName: "backCamera", required: false, type: ForwardOffset<RemoteShutter_CameraInfo>.self)
+    try _v.visit(field: VTOFFSET.cameraDevices.p, fieldName: "cameraDevices", required: false, type: ForwardOffset<Vector<ForwardOffset<RemoteShutter_CameraDeviceInfo>, RemoteShutter_CameraDeviceInfo>>.self)
+    try _v.visit(field: VTOFFSET.activeDeviceId.p, fieldName: "activeDeviceId", required: false, type: ForwardOffset<String>.self)
     _v.finish()
   }
 }

--- a/RemoteCam/FrameSender.swift
+++ b/RemoteCam/FrameSender.swift
@@ -68,6 +68,12 @@ final class FrameSender {
         queue.async {
             guard self.hasSession, let peer = self.peer, let transport = self.transport else { return }
             guard self.window.hasCredit else { return } // back-pressure: drop until a credit frees
+            // ALWAYS .unreliable for frames: a live viewfinder shows the
+            // newest frame or nothing — reliable mode queues and retransmits,
+            // turning any network hiccup into an ever-staler laggy stream.
+            // MC's datagram channel negotiates for ~10s after "Connected" and
+            // drops sends until ready; that is solved by warming the channel
+            // at session connect, never by switching frames to reliable.
             if transport.send(frame, to: [peer], mode: .unreliable).isFailure() {
                 self.coordinator?.tell(FrameSendFailed())
                 return

--- a/RemoteCam/FrameStreamingCoordinator.swift
+++ b/RemoteCam/FrameStreamingCoordinator.swift
@@ -74,6 +74,11 @@ final class FrameStreamingCoordinator: NSObject {
     func acknowledgeWatchPreview() {
         watchPreviewStreamer.acknowledge()
     }
+
+    /// Wall-clock of the most recent video sample buffer, for the rig's
+    /// first-frame watchdog (a suspended or stalled camera delivers nothing,
+    /// forever). Written per-frame on the data queue, read from the watchdog.
+    let lastVideoFrameAt = Locked<TimeInterval>(0)
 }
 
 extension FrameStreamingCoordinator: AVCaptureVideoDataOutputSampleBufferDelegate,
@@ -85,6 +90,7 @@ extension FrameStreamingCoordinator: AVCaptureVideoDataOutputSampleBufferDelegat
         // Route by output identity (`let`s, safe from any thread) rather than
         // comparing connections, which are sessionQueue-owned mutable state.
         if captureOutput === engine.videoDataOutput {
+            lastVideoFrameAt.value = Date().timeIntervalSinceReferenceDate
             sendFrameToMonitor(captureOutput, didOutput: sampleBuffer, from: connection)
         }
         if (pipeline.recordingWillBeStarted || pipeline.isRecording) && !pipeline.recordingWillBeStopped {

--- a/RemoteCam/Info.plist
+++ b/RemoteCam/Info.plist
@@ -37,6 +37,8 @@
 	</array>
 	<key>NSCameraUsageDescription</key>
 	<string>Take Pictures using a Remote Shutter</string>
+	<key>NSCameraUseContinuityCameraDeviceType</key>
+	<true/>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Allow camera to connect to the remote shutter</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/RemoteCam/MonitorPresenter.swift
+++ b/RemoteCam/MonitorPresenter.swift
@@ -109,6 +109,12 @@ public final class MonitorPresenter {
 
     func updateCapabilities(_ capabilities: RemoteCmd.CameraCapabilitiesResp) {
         onMain { display in
+            // Device list first: a Mac camera has no front/back info, so the
+            // guard below would otherwise starve the device picker.
+            display.viewModel.updateCameraDevices(
+                capabilities.cameraDevices,
+                activeID: capabilities.activeDeviceID)
+
             guard let cameraInfo = capabilities.getCurrentCameraInfo() else { return }
             // Update lens controls in view model
             display.updateLensTypesInViewModel(

--- a/RemoteCam/MonitorView.swift
+++ b/RemoteCam/MonitorView.swift
@@ -11,6 +11,7 @@ struct MonitorView: View {
     // Callbacks to MonitorViewController for Actor integration
     let onTakePicture: () -> Void
     let onToggleCamera: () -> Void
+    let onSelectCameraDevice: (String) -> Void
     let onToggleFlash: () -> Void
     let onToggleTorch: () -> Void
     let onTimerChange: (Int) -> Void
@@ -49,29 +50,33 @@ struct MonitorView: View {
             // Camera preview background
             Color.black
             
-            // Camera image with aspect ratio crop overlay
-            if let image = viewModel.cameraImage {
-                Image(uiImage: image)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .clipped()
-                    .overlay(
-                        AspectRatioCropOverlay(
-                            selectedRatio: viewModel.currentAspectRatio,
-                            imageSize: image.size
-                        )
-                    )
-            } else {
-                // Placeholder
-                Rectangle()
-                    .fill(Color.gray.opacity(0.3))
-                    .overlay(
-                        Image(systemName: "camera")
-                            .font(.system(size: 50))
-                            .foregroundColor(.white.opacity(0.5))
-                    )
-            }
+            // Camera image with aspect ratio crop overlay. Its own view so
+            // the ~20fps frame stream re-renders ONLY this subtree — not the
+            // menu and the rest of the chrome.
+            LiveFrameView(frames: viewModel.frames,
+                          aspectRatio: viewModel.currentAspectRatio)
             
+            // Which camera is driving the preview — iOS and Mac peers both
+            // advertise their device list, so the name is always real.
+            if let active = viewModel.remoteCameraDevices.first(where: { $0.isActive }) {
+                VStack {
+                    HStack {
+                        Text(active.localizedName)
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.9))
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(Color.black.opacity(0.45))
+                            .cornerRadius(6)
+                            .padding(.top, 20)
+                            .padding(.leading, 12)
+                        Spacer()
+                    }
+                    Spacer()
+                }
+                .allowsHitTesting(false)
+            }
+
             // Recording indicator with duration timer
             if viewModel.isShowingRecordingDuration {
                 VStack {
@@ -553,12 +558,18 @@ struct MonitorView: View {
             // Main Action Button (Take Photo/Record Video)
             mainActionButton
             
-            // Toggle Camera Button
-            actionButton(
-                systemImage: "arrow.triangle.2.circlepath.camera",
-                action: onToggleCamera,
-                isEnabled: viewModel.isToggleCameraEnabled
+            // Camera switch control, isolated behind Equatable: it must not
+            // re-render (an open menu dismisses if rebuilt) unless the
+            // devices, active ID, or enabled state actually changed.
+            CameraSwitchControlView(
+                control: viewModel.cameraSwitchControl,
+                devices: viewModel.remoteCameraDevices,
+                activeDeviceID: viewModel.activeRemoteDeviceID,
+                isEnabled: viewModel.isToggleCameraEnabled,
+                onToggleCamera: onToggleCamera,
+                onSelectCameraDevice: onSelectCameraDevice
             )
+            .equatable()
         }
     }
     
@@ -667,6 +678,7 @@ struct MonitorView_Previews: PreviewProvider {
             viewModel: MonitorViewModel(),
             onTakePicture: {},
             onToggleCamera: {},
+            onSelectCameraDevice: { _ in },
             onToggleFlash: {},
             onToggleTorch: {},
             onTimerChange: { _ in },
@@ -680,6 +692,122 @@ struct MonitorView_Previews: PreviewProvider {
             onAspectRatioChange: { _ in }
         )
         .preferredColorScheme(.dark)
+    }
+}
+
+// MARK: - Live Frame View
+
+/// Renders the streamed preview frames. Deliberately its own view observing
+/// only `FrameDisplayModel`: frames publish ~20×/sec, and observing them
+/// from `MonitorView` re-rendered every control on each frame.
+struct LiveFrameView: View {
+    @ObservedObject var frames: FrameDisplayModel
+    let aspectRatio: AspectRatio
+
+    var body: some View {
+        if let image = frames.cameraImage {
+            Image(uiImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .clipped()
+                .overlay(
+                    AspectRatioCropOverlay(
+                        selectedRatio: aspectRatio,
+                        imageSize: image.size
+                    )
+                )
+        } else {
+            // Placeholder until the first frame arrives.
+            Rectangle()
+                .fill(Color.gray.opacity(0.3))
+                .overlay(
+                    Image(systemName: "camera")
+                        .font(.system(size: 50))
+                        .foregroundColor(.white.opacity(0.5))
+                )
+        }
+    }
+}
+
+// MARK: - Camera Switch Control
+
+/// The flip button / device menu, sized to the peer's cameras (one: hidden;
+/// two usable: flip; more: menu). Equatable so SwiftUI provably skips it on
+/// unrelated monitor updates — rebuilding a Menu dismisses it while open.
+/// Callbacks are deliberately excluded from equality (they are stable
+/// controller closures).
+struct CameraSwitchControlView: View, Equatable {
+    let control: MonitorViewModel.CameraSwitchControl
+    let devices: [RemoteCmd.CameraDeviceEntry]
+    let activeDeviceID: String?
+    let isEnabled: Bool
+    let onToggleCamera: () -> Void
+    let onSelectCameraDevice: (String) -> Void
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.control == rhs.control
+            && lhs.devices == rhs.devices
+            && lhs.activeDeviceID == rhs.activeDeviceID
+            && lhs.isEnabled == rhs.isEnabled
+    }
+
+    var body: some View {
+        switch control {
+        case .hidden:
+            Color.clear.frame(width: 44, height: 44)   // keep the shutter centered
+        case .flipButton:
+            Button(action: onToggleCamera) {
+                switchIcon
+            }
+            .disabled(!isEnabled)
+        case .deviceMenu:
+            Menu {
+                ForEach(devices, id: \.uniqueID) { device in
+                    CameraDeviceMenuItem(
+                        name: device.localizedName,
+                        isActive: device.uniqueID == activeDeviceID,
+                        isSuspended: device.isSuspended,
+                        select: { onSelectCameraDevice(device.uniqueID) })
+                }
+            } label: {
+                switchIcon
+            }
+            .disabled(!isEnabled)
+        }
+    }
+
+    private var switchIcon: some View {
+        Image(systemName: "arrow.triangle.2.circlepath.camera")
+            .font(.system(size: 24))
+            .foregroundColor(isEnabled ? .white : .gray)
+            .frame(width: 44, height: 44)
+    }
+}
+
+// MARK: - Camera Device Menu Item
+
+/// One camera in a device-picker menu: checkmark on the active device;
+/// suspended devices (connected but delivering no frames — e.g. a clamshell
+/// MacBook's built-in camera) are grayed out and not selectable.
+/// Shared by the monitor's remote picker and the camera screen's local picker.
+struct CameraDeviceMenuItem: View {
+    let name: String
+    let isActive: Bool
+    let isSuspended: Bool
+    let select: () -> Void
+
+    var body: some View {
+        Button(action: select) {
+            if isActive {
+                Label(name, systemImage: "checkmark")
+            } else if isSuspended {
+                Label(String(format: NSLocalizedString("%@ (unavailable)", comment: "suspended camera"), name),
+                      systemImage: "moon.zzz")
+            } else {
+                Text(name)
+            }
+        }
+        .disabled(isSuspended)
     }
 }
 

--- a/RemoteCam/MonitorViewController+SwiftUI.swift
+++ b/RemoteCam/MonitorViewController+SwiftUI.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import UIKit
 import AVFoundation
+import PhotosUI
 
 // MARK: - MonitorViewController SwiftUI Integration
 extension MonitorViewController {
@@ -15,6 +16,9 @@ extension MonitorViewController {
             },
             onToggleCamera: { [weak self] in
                 self?.handleToggleCamera()
+            },
+            onSelectCameraDevice: { [weak self] uniqueID in
+                self?.handleSelectCameraDevice(uniqueID)
             },
             onToggleFlash: { [weak self] in
                 self?.handleToggleFlash()
@@ -159,6 +163,10 @@ extension MonitorViewController {
         }
     }
     
+    private func handleSelectCameraDevice(_ uniqueID: String) {
+        session ! UICmd.SelectCameraDevice(uniqueID: uniqueID)
+    }
+
     private func handleToggleCamera() {
         session ! UICmd.ToggleCamera()
     }
@@ -247,20 +255,13 @@ extension MonitorViewController {
     // MARK: - Helper Methods
     
     private func showGallery() {
-        let imagePickerController = UIImagePickerController()
-        imagePickerController.delegate = self
-        imagePickerController.sourceType = .photoLibrary
-        imagePickerController.mediaTypes = ["public.image", "public.movie"]
-        
-        #if targetEnvironment(macCatalyst)
-        imagePickerController.modalPresentationStyle = .pageSheet
-        #else
-        imagePickerController.modalPresentationStyle = .popover
-        imagePickerController.popoverPresentationController?.sourceView = view
-        imagePickerController.popoverPresentationController?.sourceRect = CGRect(x: view.bounds.midX, y: view.bounds.midY, width: 0, height: 0)
-        #endif
-        
-        present(imagePickerController, animated: true)
+        var config = PHPickerConfiguration()
+        config.filter = .any(of: [.images, .videos])
+        config.selectionLimit = 1
+        let picker = PHPickerViewController(configuration: config)
+        picker.delegate = self
+        picker.modalPresentationStyle = .pageSheet
+        present(picker, animated: true)
     }
     
     private func showSettings() {

--- a/RemoteCam/MonitorViewController.swift
+++ b/RemoteCam/MonitorViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 import SwiftUI
 import AVFoundation
+import PhotosUI
 
 let timerDefault = "timerDefault"
 
@@ -18,7 +19,7 @@ let timerDefault = "timerDefault"
 UI for the monitor.
 */
 
-public class MonitorViewController: UIViewController, UIImagePickerControllerDelegate & UINavigationControllerDelegate {
+public class MonitorViewController: UIViewController {
 
     let session: SessionCoordinator
 
@@ -184,19 +185,31 @@ public class MonitorViewController: UIViewController, UIImagePickerControllerDel
     
     // All legacy UIKit methods removed - using SwiftUI view model integration instead
     
-    // MARK: - Essential UIImagePickerController Delegate (keep for now)
-    public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
-        if let image = info[.originalImage] {
-            let activityViewController = UIActivityViewController(activityItems: [image], applicationActivities: [])
-            picker.dismiss(animated: true) {
-                #if targetEnvironment(macCatalyst)
-                activityViewController.modalPresentationStyle = UIModalPresentationStyle.pageSheet
-                #else
-                activityViewController.modalPresentationStyle = UIModalPresentationStyle.popover
-                // Note: Using view instead of removed galleryButton
-                activityViewController.popoverPresentationController?.sourceView = self.view
-                #endif
-                self.present(activityViewController, animated: true)
+}
+
+// MARK: - Gallery picker (PHPicker: modern, no photo-library permission prompt)
+
+extension MonitorViewController: PHPickerViewControllerDelegate {
+    public func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        guard let provider = results.first?.itemProvider,
+              provider.canLoadObject(ofClass: UIImage.self) else {
+            picker.dismiss(animated: true)
+            return
+        }
+        provider.loadObject(ofClass: UIImage.self) { [weak self] object, _ in
+            DispatchQueue.main.async {
+                picker.dismiss(animated: true) {
+                    guard let self, let image = object as? UIImage else { return }
+                    let activityViewController = UIActivityViewController(
+                        activityItems: [image], applicationActivities: [])
+                    #if targetEnvironment(macCatalyst)
+                    activityViewController.modalPresentationStyle = .pageSheet
+                    #else
+                    activityViewController.modalPresentationStyle = .popover
+                    activityViewController.popoverPresentationController?.sourceView = self.view
+                    #endif
+                    self.present(activityViewController, animated: true)
+                }
             }
         }
     }

--- a/RemoteCam/MonitorViewModel.swift
+++ b/RemoteCam/MonitorViewModel.swift
@@ -10,13 +10,24 @@ enum MonitorUIState {
     case shortsMode
 }
 
+// MARK: - Frame Display Model
+
+/// The live-preview frame stream, isolated from the rest of the monitor's
+/// state: frames arrive ~20×/sec, and publishing them through the main view
+/// model re-rendered every control on each frame (the device menu visibly
+/// flickered). Only the preview's `LiveFrameView` observes this.
+final class FrameDisplayModel: ObservableObject {
+    @Published var cameraImage: UIImage?
+}
+
 // MARK: - Monitor View Model
 class MonitorViewModel: ObservableObject {
     // MARK: - Published Properties
     @Published var currentMode: RecordingMode = .Photo
     @Published var uiState: MonitorUIState = .photoMode
     @Published var isRecording: Bool = false
-    @Published var cameraImage: UIImage?
+    /// Live frames — deliberately NOT @Published here; see FrameDisplayModel.
+    let frames = FrameDisplayModel()
     @Published var flashStatus: String = ""
     @Published var isFlashEnabled: Bool = false
     @Published var isTorchEnabled: Bool = false
@@ -46,6 +57,36 @@ class MonitorViewModel: ObservableObject {
 
     // MARK: - Aspect Ratio Properties
     @Published var currentAspectRatio: AspectRatio = .sixteenNine
+
+    // MARK: - Remote Camera Devices (empty = peer predates device selection)
+    @Published var remoteCameraDevices: [RemoteCmd.CameraDeviceEntry] = []
+    @Published var activeRemoteDeviceID: String?
+
+    /// Which switch control the monitor shows for the peer's cameras.
+    enum CameraSwitchControl {
+        /// One camera — nothing to switch to.
+        case hidden
+        /// Two usable cameras (or a legacy peer with no device list):
+        /// the classic flip button, tap toggles.
+        case flipButton
+        /// Three or more cameras — or a suspended one worth *seeing* grayed
+        /// out: a menu, tap opens the device list.
+        case deviceMenu
+    }
+
+    static func switchControl(for devices: [RemoteCmd.CameraDeviceEntry]) -> CameraSwitchControl {
+        guard !devices.isEmpty else { return .flipButton }   // legacy peer: count unknown
+        let healthy = devices.filter { !$0.isSuspended }
+        switch (devices.count, healthy.count) {
+        case (1, _): return .hidden
+        case (2, 2): return .flipButton
+        default: return .deviceMenu
+        }
+    }
+
+    var cameraSwitchControl: CameraSwitchControl {
+        Self.switchControl(for: remoteCameraDevices)
+    }
     
     // MARK: - Video Transfer Progress Properties
     @Published var isVideoTransferring: Bool = false
@@ -166,7 +207,7 @@ class MonitorViewModel: ObservableObject {
     // MARK: - Update Methods (called from MonitorViewController Actor messages)
     func updateCameraImage(_ image: UIImage?) {
         DispatchQueue.main.async {
-            self.cameraImage = image
+            self.frames.cameraImage = image
         }
     }
     
@@ -211,6 +252,20 @@ class MonitorViewModel: ObservableObject {
     func updateAspectRatio(_ ratio: AspectRatio) {
         DispatchQueue.main.async {
             self.currentAspectRatio = ratio
+        }
+    }
+
+    func updateCameraDevices(_ devices: [RemoteCmd.CameraDeviceEntry], activeID: String?) {
+        DispatchQueue.main.async {
+            // Capabilities re-broadcasts are frequent (device switches,
+            // hot-plug); only publish real changes so the picker menu isn't
+            // rebuilt for identical content.
+            if self.remoteCameraDevices != devices {
+                self.remoteCameraDevices = devices
+            }
+            if self.activeRemoteDeviceID != activeID {
+                self.activeRemoteDeviceID = activeID
+            }
         }
     }
 

--- a/RemoteCam/OrientationUtils.swift
+++ b/RemoteCam/OrientationUtils.swift
@@ -12,6 +12,20 @@ import UIKit
 
 public class OrientationUtils {
 
+    /// Whether this platform rotates capture/preview connections to match the
+    /// interface orientation. iOS sensors are portrait-native and need the
+    /// rotation for buffers to leave the connection upright; Mac cameras are
+    /// landscape-native and already upright, so Catalyst never applies
+    /// interface-derived rotation. Single definition of the policy — every
+    /// connection-orientation write reads this.
+    public static var appliesInterfaceRotation: Bool {
+        #if targetEnvironment(macCatalyst)
+        return false
+        #else
+        return true
+        #endif
+    }
+
     class public func transform(o: UIInterfaceOrientation) -> AVCaptureVideoOrientation {
         switch o {
         case .landscapeLeft:

--- a/RemoteCam/PermissionManager.swift
+++ b/RemoteCam/PermissionManager.swift
@@ -101,13 +101,21 @@ class PermissionManager: ObservableObject {
     // MARK: - Settings Navigation
     
     func openAppSettings() {
+        #if targetEnvironment(macCatalyst)
+        // macOS has no per-app settings page; land on Privacy & Security,
+        // where the camera/microphone/photos toggles live.
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy") {
+            UIApplication.shared.open(url)
+        }
+        #else
         guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
             return
         }
-        
+
         if UIApplication.shared.canOpenURL(settingsUrl) {
             UIApplication.shared.open(settingsUrl)
         }
+        #endif
     }
     
     // MARK: - Helper Methods

--- a/RemoteCam/Photos.swift
+++ b/RemoteCam/Photos.swift
@@ -18,8 +18,15 @@ func goToPhotos() {
 }
 
 func getOrientation() -> UIInterfaceOrientation {
+    #if targetEnvironment(macCatalyst)
+    // Macs don't rotate and their cameras are landscape-native: report a
+    // fixed landscape orientation so capture connections and streamed frames
+    // stay unrotated and monitors render them as-is.
+    return .landscapeRight
+    #else
     return UIApplication.shared.connectedScenes
         .compactMap { $0 as? UIWindowScene }
         .first(where: { $0.activationState == .foregroundActive })?
         .interfaceOrientation ?? .portrait
+    #endif
 }

--- a/RemoteCam/RemoteCmdFlatBuffers.swift
+++ b/RemoteCam/RemoteCmdFlatBuffers.swift
@@ -41,7 +41,8 @@ func serializeToFlatBuffer(_ msg: Message) -> Data? {
     case let m as RemoteCmd.SetTorch: return m.toFlatBuffer()
     case let m as RemoteCmd.SetTorchResp: return m.toFlatBuffer()
     case let m as RemoteCmd.ToggleCamera: return m.toFlatBuffer()
-    case let m as RemoteCmd.ToggleCameraResp: return m.toFlatBuffer()
+    case let m as RemoteCmd.ToggleCameraResp: return m.toFlatBuffer() // also SelectCameraDeviceResp (subclass)
+    case let m as RemoteCmd.SelectCameraDevice: return m.toFlatBuffer()
     case let m as RemoteCmd.RequestCameraCapabilities: return m.toFlatBuffer()
     case let m as RemoteCmd.SetVideoQuality: return m.toFlatBuffer()
     case let m as RemoteCmd.SetVideoQualityResp: return m.toFlatBuffer()
@@ -368,6 +369,81 @@ private func decodeCameraInfo(_ fb: RemoteShutter_CameraInfo) -> RemoteCmd.Camer
     )
 }
 
+// MARK: - Capabilities envelope encode helpers
+
+/// Encodes a `CameraCapabilitiesResp` into the wire `CameraCapabilities` +
+/// `CameraState` pair, including the appended camera-device list. Shared by
+/// every response that carries capabilities (request/toggle/select).
+private func encodeCapabilitiesEnvelope(
+    _ c: RemoteCmd.CameraCapabilitiesResp,
+    _ fbb: inout FlatBufferBuilder
+) -> (caps: Offset, state: Offset) {
+    let frontOffset = c.frontCamera.map { encodeCameraInfo($0, &fbb) } ?? Offset()
+    let backOffset = c.backCamera.map { encodeCameraInfo($0, &fbb) } ?? Offset()
+
+    var devicesVector = Offset()
+    if !c.cameraDevices.isEmpty {
+        let deviceOffsets = c.cameraDevices.map { entry -> Offset in
+            let idOffset = fbb.create(string: entry.uniqueID)
+            let nameOffset = fbb.create(string: entry.localizedName)
+            let infoOffset = entry.info.map { encodeCameraInfo($0, &fbb) } ?? Offset()
+            return RemoteShutter_CameraDeviceInfo.createCameraDeviceInfo(
+                &fbb,
+                uniqueIdOffset: idOffset,
+                localizedNameOffset: nameOffset,
+                position: toFBCamPos(entry.position),
+                hasUnspecifiedPosition: entry.position == .unspecified,
+                isActive: entry.isActive,
+                infoOffset: infoOffset,
+                isSuspended: entry.isSuspended)
+        }
+        devicesVector = fbb.createVector(ofOffsets: deviceOffsets)
+    }
+    let activeIDOffset = c.activeDeviceID.map { fbb.create(string: $0) } ?? Offset()
+
+    let capsOffset = RemoteShutter_CameraCapabilities.createCameraCapabilities(
+        &fbb,
+        frontCameraOffset: frontOffset,
+        backCameraOffset: backOffset,
+        cameraDevicesVectorOffset: devicesVector,
+        activeDeviceIdOffset: activeIDOffset)
+
+    let stateOffset = RemoteShutter_CameraState.createCameraState(
+        &fbb,
+        currentCamera: toFBCamPos(c.currentCamera),
+        currentLens: toFBLens(c.currentLens),
+        zoomFactor: Double(c.currentZoom),
+        videoResolution: toFBResolution(c.currentVideoResolution),
+        videoFrameRate: toFBFrameRate(c.currentVideoFrameRate),
+        photoFormat: toFBPhotoFormat(c.currentPhotoFormat),
+        hdrMode: toFBHDRMode(c.currentHDRMode),
+        activeDeviceIdOffset: activeIDOffset)
+
+    return (capsOffset, stateOffset)
+}
+
+/// Builds a full capabilities-carrying response for the given action.
+private func encodeCapabilitiesResponse(action: RemoteShutter_CommandAction,
+                                        capabilities: RemoteCmd.CameraCapabilitiesResp?,
+                                        error: Error?) -> Data {
+    var fbb = FlatBufferBuilder()
+    let errorOffset = (error as NSError?).map { fbb.create(string: $0.localizedDescription) } ?? Offset()
+    var capsOffset = Offset()
+    var stateOffset = Offset()
+    if let c = capabilities {
+        (capsOffset, stateOffset) = encodeCapabilitiesEnvelope(c, &fbb)
+    }
+    let resp = RemoteShutter_CameraStateResponse.createCameraStateResponse(
+        &fbb,
+        action: action,
+        success: error == nil,
+        errorOffset: errorOffset,
+        currentStateOffset: stateOffset,
+        capabilitiesOffset: capsOffset
+    )
+    return buildResponse(&fbb, action: action, response: resp)
+}
+
 // MARK: - toFlatBuffer() extensions
 
 extension RemoteCmd.StartRecordingVideo {
@@ -526,33 +602,7 @@ extension RemoteCmd.SetZoomResp {
 
 extension RemoteCmd.CameraCapabilitiesResp {
     func toFlatBuffer() -> Data {
-        var fbb = FlatBufferBuilder()
-        let errorOffset = (self.error as NSError?).map { fbb.create(string: $0.localizedDescription) } ?? Offset()
-
-        let frontOffset = frontCamera.map { encodeCameraInfo($0, &fbb) } ?? Offset()
-        let backOffset = backCamera.map { encodeCameraInfo($0, &fbb) } ?? Offset()
-        let capsOffset = RemoteShutter_CameraCapabilities.createCameraCapabilities(&fbb, frontCameraOffset: frontOffset, backCameraOffset: backOffset)
-
-        let stateOffset = RemoteShutter_CameraState.createCameraState(
-            &fbb,
-            currentCamera: toFBCamPos(currentCamera),
-            currentLens: toFBLens(currentLens),
-            zoomFactor: Double(currentZoom),
-            videoResolution: toFBResolution(currentVideoResolution),
-            videoFrameRate: toFBFrameRate(currentVideoFrameRate),
-            photoFormat: toFBPhotoFormat(currentPhotoFormat),
-            hdrMode: toFBHDRMode(currentHDRMode)
-        )
-
-        let resp = RemoteShutter_CameraStateResponse.createCameraStateResponse(
-            &fbb,
-            action: .requestcapabilities,
-            success: error == nil,
-            errorOffset: errorOffset,
-            currentStateOffset: stateOffset,
-            capabilitiesOffset: capsOffset
-        )
-        return buildResponse(&fbb, action: .requestcapabilities, response: resp)
+        encodeCapabilitiesResponse(action: .requestcapabilities, capabilities: self, error: error)
     }
 }
 
@@ -726,36 +776,20 @@ extension RemoteCmd.ToggleCamera {
 
 extension RemoteCmd.ToggleCameraResp {
     func toFlatBuffer() -> Data {
+        // SelectCameraDeviceResp subclasses this type; the payload shape is
+        // identical, only the wire action differs.
+        let action: RemoteShutter_CommandAction =
+            self is RemoteCmd.SelectCameraDeviceResp ? .selectcameradevice : .togglecamera
+        return encodeCapabilitiesResponse(action: action, capabilities: cameraCapabilities, error: error)
+    }
+}
+
+extension RemoteCmd.SelectCameraDevice {
+    func toFlatBuffer() -> Data {
         var fbb = FlatBufferBuilder()
-        let errorOffset = (error as NSError?).map { fbb.create(string: $0.localizedDescription) } ?? Offset()
-
-        var capsOffset = Offset()
-        var stateOffset = Offset()
-        if let c = cameraCapabilities {
-            let frontOffset = c.frontCamera.map { encodeCameraInfo($0, &fbb) } ?? Offset()
-            let backOffset = c.backCamera.map { encodeCameraInfo($0, &fbb) } ?? Offset()
-            capsOffset = RemoteShutter_CameraCapabilities.createCameraCapabilities(&fbb, frontCameraOffset: frontOffset, backCameraOffset: backOffset)
-            stateOffset = RemoteShutter_CameraState.createCameraState(
-                &fbb,
-                currentCamera: toFBCamPos(c.currentCamera),
-                currentLens: toFBLens(c.currentLens),
-                zoomFactor: Double(c.currentZoom),
-                videoResolution: toFBResolution(c.currentVideoResolution),
-                videoFrameRate: toFBFrameRate(c.currentVideoFrameRate),
-                photoFormat: toFBPhotoFormat(c.currentPhotoFormat),
-                hdrMode: toFBHDRMode(c.currentHDRMode)
-            )
-        }
-
-        let resp = RemoteShutter_CameraStateResponse.createCameraStateResponse(
-            &fbb,
-            action: .togglecamera,
-            success: error == nil,
-            errorOffset: errorOffset,
-            currentStateOffset: stateOffset,
-            capabilitiesOffset: capsOffset
-        )
-        return buildResponse(&fbb, action: .togglecamera, response: resp)
+        let idOffset = fbb.create(string: uniqueID)
+        let params = RemoteShutter_CommandParameters.createCommandParameters(&fbb, deviceUniqueIdOffset: idOffset)
+        return buildCommand(&fbb, action: .selectcameradevice, parameters: params)
     }
 }
 
@@ -1019,6 +1053,9 @@ extension RemoteCmd {
         case .setaspectratio:
             let ratio = fromFBAspectRatio(params?.aspectRatio ?? .unknown)
             return SetAspectRatio(aspectRatio: ratio)
+
+        case .selectcameradevice:
+            return SelectCameraDevice(uniqueID: params?.deviceUniqueId ?? "")
         }
     }
 
@@ -1099,6 +1136,13 @@ extension RemoteCmd {
             let capabilities = decodeCameraCapabilitiesResp(resp, error: nil)
             return ToggleCameraResp(cameraCapabilities: capabilities, error: nil)
 
+        case .selectcameradevice:
+            if nsError != nil {
+                return SelectCameraDeviceResp(cameraCapabilities: nil, error: nsError)
+            }
+            let capabilities = decodeCameraCapabilitiesResp(resp, error: nil)
+            return SelectCameraDeviceResp(cameraCapabilities: capabilities, error: nil)
+
         case .setvideoquality:
             let state = resp.currentState
             let resolution: VideoResolution? = state.map { fromFBResolution($0.videoResolution) }
@@ -1128,6 +1172,25 @@ extension RemoteCmd {
         let frontCamera: CameraInfo? = caps?.frontCamera.map { decodeCameraInfo($0) }
         let backCamera: CameraInfo? = caps?.backCamera.map { decodeCameraInfo($0) }
 
+        // Appended fields: absent on legacy peers, which leaves the device
+        // list empty — the signal that SelectCameraDevice must not be sent.
+        var cameraDevices: [CameraDeviceEntry] = []
+        if let caps {
+            for i in 0..<caps.cameraDevicesCount {
+                guard let d = caps.cameraDevices(at: i) else { continue }
+                let position: AVCaptureDevice.Position =
+                    d.hasUnspecifiedPosition ? .unspecified : fromFBCamPos(d.position)
+                cameraDevices.append(CameraDeviceEntry(
+                    uniqueID: d.uniqueId ?? "",
+                    localizedName: d.localizedName ?? "",
+                    positionRaw: position.rawValue,
+                    isActive: d.isActive,
+                    isSuspended: d.isSuspended,
+                    info: d.info.map { decodeCameraInfo($0) }))
+            }
+        }
+        let activeDeviceID = caps?.activeDeviceId ?? state?.activeDeviceId
+
         return CameraCapabilitiesResp(
             frontCamera: frontCamera,
             backCamera: backCamera,
@@ -1138,6 +1201,8 @@ extension RemoteCmd {
             currentVideoFrameRate: state.map { fromFBFrameRate($0.videoFrameRate) } ?? .fps30,
             currentPhotoFormat: state.map { fromFBPhotoFormat($0.photoFormat) } ?? .jpeg,
             currentHDRMode: state.map { fromFBHDRMode($0.hdrMode) } ?? .off,
+            cameraDevices: cameraDevices,
+            activeDeviceID: activeDeviceID,
             error: error
         )
     }

--- a/RemoteCam/RemoteCmds.swift
+++ b/RemoteCam/RemoteCmds.swift
@@ -219,7 +219,7 @@ public class RemoteCmd: Message {
 
     // MARK: - Camera Capabilities Structure
 
-    public struct CameraInfo: Codable {
+    public struct CameraInfo: Codable, Equatable {
         public let availableLenses: [CameraLensType]
         public let hasFlash: Bool
         public let hasTorch: Bool
@@ -269,13 +269,47 @@ public class RemoteCmd: Message {
         }
     }
 
-    public struct ZoomRange: Codable {
+    public struct ZoomRange: Codable, Equatable {
         public let minZoom: CGFloat
         public let maxZoom: CGFloat
 
         public init(minZoom: CGFloat, maxZoom: CGFloat) {
             self.minZoom = minZoom
             self.maxZoom = maxZoom
+        }
+    }
+
+    // MARK: - Camera Device List (N cameras; Macs have no front/back pair)
+
+    /// One selectable camera on the camera peer, as advertised in
+    /// `CameraCapabilitiesResp.cameraDevices`. An empty device list means the
+    /// peer predates device selection — the monitor must not send
+    /// `SelectCameraDevice` to it.
+    public struct CameraDeviceEntry: Codable, Equatable {
+        public let uniqueID: String
+        public let localizedName: String
+        /// AVCaptureDevice.Position.rawValue; `.unspecified` is preserved here
+        /// (the wire carries Back + has_unspecified_position for old peers).
+        public let positionRaw: Int
+        public let isActive: Bool
+        /// Connected but delivering no frames (Mac clamshell built-in camera):
+        /// pickers show it grayed out; selection is rejected.
+        public let isSuspended: Bool
+        public let info: CameraInfo?
+
+        public var position: AVCaptureDevice.Position {
+            AVCaptureDevice.Position(rawValue: positionRaw) ?? .unspecified
+        }
+
+        public init(uniqueID: String, localizedName: String,
+                    positionRaw: Int, isActive: Bool,
+                    isSuspended: Bool = false, info: CameraInfo?) {
+            self.uniqueID = uniqueID
+            self.localizedName = localizedName
+            self.positionRaw = positionRaw
+            self.isActive = isActive
+            self.isSuspended = isSuspended
+            self.info = info
         }
     }
 
@@ -291,6 +325,8 @@ public class RemoteCmd: Message {
         public let currentVideoFrameRate: VideoFrameRate
         public let currentPhotoFormat: PhotoFormat
         public let currentHDRMode: HDRMode
+        public let cameraDevices: [CameraDeviceEntry]
+        public let activeDeviceID: String?
         public let error: Error?
 
         public init(frontCamera: CameraInfo?, backCamera: CameraInfo?,
@@ -300,6 +336,8 @@ public class RemoteCmd: Message {
                    currentVideoFrameRate: VideoFrameRate = .fps30,
                    currentPhotoFormat: PhotoFormat = .jpeg,
                    currentHDRMode: HDRMode = .off,
+                   cameraDevices: [CameraDeviceEntry] = [],
+                   activeDeviceID: String? = nil,
                    error: Error?) {
             self.frontCamera = frontCamera
             self.backCamera = backCamera
@@ -310,6 +348,8 @@ public class RemoteCmd: Message {
             self.currentVideoFrameRate = currentVideoFrameRate
             self.currentPhotoFormat = currentPhotoFormat
             self.currentHDRMode = currentHDRMode
+            self.cameraDevices = cameraDevices
+            self.activeDeviceID = activeDeviceID
             self.error = error
             super.init(sender: nil)
         }
@@ -452,6 +492,25 @@ public class RemoteCmd: Message {
             super.init(sender: nil)
         }
     }
+
+    // MARK: - Camera Device Selection (guarded by capability advertising)
+
+    /// Switch the camera peer to the device with this uniqueID. Only valid
+    /// against peers whose capabilities carried a non-empty `cameraDevices`
+    /// list — old decoders read unknown actions as TakePicture.
+    public class SelectCameraDevice: Message {
+        public let uniqueID: String
+
+        public init(uniqueID: String) {
+            self.uniqueID = uniqueID
+            super.init(sender: nil)
+        }
+    }
+
+    /// Subclasses ToggleCameraResp: the monitor treats a completed device
+    /// selection exactly like a completed front/back toggle — fresh
+    /// capabilities in, UI re-synced — so it shares that state's handling.
+    public class SelectCameraDeviceResp: ToggleCameraResp {}
 
     public class SetZoomResp: Message {
         public let zoomFactor: CGFloat?

--- a/RemoteCam/RolePickerController.swift
+++ b/RemoteCam/RolePickerController.swift
@@ -72,7 +72,13 @@ public class RolePickerController: UIViewController {
     }
 
     func becomeWatchRemote() {
+        #if targetEnvironment(macCatalyst)
+        // No WatchConnectivity on the Mac; the role-picker row is already
+        // hidden (watchPaired stays false), this guards the seam itself.
+        return
+        #else
         checkCameraPermissionsForWatchRemote()
+        #endif
     }
 
     private func checkCameraPermissionsForWatchRemote() {

--- a/RemoteCam/SessionCoordinator.swift
+++ b/RemoteCam/SessionCoordinator.swift
@@ -170,6 +170,12 @@ public actor SessionCoordinator {
     private var ctrl: CameraControlling?
     private var monitor: MonitorPresenter?
 
+    /// Whether the connected camera peer advertised a camera-device list in
+    /// its capabilities — the feature gate for `RemoteCmd.SelectCameraDevice`.
+    /// Never send that command otherwise: old decoders read unknown command
+    /// actions as TakePicture (the FlatBuffers field default).
+    private var peerAdvertisedCameraDevices = false
+
     /// Test support: the generation of the most recently armed timeout.
     func currentTimeoutGeneration() -> Int { timeoutGeneration }
 
@@ -368,6 +374,7 @@ public actor SessionCoordinator {
     /// Pop to scanning (stops at the lobby floor like the old machine) and
     /// restart discovery via `.scanning`'s entry behavior.
     func popToScanning() async {
+        peerAdvertisedCameraDevices = false
         switch state {
         case .scanning:
             // Already there — re-entering would restart discovery and reset
@@ -578,12 +585,26 @@ public actor SessionCoordinator {
         case is RemoteCmd.ToggleCamera:
             do {
                 _ = try await ctrl.toggleCamera()
+                try await confirmFrameDelivery(ctrl)
                 await ctrl.gatherAllCameraCapabilities()
                 let capabilities = await ctrl.gatherCurrentCameraCapabilities()
                 await sendOrGoToScanning(RemoteCmd.ToggleCameraResp(
                     cameraCapabilities: capabilities, error: nil))
             } catch {
                 await sendOrGoToScanning(RemoteCmd.ToggleCameraResp(
+                    cameraCapabilities: nil, error: error as NSError))
+            }
+
+        case let select as RemoteCmd.SelectCameraDevice:
+            do {
+                _ = try await ctrl.selectCameraDevice(uniqueID: select.uniqueID)
+                try await confirmFrameDelivery(ctrl)
+                await ctrl.gatherAllCameraCapabilities()
+                let capabilities = await ctrl.gatherCurrentCameraCapabilities()
+                await sendOrGoToScanning(RemoteCmd.SelectCameraDeviceResp(
+                    cameraCapabilities: capabilities, error: nil))
+            } catch {
+                await sendOrGoToScanning(RemoteCmd.SelectCameraDeviceResp(
                     cameraCapabilities: nil, error: error as NSError))
             }
 
@@ -678,6 +699,23 @@ public actor SessionCoordinator {
 
         default:
             await handleRoot(msg)
+        }
+    }
+
+    /// A camera can accept an input swap and still never deliver a frame (a
+    /// wedged virtual camera): a switch is only *successful* once a frame
+    /// actually arrives, so the monitor gets a real error instead of a
+    /// silently black preview. Bounded wait — shorter than the rig watchdog
+    /// (5s, which restores a working device) and the monitor's state timeout
+    /// (10s). Deliberately blocks this camera's inbox meanwhile: the peer is
+    /// waiting on this exact response, and busy states already reject
+    /// concurrent commands.
+    private func confirmFrameDelivery(_ ctrl: CameraControlling) async throws {
+        guard await ctrl.awaitFrameDelivery(timeout: 4) else {
+            let name = await ctrl.currentCameraDevice()?.localizedName ?? "Camera"
+            throw NSError(
+                domain: String(format: NSLocalizedString("%@ is not delivering video", comment: "dead camera"), name),
+                code: 0, userInfo: nil)
         }
     }
 
@@ -898,6 +936,8 @@ public actor SessionCoordinator {
             await sendOrGoToScanning(RemoteCmd.TakePicResp(sender: nil, error: unableToProcessError(msg)))
         case is RemoteCmd.ToggleCamera:
             await sendOrGoToScanning(RemoteCmd.ToggleCameraResp(cameraCapabilities: nil, error: unableToProcessError(msg)))
+        case is RemoteCmd.SelectCameraDevice:
+            await sendOrGoToScanning(RemoteCmd.SelectCameraDeviceResp(cameraCapabilities: nil, error: unableToProcessError(msg)))
         case is RemoteCmd.ToggleFlash:
             await sendOrGoToScanning(RemoteCmd.ToggleFlashResp(flashMode: nil, error: unableToProcessError(msg)))
         case is RemoteCmd.SetZoom:
@@ -1061,6 +1101,19 @@ public actor SessionCoordinator {
                 await popToScanning()
             }
 
+        case let select as UICmd.SelectCameraDevice:
+            guard peerAdvertisedCameraDevices else {
+                debugLog("SelectCameraDevice dropped: peer did not advertise camera devices")
+                break
+            }
+            if sendMessage(RemoteCmd.SelectCameraDevice(uniqueID: select.uniqueID)) {
+                await showCameraAlert(NSLocalizedString("Switching camera", comment: ""))
+                let generation = scheduleTimeout(.monitorTogglingCamera)
+                await transition(to: .monitorTogglingCamera(mode: mode, generation: generation))
+            } else {
+                await popToScanning()
+            }
+
         case is UICmd.ToggleFlash where mode == .photo:
             if sendMessage(RemoteCmd.ToggleFlash()) {
                 await showCameraAlert("Requesting flash toggle")
@@ -1098,6 +1151,7 @@ public actor SessionCoordinator {
             }
 
         case let capabilities as RemoteCmd.CameraCapabilitiesResp:
+            peerAdvertisedCameraDevices = !capabilities.cameraDevices.isEmpty
             monitor?.updateCapabilities(capabilities)
 
         case let zoom as UICmd.SetZoom:
@@ -1226,6 +1280,8 @@ public actor SessionCoordinator {
             break // Already sent from parent state; ignore duplicate taps
         case is UICmd.ToggleCamera where kind == .camera:
             break // Already sent from parent state; ignore duplicate taps
+        case is UICmd.SelectCameraDevice where kind == .camera:
+            break // A selection is already in flight; ignore duplicate taps
 
         case let flashResp as RemoteCmd.ToggleFlashResp where kind == .flash:
             if flashResp.flashMode != nil {
@@ -1240,9 +1296,12 @@ public actor SessionCoordinator {
             await transition(to: .monitor(mode: mode))
 
         case let toggleResp as RemoteCmd.ToggleCameraResp where kind == .camera:
+            // Also matches SelectCameraDeviceResp (a subclass): a completed
+            // device selection re-syncs the monitor exactly like a toggle.
             // Forward the fresh capabilities so the monitor UI re-syncs to the
             // new camera (lens list, zoom range, quality).
             if let capabilities = toggleResp.cameraCapabilities {
+                peerAdvertisedCameraDevices = !capabilities.cameraDevices.isEmpty
                 monitor?.updateCapabilities(capabilities)
                 await dismissCameraAlert()
             } else if let error = toggleResp.error {
@@ -1806,6 +1865,16 @@ extension SessionCoordinator: MultipeerServiceDelegate {
     }
 
     public nonisolated func peerDidConnect(_ peer: MCPeerID) {
+        // Warm MultipeerConnectivity's unreliable datagram channel: it
+        // negotiates lazily on first use (~10s) and silently drops sends
+        // until ready ("giving up for participant" in the MC logs). One
+        // no-op ping here starts that clock at connect, so negotiation
+        // finishes while the user is still picking roles and the live
+        // preview flows from its very first frame. RequestFrame is the safe
+        // no-op: a stray one is treated as a frame-credit ack, and the
+        // credit window clamps at zero.
+        _ = transportShared.value?.send(
+            RemoteCmd.RequestFrame(sender: nil), to: [peer], mode: .unreliable)
         tell(OnConnectToDevice(peer: peer, sender: nil))
     }
 

--- a/RemoteCam/UICmds.swift
+++ b/RemoteCam/UICmds.swift
@@ -406,7 +406,18 @@ public class UICmd {
             super.init(sender: nil)
         }
     }
-    
+
+    /// Monitor UI asks the camera peer to switch to a specific device
+    /// (by uniqueID from the advertised `cameraDevices` list).
+    public class SelectCameraDevice: Message {
+        public let uniqueID: String
+
+        public init(uniqueID: String) {
+            self.uniqueID = uniqueID
+            super.init(sender: nil)
+        }
+    }
+
     // MARK: - Video Resource Transfer Messages
     
     @objc(_TtCC10ActorsDemo5UICmd17SendVideoResource)public class SendVideoResource: Message, NSCoding {

--- a/RemoteCam/WatchSessionManager.swift
+++ b/RemoteCam/WatchSessionManager.swift
@@ -9,7 +9,9 @@
 
 import Foundation
 import UIKit
+#if !targetEnvironment(macCatalyst)
 import WatchConnectivity
+#endif
 import FlatBuffers
 
 /// Seam through which `RemoteCamSession`'s watch states publish camera state,
@@ -18,6 +20,30 @@ protocol WatchStatePushing: AnyObject {
     func pushCameraState(_ snapshot: WatchCameraStateSnapshot)
     func pushDisconnectedState()
 }
+
+#if targetEnvironment(macCatalyst)
+
+/// WatchConnectivity does not exist on the Mac. This stub keeps every call
+/// site compiling; `watchPaired` stays false, so the Watch Remote role never
+/// surfaces in the UI and the coordinator's watch states never fire.
+class WatchSessionManager: NSObject, ObservableObject {
+
+    static let shared = WatchSessionManager()
+
+    @Published private(set) var watchPaired = false
+    weak var cameraController: WatchRemoteCameraController?
+
+    func activate() {}
+    var isWatchPaired: Bool { false }
+    var isWatchReachable: Bool { false }
+    func pushCameraState(_ snapshot: WatchCameraStateSnapshot) {}
+    func pushDisconnectedState() {}
+    func pushPreviewFrame(jpeg: Data) {}
+}
+
+extension WatchSessionManager: WatchStatePushing {}
+
+#else
 
 class WatchSessionManager: NSObject, ObservableObject, WCSessionDelegate {
 
@@ -208,3 +234,5 @@ class WatchSessionManager: NSObject, ObservableObject, WCSessionDelegate {
 }
 
 extension WatchSessionManager: WatchStatePushing {}
+
+#endif

--- a/RemoteCamTests/CameraDeviceSelectionTests.swift
+++ b/RemoteCamTests/CameraDeviceSelectionTests.swift
@@ -1,0 +1,168 @@
+//
+//  CameraDeviceSelectionTests.swift
+//  RemoteShutterTests
+//
+//  The pure device-selection policy: exact ID → same position → first
+//  available → nil. Macs expose N cameras (often all `.unspecified`), so the
+//  fallbacks are what keep an unplugged-camera request from failing outright.
+//
+
+import XCTest
+import AVFoundation
+
+@testable import RemoteShutter
+
+final class CameraDeviceSelectionTests: XCTestCase {
+
+    private let backCamera = CameraDeviceDescriptor(
+        uniqueID: "back-0", localizedName: "Back Camera",
+        position: .back, deviceType: .builtInWideAngleCamera)
+    private let frontCamera = CameraDeviceDescriptor(
+        uniqueID: "front-0", localizedName: "Front Camera",
+        position: .front, deviceType: .builtInWideAngleCamera)
+    private let usbCamera = CameraDeviceDescriptor(
+        uniqueID: "usb-0", localizedName: "USB Camera",
+        position: .unspecified, deviceType: .builtInWideAngleCamera)
+
+    func testExactIDMatchWins() {
+        let resolved = CameraDeviceDescriptor.resolveSelection(
+            requestedID: "front-0",
+            available: [backCamera, frontCamera, usbCamera],
+            fallbackPosition: .back)
+        XCTAssertEqual(resolved, frontCamera)
+    }
+
+    func testVanishedIDFallsBackToSamePosition() {
+        let resolved = CameraDeviceDescriptor.resolveSelection(
+            requestedID: "gone-camera",
+            available: [usbCamera, frontCamera],
+            fallbackPosition: .front)
+        XCTAssertEqual(resolved, frontCamera)
+    }
+
+    func testVanishedIDWithNoPositionMatchFallsBackToFirst() {
+        let resolved = CameraDeviceDescriptor.resolveSelection(
+            requestedID: "gone-camera",
+            available: [usbCamera, frontCamera],
+            fallbackPosition: .back)
+        XCTAssertEqual(resolved, usbCamera)
+    }
+
+    func testUnspecifiedFallbackPositionMatchesUnspecifiedDevice() {
+        // Mac-shaped fleet: everything is .unspecified.
+        let secondUSB = CameraDeviceDescriptor(
+            uniqueID: "usb-1", localizedName: "Other USB Camera",
+            position: .unspecified, deviceType: .builtInWideAngleCamera)
+        let resolved = CameraDeviceDescriptor.resolveSelection(
+            requestedID: "gone-camera",
+            available: [usbCamera, secondUSB],
+            fallbackPosition: .unspecified)
+        XCTAssertEqual(resolved, usbCamera)
+    }
+
+    func testEmptyDeviceListResolvesToNil() {
+        let resolved = CameraDeviceDescriptor.resolveSelection(
+            requestedID: "anything", available: [], fallbackPosition: .back)
+        XCTAssertNil(resolved)
+    }
+
+    // MARK: - Toggle selection (iOS position flip / Mac device cycle)
+
+    func testFlipTogglesBackToFront() {
+        let next = CameraDeviceDescriptor.nextToggleSelection(
+            currentID: "back-0", available: [backCamera, frontCamera], flipPosition: true)
+        XCTAssertEqual(next, frontCamera)
+    }
+
+    func testFlipWithUnknownCurrentReturnsNil() {
+        // Mirrors the engine's historical behavior: a flip with no active
+        // device is an error, not a silent pick.
+        XCTAssertNil(CameraDeviceDescriptor.nextToggleSelection(
+            currentID: nil, available: [backCamera, frontCamera], flipPosition: true))
+    }
+
+    func testCycleAdvancesInListOrderAndWraps() {
+        let devices = [backCamera, frontCamera, usbCamera]
+        let afterBack = CameraDeviceDescriptor.nextToggleSelection(
+            currentID: "back-0", available: devices, flipPosition: false)
+        XCTAssertEqual(afterBack, frontCamera)
+        let afterUSB = CameraDeviceDescriptor.nextToggleSelection(
+            currentID: "usb-0", available: devices, flipPosition: false)
+        XCTAssertEqual(afterUSB, backCamera, "cycle wraps to the first device")
+    }
+
+    func testCycleSkipsSuspendedDevices() {
+        var suspended = frontCamera
+        suspended.isSuspended = true
+        let next = CameraDeviceDescriptor.nextToggleSelection(
+            currentID: "back-0", available: [backCamera, suspended, usbCamera], flipPosition: false)
+        XCTAssertEqual(next, usbCamera, "a clamshell camera must never be cycled onto")
+    }
+
+    func testCycleWithUnknownCurrentStartsAtFirstHealthyDevice() {
+        var suspended = backCamera
+        suspended.isSuspended = true
+        let next = CameraDeviceDescriptor.nextToggleSelection(
+            currentID: nil, available: [suspended, usbCamera], flipPosition: false)
+        XCTAssertEqual(next, usbCamera)
+    }
+
+    // MARK: - Suspension (connected but zero frames — clamshell built-in)
+
+    func testSuspendedDeviceIsNeverResolvedEvenWhenRequested() {
+        var suspendedBuiltIn = backCamera
+        suspendedBuiltIn.isSuspended = true
+        let resolved = CameraDeviceDescriptor.resolveSelection(
+            requestedID: suspendedBuiltIn.uniqueID,
+            available: [suspendedBuiltIn, usbCamera],
+            fallbackPosition: .back)
+        XCTAssertEqual(resolved, usbCamera, "a suspended camera must never be selected")
+    }
+
+    func testAllSuspendedResolvesToNil() {
+        var a = backCamera, b = usbCamera
+        a.isSuspended = true
+        b.isSuspended = true
+        XCTAssertNil(CameraDeviceDescriptor.resolveSelection(
+            requestedID: "anything", available: [a, b], fallbackPosition: .back))
+    }
+
+    func testFakeRejectsExplicitSelectionOfSuspendedDevice() async {
+        let fake = FakeCameraControlling()
+        fake.availableDevices = [
+            CameraDeviceDescriptor(uniqueID: "builtin", localizedName: "Built-in",
+                                   position: .unspecified, deviceType: .builtInWideAngleCamera,
+                                   isSuspended: true),
+            CameraDeviceDescriptor(uniqueID: "usb", localizedName: "USB",
+                                   position: .unspecified, deviceType: .builtInWideAngleCamera)
+        ]
+        fake.activeDeviceID = "usb"
+        do {
+            _ = try await fake.selectCameraDevice(uniqueID: "builtin")
+            XCTFail("selecting a suspended camera must throw")
+        } catch {
+            XCTAssertTrue(error._domain.contains("unavailable"))
+        }
+    }
+
+    @MainActor
+    func testCameraViewModelPublishesDeviceList() async {
+        let model = CameraViewModel()
+        model.updateCameraDevices([backCamera, usbCamera], activeID: "usb-0")
+        // updateCameraDevices hops to main; pump the queue once.
+        await Task.yield()
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.05))
+        XCTAssertEqual(model.availableCameraDevices, [backCamera, usbCamera])
+        XCTAssertEqual(model.activeCameraDeviceID, "usb-0")
+    }
+
+    func testFakeCameraSelectionUpdatesActiveDevice() async throws {
+        let fake = FakeCameraControlling()
+        let result = try await fake.selectCameraDevice(uniqueID: "fake-front")
+        XCTAssertEqual(result.device.uniqueID, "fake-front")
+        let current = await fake.currentCameraDevice()
+        XCTAssertEqual(current?.uniqueID, "fake-front")
+        XCTAssertEqual(fake.deviceSelections, ["fake-front"])
+        XCTAssertNil(result.flashMode, "front camera has no flash in the fake")
+    }
+}

--- a/RemoteCamTests/CaptureEngineTests.swift
+++ b/RemoteCamTests/CaptureEngineTests.swift
@@ -6,6 +6,61 @@ import AVFoundation
 /// need no `AVCaptureDevice`, so they run on the simulator.
 final class CaptureEngineTests: XCTestCase {
 
+    // MARK: - resolveFrameRate
+    // Supported rates form disjoint ranges; a value outside every range
+    // raises an uncatchable ObjC exception in AVFoundation, so the resolver
+    // must always land inside one.
+
+    func testFrameRateBelowOnlyRangeSnapsUp() {
+        // The Mac-camera crash: format supports exactly 60–60, app asked for 30.
+        let resolved = CaptureEngine.resolveFrameRate(requested: 30, supportedRanges: [60...60])
+        XCTAssertEqual(resolved?.fps, 60)
+        XCTAssertEqual(resolved?.rangeIndex, 0)
+    }
+
+    func testFrameRateInsideRangeIsUnchanged() {
+        XCTAssertEqual(CaptureEngine.resolveFrameRate(requested: 30, supportedRanges: [1...60])?.fps, 30)
+        XCTAssertEqual(CaptureEngine.resolveFrameRate(requested: 24, supportedRanges: [24...30, 60...60])?.fps, 24)
+    }
+
+    func testFrameRateAboveAllRangesClampsToMax() {
+        let resolved = CaptureEngine.resolveFrameRate(requested: 120, supportedRanges: [1...30, 1...60])
+        XCTAssertEqual(resolved?.fps, 60)
+        XCTAssertEqual(resolved?.rangeIndex, 1, "the chosen range must be the one containing the answer")
+    }
+
+    func testFrameRateBetweenDisjointRangesPicksNearest() {
+        // 40 is 10 away from 30, 20 away from 60.
+        let low = CaptureEngine.resolveFrameRate(requested: 40, supportedRanges: [24...30, 60...60])
+        XCTAssertEqual(low?.fps, 30)
+        XCTAssertEqual(low?.rangeIndex, 0)
+        // 55 is 25 away from 30, 5 away from 60.
+        let high = CaptureEngine.resolveFrameRate(requested: 55, supportedRanges: [24...30, 60...60])
+        XCTAssertEqual(high?.fps, 60)
+        XCTAssertEqual(high?.rangeIndex, 1)
+    }
+
+    func testFrameRateTiePrefersLowerRate() {
+        // 45 is equidistant from 30 and 60 — don't exceed the request unnecessarily.
+        XCTAssertEqual(CaptureEngine.resolveFrameRate(requested: 45, supportedRanges: [24...30, 60...60])?.fps, 30)
+    }
+
+    func testFrameRateWithNoReportedRangesResolvesNil() {
+        // No ranges: the caller leaves the device's defaults untouched.
+        XCTAssertNil(CaptureEngine.resolveFrameRate(requested: 30, supportedRanges: []))
+    }
+
+    func testFrameRateFractionalUVCRangeStillChoosesIt() {
+        // Real UVC hardware advertises "60 fps" as 60.00024 — the resolver
+        // must pick that range so the caller can use ITS CMTime durations.
+        let resolved = CaptureEngine.resolveFrameRate(
+            requested: 60, supportedRanges: [30.00003...30.00003, 60.00024...60.00024])
+        XCTAssertEqual(resolved?.fps, 60)
+        XCTAssertEqual(resolved?.rangeIndex, 1)
+    }
+
+    // MARK: - Configuration state
+
     func testDefaultConfigurationState() {
         let engine = CaptureEngine()
         XCTAssertEqual(engine.currentAspectRatioValue(), .sixteenNine)

--- a/RemoteCamTests/CaptureIntegrationTests.swift
+++ b/RemoteCamTests/CaptureIntegrationTests.swift
@@ -34,6 +34,7 @@ final class CaptureIntegrationTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
+        try Self.skipIfHeadless()
         #if targetEnvironment(macCatalyst)
         if #available(macCatalyst 17.0, *) {
             // selectCameraDevice writes the SYSTEM-WIDE preference (Apple's
@@ -52,6 +53,23 @@ final class CaptureIntegrationTests: XCTestCase {
         }
         #endif
         try await super.tearDown()
+    }
+
+    /// Skips the whole suite before ANY AVFoundation call on machines that
+    /// cannot answer a TCC prompt. `requestAccess(for: .video)` on a fresh
+    /// headless runner posts a prompt no one can click — the await never
+    /// resumes and the CI job hangs forever (run 29173204289). The skip must
+    /// therefore happen up front, not after probing the camera.
+    /// GitHub Actions sets `CI=true`; ios-ci.yml forwards it to the test
+    /// process as `TEST_RUNNER_CI` (xcodebuild strips the prefix). Local
+    /// interactive runs keep the real TCC prompt.
+    private static func skipIfHeadless() throws {
+        if ProcessInfo.processInfo.environment["CI"] != nil {
+            throw XCTSkip("headless CI — no camera, and a TCC prompt could never be answered")
+        }
+        #if targetEnvironment(simulator)
+        throw XCTSkip("iOS simulator has no cameras")
+        #endif
     }
 
     /// Timestamp source the rig's own watchdog uses.
@@ -122,7 +140,6 @@ final class CaptureIntegrationTests: XCTestCase {
         try await startRealRig()
 
         guard let latency = await waitForFrames(since: 0) else {
-            let device = await rig.currentCameraDevice()
             return XCTFail("no frames within \(Self.framesDeadline)s — \(await diagnostics())")
         }
         let device = await rig.currentCameraDevice()

--- a/RemoteCamTests/CaptureIntegrationTests.swift
+++ b/RemoteCamTests/CaptureIntegrationTests.swift
@@ -1,0 +1,181 @@
+//
+//  CaptureIntegrationTests.swift
+//  RemoteShutterTests
+//
+//  Drives the REAL camera stack — CameraRig, watchdog included — against the
+//  machine's physical cameras. The product invariant under test is not
+//  "every device delivers frames" (a Mac always has junk virtual cameras and
+//  suspended built-ins that enumerate but never deliver); it is:
+//
+//      frames are flowing within a bounded time after every action,
+//      no matter which device was picked — via fallback if necessary.
+//
+//  Skips itself where no camera exists (iOS simulator, CI). Run for real:
+//    xcodebuild test -workspace RemoteShutter.xcworkspace -scheme RemoteCam \
+//      -destination 'platform=macOS,variant=Mac Catalyst' \
+//      -only-testing:RemoteShutterTests/CaptureIntegrationTests
+//
+
+import XCTest
+import AVFoundation
+
+@testable import RemoteShutter
+
+final class CaptureIntegrationTests: XCTestCase {
+
+    /// Worst case: junk initial device (5s watchdog) + fallback attach
+    /// (Continuity Camera needs ~3s wireless attach).
+    private static let framesDeadline: TimeInterval = 15
+
+    private var rig: CameraRig!
+    #if targetEnvironment(macCatalyst)
+    private var savedPreferredCamera: AVCaptureDevice?
+    #endif
+
+    override func setUp() async throws {
+        try await super.setUp()
+        #if targetEnvironment(macCatalyst)
+        if #available(macCatalyst 17.0, *) {
+            // selectCameraDevice writes the SYSTEM-WIDE preference (Apple's
+            // manual mode) — save it so tests don't repoint FaceTime et al.
+            savedPreferredCamera = AVCaptureDevice.userPreferredCamera
+        }
+        #endif
+    }
+
+    override func tearDown() async throws {
+        rig?.stopSession()
+        rig = nil
+        #if targetEnvironment(macCatalyst)
+        if #available(macCatalyst 17.0, *) {
+            AVCaptureDevice.userPreferredCamera = savedPreferredCamera
+        }
+        #endif
+        try await super.tearDown()
+    }
+
+    /// Timestamp source the rig's own watchdog uses.
+    private var lastFrameAt: TimeInterval {
+        rig.streamingCoordinator.lastVideoFrameAt.value
+    }
+
+    /// Waits until a frame newer than `since` arrives. Suspends (never
+    /// spins): the rig's completion and fallback paths hop through the main
+    /// queue, which cannot drain while a main-actor test is busy-waiting.
+    private func waitForFrames(since: TimeInterval,
+                               timeout: TimeInterval = CaptureIntegrationTests.framesDeadline) async -> TimeInterval? {
+        let start = Date()
+        while Date().timeIntervalSince(start) < timeout {
+            if lastFrameAt > since { return Date().timeIntervalSince(start) }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return nil
+    }
+
+    /// Builds the real rig and starts the camera as the camera screen does,
+    /// or skips (simulator/CI have no cameras; TCC denied means this
+    /// environment can't run it).
+    @MainActor
+    private func startRealRig() async throws {
+        var status = AVCaptureDevice.authorizationStatus(for: .video)
+        if status == .notDetermined {
+            status = await AVCaptureDevice.requestAccess(for: .video) ? .authorized : .denied
+        }
+        guard status == .authorized else {
+            throw XCTSkip("no camera permission in this environment")
+        }
+
+        rig = CameraRig(session: SessionCoordinator(), frameSender: FrameSender())
+        rig.startCameraOnce()
+
+        // Wait for the engine to finish configuration (isBusy clears via a
+        // main-queue hop — suspend, don't spin, or it can never land).
+        let deadline = Date().addingTimeInterval(10)
+        while rig.cameraViewModel.isBusy && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        guard rig.cameraViewModel.previewSession != nil else {
+            throw XCTSkip("no camera on this machine (simulator/CI)")
+        }
+        let initial = await rig.currentCameraDevice()
+        var preferred = "n/a"
+        #if targetEnvironment(macCatalyst)
+        if #available(macCatalyst 17.0, *) {
+            preferred = AVCaptureDevice.systemPreferredCamera?.localizedName ?? "nil"
+        }
+        #endif
+        print("📸 startup: initial=\(initial?.localizedName ?? "none") systemPreferred=\(preferred)")
+    }
+
+    /// Session-state dump for failures — the difference between "device never
+    /// delivered" and "session isn't even running" is the whole diagnosis.
+    private func diagnostics() async -> String {
+        let session = rig.engine.captureSession
+        let device = await rig.currentCameraDevice()
+        return "isRunning=\(session.isRunning) interrupted=\(session.isInterrupted) "
+            + "inputs=\(session.inputs.count) outputs=\(session.outputs.count) "
+            + "active=\(device?.localizedName ?? "none") suspended=\(device?.isSuspended ?? false) "
+            + "lastFrameAt=\(lastFrameAt)"
+    }
+
+    func testCameraStartsAndFramesFlowWithinDeadline() async throws {
+        try await startRealRig()
+
+        guard let latency = await waitForFrames(since: 0) else {
+            let device = await rig.currentCameraDevice()
+            return XCTFail("no frames within \(Self.framesDeadline)s — \(await diagnostics())")
+        }
+        let device = await rig.currentCameraDevice()
+        print("📸 startup: frames from \(device?.localizedName ?? "?") in \(Int(latency * 1000))ms")
+    }
+
+    /// Selecting ANY healthy-looking device must end with frames flowing —
+    /// from that device, or from the watchdog's fallback if it turned out to
+    /// be a zero-frame source (suspended, sandboxed-out virtual camera).
+    func testEverySelectionEndsWithFramesFlowing() async throws {
+        try await startRealRig()
+        guard await waitForFrames(since: 0) != nil else {
+            return XCTFail("startup never delivered frames — \(await diagnostics())")
+        }
+
+        let candidates = await rig.availableCameraDevices().filter { !$0.isSuspended }
+        print("📸 candidates: \(candidates.map(\.localizedName))")
+
+        for device in candidates {
+            let mark = Date().timeIntervalSinceReferenceDate
+            _ = try? await rig.selectCameraDevice(uniqueID: device.uniqueID)
+
+            guard let latency = await waitForFrames(since: mark) else {
+                let active = await rig.currentCameraDevice()
+                return XCTFail("selected \(device.localizedName): no frames within \(Self.framesDeadline)s (active: \(active?.localizedName ?? "none"))")
+            }
+            let active = await rig.currentCameraDevice()
+            let outcome = active?.uniqueID == device.uniqueID
+                ? "delivers" : "fell back to \(active?.localizedName ?? "?")"
+            print("📸 \(device.localizedName): \(outcome), frames in \(Int(latency * 1000))ms")
+        }
+    }
+
+    func testToggleKeepsFramesFlowing() async throws {
+        try await startRealRig()
+        guard await waitForFrames(since: 0) != nil else {
+            return XCTFail("startup never delivered frames — \(await diagnostics())")
+        }
+
+        let healthy = await rig.availableCameraDevices().filter { !$0.isSuspended }
+        guard healthy.count > 1 else {
+            throw XCTSkip("only one healthy camera — nothing to toggle between")
+        }
+
+        let before = await rig.currentCameraDevice()
+        let mark = Date().timeIntervalSinceReferenceDate
+        _ = try? await rig.toggleCamera()
+
+        guard let latency = await waitForFrames(since: mark) else {
+            return XCTFail("no frames within \(Self.framesDeadline)s after toggle")
+        }
+        let after = await rig.currentCameraDevice()
+        XCTAssertFalse(after?.isSuspended ?? true, "toggle must never land on a suspended device")
+        print("📸 toggle \(before?.localizedName ?? "?") → \(after?.localizedName ?? "?"): frames in \(Int(latency * 1000))ms")
+    }
+}

--- a/RemoteCamTests/FrameSenderTests.swift
+++ b/RemoteCamTests/FrameSenderTests.swift
@@ -73,8 +73,31 @@ class FrameSenderTests: XCTestCase {
         XCTAssertEqual(sentFrameCount, 1)
         let sent = fakeMP.sentMessages[0]
         XCTAssertEqual(sent.peers, [peer])
+        // Frames are ALWAYS .unreliable (hard rule): a live viewfinder drops
+        // stale frames, it never queues them.
         XCTAssertEqual(sent.mode, .unreliable)
         XCTAssertEqual(frameSender.windowSnapshot().inFlight, 1)
+    }
+
+    /// The datagram-channel warm-up must be harmless on the receiving side:
+    /// a stray RequestFrame before any frame is in flight is a no-op ack.
+    func testStrayAckOnEmptyWindowIsHarmless() {
+        frameSender.receiveAck(RemoteCmd.RequestFrame(sender: nil))
+        frameSender.drain()
+        XCTAssertEqual(frameSender.windowSnapshot().inFlight, 0)
+    }
+
+    /// Peer connect fires exactly one unreliable no-op ping so MC starts
+    /// negotiating its lossy datagram channel (~10s) during role selection
+    /// instead of during the first seconds of live preview.
+    func testPeerConnectSendsOneUnreliableWarmUpPing() async {
+        let harness = await makeCoordinatorHarness()
+        harness.coordinator.peerDidConnect(harness.peer)
+        await harness.coordinator.waitForIdle()
+
+        let pings = harness.fakeMP.sentMessages.filter { $0.msg is RemoteCmd.RequestFrame }
+        XCTAssertEqual(pings.count, 1, "connect must warm the unreliable channel exactly once")
+        XCTAssertEqual(pings.first?.mode, .unreliable)
     }
 
     func testWindowAllowsMultipleFramesInFlight() {

--- a/RemoteCamTests/LoopbackSessionTests.swift
+++ b/RemoteCamTests/LoopbackSessionTests.swift
@@ -394,6 +394,159 @@ class LoopbackSessionTests: XCTestCase {
         XCTAssertEqual(monitorState, .monitor)
     }
 
+    // MARK: - Camera device selection
+
+    func testSelectCameraDeviceHappyPathAcrossTheWire() async {
+        let fakeCamera = await connectCameraAndMonitor()
+
+        monitorCoordinator.tell(UICmd.SelectCameraDevice(uniqueID: "fake-front"))
+        await drainBothSessions()
+
+        // The camera switched devices and answered with fresh capabilities.
+        XCTAssertEqual(fakeCamera.deviceSelections, ["fake-front"])
+        let resps = cameraTransport.sentMessages.compactMap { $0 as? RemoteCmd.SelectCameraDeviceResp }
+        XCTAssertEqual(resps.count, 1)
+        XCTAssertNil(resps.first?.error)
+        XCTAssertEqual(resps.first?.cameraCapabilities?.activeDeviceID, "fake-front")
+        XCTAssertEqual(resps.first?.cameraCapabilities?.cameraDevices.count, 2)
+        XCTAssertEqual(
+            resps.first?.cameraCapabilities?.cameraDevices.first { $0.isActive }?.uniqueID,
+            "fake-front")
+
+        let monitorState = await monitorCoordinator.currentStateName()
+        XCTAssertEqual(monitorState, .monitor)
+        XCTAssertTrue(monitorAlerts.shownErrors.isEmpty)
+    }
+
+    /// The safety gate: old peers decode unknown command actions as
+    /// TakePicture, so a monitor must never emit SelectCameraDevice unless the
+    /// peer's capabilities advertised a device list.
+    func testSelectCameraDeviceIsNeverSentToLegacyPeer() async {
+        await connectBothSessions()
+        let fakeCamera = LoopbackFakeCamera()
+        fakeCamera.advertisesCameraDevices = false   // legacy-shaped capabilities
+        fakeCamera.coordinator = cameraCoordinator
+        cameraCoordinator.tell(UICmd.BecomeCamera(sender: nil, ctrl: fakeCamera))
+        await drainBothSessions()
+        await becomeMonitor(mode: .Photo)
+        monitorTransport.sentMessages.removeAll()
+
+        monitorCoordinator.tell(UICmd.SelectCameraDevice(uniqueID: "fake-front"))
+        await drainBothSessions()
+
+        XCTAssertFalse(monitorTransport.sentMessages.contains { $0 is RemoteCmd.SelectCameraDevice },
+                       "SelectCameraDevice must be gated on advertised camera_devices")
+        XCTAssertTrue(fakeCamera.deviceSelections.isEmpty)
+        XCTAssertTrue(fakeCamera.takePictureCalls.isEmpty,
+                      "an ungated command would decode as TakePicture on an old peer")
+        // The monitor quietly stays where it was.
+        let monitorState = await monitorCoordinator.currentStateName()
+        XCTAssertEqual(monitorState, .monitor)
+    }
+
+    /// A suspended camera (clamshell built-in: connected, zero frames) is
+    /// advertised with its flag so the monitor grays it out — and if a peer
+    /// selects it anyway (old UI, race), the camera answers with an error
+    /// instead of switching to a dead device.
+    func testSuspendedDeviceIsAdvertisedAndRejectedOnSelection() async {
+        await connectBothSessions()
+        let fakeCamera = LoopbackFakeCamera()
+        fakeCamera.availableDevices.append(CameraDeviceDescriptor(
+            uniqueID: "builtin-lid-closed", localizedName: "MacBook Pro Camera",
+            position: .unspecified, deviceType: .builtInWideAngleCamera,
+            isSuspended: true))
+        fakeCamera.coordinator = cameraCoordinator
+        cameraCoordinator.tell(UICmd.BecomeCamera(sender: nil, ctrl: fakeCamera))
+        await drainBothSessions()
+        await becomeMonitor(mode: .Photo)
+        cameraTransport.sentMessages.removeAll()
+
+        // The handshake capabilities already advertised the suspended device.
+        monitorCoordinator.tell(UICmd.SelectCameraDevice(uniqueID: "builtin-lid-closed"))
+        await drainBothSessions()
+
+        let resps = cameraTransport.sentMessages.compactMap { $0 as? RemoteCmd.SelectCameraDeviceResp }
+        XCTAssertEqual(resps.count, 1)
+        XCTAssertNotNil(resps.first?.error, "selecting a suspended camera must fail loudly")
+        // The camera did not switch away from its healthy device.
+        let current = await fakeCamera.currentCameraDevice()
+        XCTAssertEqual(current?.uniqueID, "fake-back")
+    }
+
+    /// Hot-plug contract: when a camera appears or vanishes, the rig tells its
+    /// OWN coordinator RequestCameraCapabilities (CameraRig's
+    /// onCameraDevicesChanged handler) — the camera state must answer by
+    /// broadcasting fresh capabilities, so the monitor's picker updates live.
+    func testHotPlugRebroadcastsCapabilitiesWithNewDeviceList() async {
+        let fakeCamera = await connectCameraAndMonitor()
+
+        // A USB camera appears…
+        fakeCamera.availableDevices.append(CameraDeviceDescriptor(
+            uniqueID: "usb-0", localizedName: "USB Camera",
+            position: .unspecified, deviceType: .builtInWideAngleCamera))
+        // …and the rig nudges its own coordinator, as the hot-plug observer does.
+        cameraCoordinator.tell(RemoteCmd.RequestCameraCapabilities())
+        await drainBothSessions()
+
+        let resps = cameraTransport.sentMessages.compactMap { $0 as? RemoteCmd.CameraCapabilitiesResp }
+        XCTAssertEqual(resps.count, 1, "hot-plug must trigger exactly one capabilities broadcast")
+        XCTAssertEqual(resps.first?.cameraDevices.count, 3)
+        XCTAssertTrue(resps.first?.cameraDevices.contains { $0.uniqueID == "usb-0" } ?? false,
+                      "the freshly plugged camera must be advertised to the monitor")
+    }
+
+    /// A camera can accept the input swap and then never deliver a frame (a
+    /// wedged virtual camera, e.g. OBS in a sandboxed app). The selection
+    /// must come back as a VISIBLE error naming the device — not a success
+    /// followed by a silently black preview.
+    func testSelectingCameraThatDeliversNoFramesReturnsError() async {
+        await connectBothSessions()
+        let fakeCamera = LoopbackFakeCamera()
+        fakeCamera.availableDevices.append(CameraDeviceDescriptor(
+            uniqueID: "obs-0", localizedName: "OBS Virtual Camera",
+            position: .unspecified, deviceType: .builtInWideAngleCamera))
+        fakeCamera.stalledDeviceIDs = ["obs-0"]
+        fakeCamera.coordinator = cameraCoordinator
+        cameraCoordinator.tell(UICmd.BecomeCamera(sender: nil, ctrl: fakeCamera))
+        await drainBothSessions()
+        await becomeMonitor(mode: .Photo)
+        cameraTransport.sentMessages.removeAll()
+
+        monitorCoordinator.tell(UICmd.SelectCameraDevice(uniqueID: "obs-0"))
+        await drainBothSessions()
+
+        let resps = cameraTransport.sentMessages.compactMap { $0 as? RemoteCmd.SelectCameraDeviceResp }
+        XCTAssertEqual(resps.count, 1)
+        XCTAssertNotNil(resps.first?.error, "a no-frames camera must fail the selection")
+        XCTAssertTrue(resps.first?.error?._domain.contains("OBS Virtual Camera") ?? false,
+                      "the error must name the dead device")
+        // The monitor surfaced it as an alert (the toggling state's error path).
+        XCTAssertFalse(monitorAlerts.shownErrors.isEmpty)
+    }
+
+    func testSelectCameraDeviceWhileRecordingIsRejected() async {
+        let fakeCamera = await connectCameraAndMonitor(monitorMode: .Video)
+
+        // Start a recording so the camera sits in a busy state.
+        monitorCoordinator.tell(UICmd.TakePicture(sender: nil, sendMediaToRemote: false))
+        await drainBothSessions()
+        let cameraState = await cameraCoordinator.currentStateName()
+        XCTAssertEqual(cameraState, .cameraRecordingVideo)
+        cameraTransport.sentMessages.removeAll()
+
+        // Deliver the command straight to the busy camera (as a peer would).
+        cameraCoordinator.tell(RemoteCmd.SelectCameraDevice(uniqueID: "fake-front"))
+        await drainBothSessions()
+
+        let resps = cameraTransport.sentMessages.compactMap { $0 as? RemoteCmd.SelectCameraDeviceResp }
+        XCTAssertEqual(resps.count, 1)
+        XCTAssertNotNil(resps.first?.error, "busy camera must reject device selection")
+        XCTAssertTrue(fakeCamera.deviceSelections.isEmpty)
+        // Still recording — the request must not disturb the session.
+        let stillRecording = await cameraCoordinator.currentStateName()
+        XCTAssertEqual(stillRecording, .cameraRecordingVideo)
+    }
+
     func testSetZoomHappyPathEchoesFactorAndRange() async {
         let fakeCamera = await connectCameraAndMonitor()
 

--- a/RemoteCamTests/MonitorPresenterTests.swift
+++ b/RemoteCamTests/MonitorPresenterTests.swift
@@ -151,6 +151,79 @@ class MonitorPresenterTests: XCTestCase {
         XCTAssertEqual(display.zoomUpdates[0].maxFactor, 8.0, accuracy: 0.001)
     }
 
+    // MARK: - Camera device list
+
+    /// A Mac camera peer advertises N devices but has no front/back
+    /// CameraInfo — the device list must reach the view model anyway.
+    func testCapabilitiesWithoutPositionInfoStillDeliverDeviceList() {
+        let devices = [
+            RemoteCmd.CameraDeviceEntry(
+                uniqueID: "facetime-0", localizedName: "FaceTime HD Camera",
+                positionRaw: AVCaptureDevice.Position.unspecified.rawValue,
+                isActive: true, info: nil),
+            RemoteCmd.CameraDeviceEntry(
+                uniqueID: "usb-0", localizedName: "USB Camera",
+                positionRaw: AVCaptureDevice.Position.unspecified.rawValue,
+                isActive: false, info: nil)
+        ]
+        let capabilities = RemoteCmd.CameraCapabilitiesResp(
+            frontCamera: nil, backCamera: nil,
+            currentCamera: .back, currentLens: .wideAngle, currentZoom: 1.0,
+            cameraDevices: devices, activeDeviceID: "facetime-0", error: nil)
+
+        presenter.updateCapabilities(capabilities)
+        drain()
+
+        XCTAssertEqual(display.viewModel.remoteCameraDevices, devices)
+        XCTAssertEqual(display.viewModel.activeRemoteDeviceID, "facetime-0")
+        // No front/back info: the lens/zoom sync is skipped, not crashed.
+        XCTAssertTrue(display.lensUpdates.isEmpty)
+    }
+
+    func testLegacyCapabilitiesClearDeviceList() {
+        display.viewModel.remoteCameraDevices = [
+            RemoteCmd.CameraDeviceEntry(
+                uniqueID: "stale", localizedName: "Stale",
+                positionRaw: 0, isActive: true, info: nil)
+        ]
+        let capabilities = RemoteCmd.CameraCapabilitiesResp(
+            frontCamera: nil, backCamera: nil,
+            currentCamera: .back, currentLens: .wideAngle, currentZoom: 1.0,
+            error: nil)
+
+        presenter.updateCapabilities(capabilities)
+        drain()
+
+        XCTAssertTrue(display.viewModel.remoteCameraDevices.isEmpty,
+                      "a legacy peer's capabilities must clear a stale device list")
+        XCTAssertNil(display.viewModel.activeRemoteDeviceID)
+    }
+
+    // MARK: - Camera switch control policy
+
+    private func entry(_ id: String, suspended: Bool = false) -> RemoteCmd.CameraDeviceEntry {
+        RemoteCmd.CameraDeviceEntry(
+            uniqueID: id, localizedName: id, positionRaw: 0,
+            isActive: false, isSuspended: suspended, info: nil)
+    }
+
+    func testSwitchControlMatchesCameraTopology() {
+        // Legacy peer (no list): count unknown — keep the classic flip.
+        XCTAssertEqual(MonitorViewModel.switchControl(for: []), .flipButton)
+        // One camera: nothing to switch to.
+        XCTAssertEqual(MonitorViewModel.switchControl(for: [entry("a")]), .hidden)
+        // Two usable cameras: the classic flip button.
+        XCTAssertEqual(MonitorViewModel.switchControl(for: [entry("a"), entry("b")]), .flipButton)
+        // Two cameras but one suspended: the menu explains the grayed device.
+        XCTAssertEqual(
+            MonitorViewModel.switchControl(for: [entry("a"), entry("b", suspended: true)]),
+            .deviceMenu)
+        // Three or more: the menu.
+        XCTAssertEqual(
+            MonitorViewModel.switchControl(for: [entry("a"), entry("b"), entry("c")]),
+            .deviceMenu)
+    }
+
     // MARK: - Video transfer progress
 
     func testVideoTransferMessagesDriveViewModel() {

--- a/RemoteCamTests/MonitorScreenSnapshotTests.swift
+++ b/RemoteCamTests/MonitorScreenSnapshotTests.swift
@@ -16,6 +16,7 @@ final class MonitorScreenSnapshotTests: SnapshotTestCase {
             viewModel: viewModel,
             onTakePicture: {},
             onToggleCamera: {},
+            onSelectCameraDevice: { _ in },
             onToggleFlash: {},
             onToggleTorch: {},
             onTimerChange: { _ in },
@@ -32,7 +33,7 @@ final class MonitorScreenSnapshotTests: SnapshotTestCase {
     /// A connected monitor with a live frame and the full lens/zoom surface.
     private func makeConnectedModel() -> MonitorViewModel {
         let model = MonitorViewModel()
-        model.cameraImage = syntheticCameraFrame()
+        model.frames.cameraImage = syntheticCameraFrame()
         model.availableLensTypes = [.ultraWide, .wideAngle, .telephoto]
         model.currentLensType = .wideAngle
         model.zoomStops = [1.0, 2.0, 5.0]
@@ -69,6 +70,48 @@ final class MonitorScreenSnapshotTests: SnapshotTestCase {
         model.uiState = .photoMode
 
         let image = renderScreen(named: "monitor-waiting-for-frame", makeMonitorView(model))
+        assertHasChrome(image)
+    }
+
+    func testTwoCamerasShowFlipButtonAndActiveName() {
+        // iPhone-shaped peer: two usable cameras — the classic flip button,
+        // plus the active-camera name overlay on the preview.
+        let model = makeConnectedModel()
+        model.currentMode = .Photo
+        model.uiState = .photoMode
+        model.remoteCameraDevices = [
+            RemoteCmd.CameraDeviceEntry(
+                uniqueID: "back-0", localizedName: "Back Dual Wide Camera",
+                positionRaw: 0, isActive: true, info: nil),
+            RemoteCmd.CameraDeviceEntry(
+                uniqueID: "front-0", localizedName: "Front Camera",
+                positionRaw: 1, isActive: false, info: nil)
+        ]
+        model.activeRemoteDeviceID = "back-0"
+
+        let image = renderScreen(named: "monitor-two-camera-flip", makeMonitorView(model))
+        assertHasChrome(image)
+    }
+
+    func testManyCamerasShowDeviceMenu() {
+        // Mac-shaped peer: several cameras, one suspended (grayed in the menu).
+        let model = makeConnectedModel()
+        model.currentMode = .Photo
+        model.uiState = .photoMode
+        model.remoteCameraDevices = [
+            RemoteCmd.CameraDeviceEntry(
+                uniqueID: "facetime-0", localizedName: "FaceTime HD Camera",
+                positionRaw: 0, isActive: true, info: nil),
+            RemoteCmd.CameraDeviceEntry(
+                uniqueID: "usb-0", localizedName: "USB Camera",
+                positionRaw: 0, isActive: false, info: nil),
+            RemoteCmd.CameraDeviceEntry(
+                uniqueID: "builtin-0", localizedName: "MacBook Pro Camera",
+                positionRaw: 0, isActive: false, isSuspended: true, info: nil)
+        ]
+        model.activeRemoteDeviceID = "facetime-0"
+
+        let image = renderScreen(named: "monitor-device-menu", makeMonitorView(model))
         assertHasChrome(image)
     }
 

--- a/RemoteCamTests/RemoteCmdSerializationTests.swift
+++ b/RemoteCamTests/RemoteCmdSerializationTests.swift
@@ -60,7 +60,8 @@ final class RemoteCmdSerializationTests: XCTestCase {
         case let m as RemoteCmd.SetTorch: return m.toFlatBuffer()
         case let m as RemoteCmd.SetTorchResp: return m.toFlatBuffer()
         case let m as RemoteCmd.ToggleCamera: return m.toFlatBuffer()
-        case let m as RemoteCmd.ToggleCameraResp: return m.toFlatBuffer()
+        case let m as RemoteCmd.ToggleCameraResp: return m.toFlatBuffer() // also SelectCameraDeviceResp (subclass)
+        case let m as RemoteCmd.SelectCameraDevice: return m.toFlatBuffer()
         case let m as RemoteCmd.RequestCameraCapabilities: return m.toFlatBuffer()
         case let m as RemoteCmd.SetVideoQuality: return m.toFlatBuffer()
         case let m as RemoteCmd.SetVideoQualityResp: return m.toFlatBuffer()
@@ -395,6 +396,115 @@ final class RemoteCmdSerializationTests: XCTestCase {
         XCTAssertNil(decoded.backCamera)
         XCTAssertEqual(decoded.currentCamera, .front)
         XCTAssertEqual(decoded.currentLens, .ultraWide)
+    }
+
+    // MARK: - 13b. Camera device selection
+
+    func testSelectCameraDevice_roundTrip() {
+        let original = RemoteCmd.SelectCameraDevice(uniqueID: "com.apple.avfoundation:USB-0x1234")
+        let decoded: RemoteCmd.SelectCameraDevice = roundTrip(original)
+        XCTAssertEqual(decoded.uniqueID, "com.apple.avfoundation:USB-0x1234")
+    }
+
+    func testSelectCameraDeviceResp_roundTripCarriesDeviceList() {
+        let usbInfo = RemoteCmd.CameraInfo(
+            availableLenses: [.wideAngle],
+            hasFlash: false,
+            hasTorch: false,
+            zoomCapabilities: [.wideAngle: RemoteCmd.ZoomRange(minZoom: 1.0, maxZoom: 1.0)]
+        )
+        let devices = [
+            RemoteCmd.CameraDeviceEntry(
+                uniqueID: "builtin-0", localizedName: "FaceTime HD Camera",
+                positionRaw: AVCaptureDevice.Position.front.rawValue,
+                isActive: false, info: nil),
+            RemoteCmd.CameraDeviceEntry(
+                uniqueID: "usb-0", localizedName: "USB Camera",
+                positionRaw: AVCaptureDevice.Position.unspecified.rawValue,
+                isActive: true, info: usbInfo)
+        ]
+        let capabilities = RemoteCmd.CameraCapabilitiesResp(
+            frontCamera: nil, backCamera: nil,
+            currentCamera: .back, currentLens: .wideAngle, currentZoom: 1.0,
+            cameraDevices: devices, activeDeviceID: "usb-0", error: nil)
+        let original = RemoteCmd.SelectCameraDeviceResp(cameraCapabilities: capabilities, error: nil)
+
+        let decoded: RemoteCmd.SelectCameraDeviceResp = roundTrip(original)
+        let decodedCaps = decoded.cameraCapabilities
+        XCTAssertNil(decoded.error)
+        XCTAssertEqual(decodedCaps?.activeDeviceID, "usb-0")
+        XCTAssertEqual(decodedCaps?.cameraDevices.count, 2)
+        XCTAssertEqual(decodedCaps?.cameraDevices[0].uniqueID, "builtin-0")
+        XCTAssertEqual(decodedCaps?.cameraDevices[0].localizedName, "FaceTime HD Camera")
+        XCTAssertEqual(decodedCaps?.cameraDevices[0].position, .front)
+        XCTAssertFalse(decodedCaps?.cameraDevices[0].isActive ?? true)
+        // .unspecified survives the wire via has_unspecified_position.
+        XCTAssertEqual(decodedCaps?.cameraDevices[1].position, .unspecified)
+        XCTAssertTrue(decodedCaps?.cameraDevices[1].isActive ?? false)
+        XCTAssertEqual(decodedCaps?.cameraDevices[1].info?.availableLenses, [.wideAngle])
+    }
+
+    func testCameraDeviceEntry_suspendedFlagRoundTrips() {
+        let devices = [
+            RemoteCmd.CameraDeviceEntry(
+                uniqueID: "builtin-0", localizedName: "MacBook Pro Camera",
+                positionRaw: AVCaptureDevice.Position.unspecified.rawValue,
+                isActive: false, isSuspended: true, info: nil),
+            RemoteCmd.CameraDeviceEntry(
+                uniqueID: "usb-0", localizedName: "USB Camera",
+                positionRaw: AVCaptureDevice.Position.unspecified.rawValue,
+                isActive: true, isSuspended: false, info: nil)
+        ]
+        let capabilities = RemoteCmd.CameraCapabilitiesResp(
+            frontCamera: nil, backCamera: nil,
+            currentCamera: .back, currentLens: .wideAngle, currentZoom: 1.0,
+            cameraDevices: devices, activeDeviceID: "usb-0", error: nil)
+        let original = RemoteCmd.SelectCameraDeviceResp(cameraCapabilities: capabilities, error: nil)
+
+        let decoded: RemoteCmd.SelectCameraDeviceResp = roundTrip(original)
+        XCTAssertEqual(decoded.cameraCapabilities?.cameraDevices[0].isSuspended, true,
+                       "suspension must cross the wire so the monitor can gray the device out")
+        XCTAssertEqual(decoded.cameraCapabilities?.cameraDevices[1].isSuspended, false)
+    }
+
+    func testSelectCameraDeviceResp_withError() {
+        let err = NSError(domain: "busy", code: 7, userInfo: [NSLocalizedDescriptionKey: "busy"])
+        let original = RemoteCmd.SelectCameraDeviceResp(cameraCapabilities: nil, error: err)
+        let decoded: RemoteCmd.SelectCameraDeviceResp = roundTrip(original)
+        XCTAssertNotNil(decoded.error)
+        XCTAssertNil(decoded.cameraCapabilities)
+    }
+
+    func testCameraCapabilitiesResp_legacyShapeDecodesEmptyDeviceList() {
+        // A peer that predates device selection encodes no camera_devices —
+        // the decoded list must be empty (the monitor's gate stays closed).
+        let original = RemoteCmd.CameraCapabilitiesResp(
+            frontCamera: nil, backCamera: nil,
+            currentCamera: .back, currentLens: .wideAngle, currentZoom: 1.0,
+            error: nil)
+        let decoded: RemoteCmd.CameraCapabilitiesResp = roundTrip(original)
+        XCTAssertTrue(decoded.cameraDevices.isEmpty)
+        XCTAssertNil(decoded.activeDeviceID)
+    }
+
+    func testCameraCapabilitiesResp_deviceListRoundTrip() {
+        let devices = [
+            RemoteCmd.CameraDeviceEntry(
+                uniqueID: "back-0", localizedName: "Back Triple Camera",
+                positionRaw: AVCaptureDevice.Position.back.rawValue,
+                isActive: true, info: nil)
+        ]
+        let original = RemoteCmd.CameraCapabilitiesResp(
+            frontCamera: nil, backCamera: nil,
+            currentCamera: .back, currentLens: .wideAngle, currentZoom: 1.0,
+            cameraDevices: devices, activeDeviceID: "back-0", error: nil)
+        let decoded: RemoteCmd.CameraCapabilitiesResp = roundTrip(original)
+        XCTAssertEqual(decoded.cameraDevices, devices.map {
+            RemoteCmd.CameraDeviceEntry(
+                uniqueID: $0.uniqueID, localizedName: $0.localizedName,
+                positionRaw: $0.positionRaw, isActive: $0.isActive, info: nil)
+        })
+        XCTAssertEqual(decoded.activeDeviceID, "back-0")
     }
 
     // MARK: - 14. SwitchLens

--- a/RemoteCamTests/SessionTestSupport.swift
+++ b/RemoteCamTests/SessionTestSupport.swift
@@ -157,6 +157,43 @@ class FakeCameraControlling: CameraControlling {
         if let errorToThrow { throw errorToThrow }
         return (flashMode, .back)
     }
+
+    /// iPhone-shaped by default; tests reshape this to a Mac (N devices,
+    /// `.unspecified` positions) to exercise the device-selection paths.
+    var availableDevices: [CameraDeviceDescriptor] = [
+        CameraDeviceDescriptor(uniqueID: "fake-back", localizedName: "Back Camera",
+                               position: .back, deviceType: .builtInWideAngleCamera),
+        CameraDeviceDescriptor(uniqueID: "fake-front", localizedName: "Front Camera",
+                               position: .front, deviceType: .builtInWideAngleCamera)
+    ]
+    var activeDeviceID = "fake-back"
+    var deviceSelections: [String] = []
+
+    func availableCameraDevices() async -> [CameraDeviceDescriptor] { availableDevices }
+    func currentCameraDevice() async -> CameraDeviceDescriptor? {
+        availableDevices.first { $0.uniqueID == activeDeviceID }
+    }
+    func selectCameraDevice(uniqueID: String) async throws -> CameraSelectionResult {
+        if let errorToThrow { throw errorToThrow }
+        deviceSelections.append(uniqueID)
+        // Mirrors the engine: explicitly selecting a suspended device errors.
+        if let requested = availableDevices.first(where: { $0.uniqueID == uniqueID }),
+           requested.isSuspended {
+            throw NSError(domain: "\(requested.localizedName) is unavailable (suspended)", code: 0, userInfo: nil)
+        }
+        let fallbackPosition = availableDevices.first { $0.uniqueID == activeDeviceID }?.position ?? .unspecified
+        guard let device = CameraDeviceDescriptor.resolveSelection(
+                requestedID: uniqueID, available: availableDevices, fallbackPosition: fallbackPosition) else {
+            throw NSError(domain: "No camera device available", code: 0, userInfo: nil)
+        }
+        activeDeviceID = device.uniqueID
+        return CameraSelectionResult(
+            device: device,
+            flashMode: device.position == .back ? flashMode : nil,
+            availableLensTypes: [.wideAngle],
+            zoomRange: RemoteCmd.ZoomRange(minZoom: 1, maxZoom: 10),
+            currentZoom: 1.0)
+    }
     func setTorchMode(mode: AVCaptureDevice.TorchMode) async throws -> AVCaptureDevice.TorchMode {
         if let errorToThrow { throw errorToThrow }
         torchActive = mode == .on
@@ -168,12 +205,38 @@ class FakeCameraControlling: CameraControlling {
     func setPhotoQuality(format: PhotoFormat, hdrMode: HDRMode) async -> (PhotoFormat, HDRMode)? {
         (format, hdrMode)
     }
+    /// False simulates a legacy peer whose capabilities carry no device list
+    /// — the monitor must never send SelectCameraDevice to it.
+    var advertisesCameraDevices = true
+
+    /// Devices that accept the input swap but never deliver a frame (a
+    /// wedged virtual camera). While one is active, awaitFrameDelivery fails.
+    var stalledDeviceIDs: Set<String> = []
+
+    func awaitFrameDelivery(timeout: TimeInterval) async -> Bool {
+        !stalledDeviceIDs.contains(activeDeviceID)
+    }
+
     func setAspectRatio(_ ratio: AspectRatio) async -> AspectRatio { ratio }
     func gatherAllCameraCapabilities() async { gatherCapabilitiesCalls += 1 }
     func gatherCurrentCameraCapabilities() async -> RemoteCmd.CameraCapabilitiesResp? {
-        RemoteCmd.CameraCapabilitiesResp(
+        let entries: [RemoteCmd.CameraDeviceEntry] = advertisesCameraDevices
+            ? availableDevices.map {
+                RemoteCmd.CameraDeviceEntry(
+                    uniqueID: $0.uniqueID,
+                    localizedName: $0.localizedName,
+                    positionRaw: $0.position.rawValue,
+                    isActive: $0.uniqueID == activeDeviceID,
+                    isSuspended: $0.isSuspended,
+                    info: nil)
+            }
+            : []
+        return RemoteCmd.CameraCapabilitiesResp(
             frontCamera: nil, backCamera: nil,
-            currentCamera: .back, currentLens: .wideAngle, currentZoom: 1.0, error: nil)
+            currentCamera: .back, currentLens: .wideAngle, currentZoom: 1.0,
+            cameraDevices: entries,
+            activeDeviceID: advertisesCameraDevices ? activeDeviceID : nil,
+            error: nil)
     }
 
     func getCurrentZoomFactor() async -> CGFloat { zoomCalls.last ?? 1.0 }

--- a/RemoteShutter.xcodeproj/project.pbxproj
+++ b/RemoteShutter.xcodeproj/project.pbxproj
@@ -105,6 +105,9 @@
 		9667E6BB6F62D30AB6928304 /* CaptureEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F7C7180B3B581F22EF07350 /* CaptureEngine.swift */; };
 		AB12CD34EF5601789ABC0DE2 /* RecordingPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DE1 /* RecordingPipeline.swift */; };
 		AB12CD34EF5601789ABC0DE6 /* FrameStreamingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DE5 /* FrameStreamingCoordinator.swift */; };
+		CADE5E1EC000000000000002 /* CameraDeviceDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADE5E1EC000000000000001 /* CameraDeviceDescriptor.swift */; };
+		CADE5E1EC000000000000004 /* CameraDeviceSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADE5E1EC000000000000003 /* CameraDeviceSelectionTests.swift */; };
+		CADE5E1EC000000000000006 /* CaptureIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADE5E1EC000000000000005 /* CaptureIntegrationTests.swift */; };
 		AB12CD34EF5601789ABC0DE8 /* CameraScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DE7 /* CameraScreenView.swift */; };
 		AB12CD34EF5601789ABC0DE4 /* RecordingPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DE3 /* RecordingPipelineTests.swift */; };
 		AB12CD34EF5601789ABC0DEA /* CameraScreenSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DE9 /* CameraScreenSnapshotTests.swift */; };
@@ -113,7 +116,7 @@
 		AB12CD34EF5601789ABC0DEE /* MonitorScreenSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DED /* MonitorScreenSnapshotTests.swift */; };
 		99F50887F138FD71CF957A08 /* CameraControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A0B888B31311AE2BB5EB70 /* CameraControlling.swift */; };
 		A0C6EAACDA1985B1DD5E8EC0 /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50951447985E618A5F3818CD /* WatchConnectivity.framework */; };
-		A31965B5A3A1F59F96002E63 /* RemoteShutterWatch.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 36D2A99A351652C2D0C29B95 /* RemoteShutterWatch.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		A31965B5A3A1F59F96002E63 /* RemoteShutterWatch.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 36D2A99A351652C2D0C29B95 /* RemoteShutterWatch.app */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		AA0001012E940001000A1001 /* AlertPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001032E940003000A1001 /* AlertPresenting.swift */; };
 		AA0001042E940004000A1001 /* AlertPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001032E940003000A1001 /* AlertPresenting.swift */; };
 		AA0001052E940005000A1001 /* UIAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001062E940006000A1001 /* UIAlertPresenter.swift */; };
@@ -309,6 +312,9 @@
 		0F7C7180B3B581F22EF07350 /* CaptureEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CaptureEngine.swift; sourceTree = "<group>"; };
 		AB12CD34EF5601789ABC0DE1 /* RecordingPipeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecordingPipeline.swift; sourceTree = "<group>"; };
 		AB12CD34EF5601789ABC0DE5 /* FrameStreamingCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FrameStreamingCoordinator.swift; sourceTree = "<group>"; };
+		CADE5E1EC000000000000001 /* CameraDeviceDescriptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CameraDeviceDescriptor.swift; sourceTree = "<group>"; };
+		CADE5E1EC000000000000003 /* CameraDeviceSelectionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CameraDeviceSelectionTests.swift; sourceTree = "<group>"; };
+		CADE5E1EC000000000000005 /* CaptureIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CaptureIntegrationTests.swift; sourceTree = "<group>"; };
 		AB12CD34EF5601789ABC0DE7 /* CameraScreenView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CameraScreenView.swift; sourceTree = "<group>"; };
 		AB12CD34EF5601789ABC0DE3 /* RecordingPipelineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecordingPipelineTests.swift; sourceTree = "<group>"; };
 		AB12CD34EF5601789ABC0DE9 /* CameraScreenSnapshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CameraScreenSnapshotTests.swift; sourceTree = "<group>"; };
@@ -518,6 +524,7 @@
 				35D7D050D0AB3D3E4F07879D /* ScannerLobby.swift */,
 				A8A0B888B31311AE2BB5EB70 /* CameraControlling.swift */,
 				0F7C7180B3B581F22EF07350 /* CaptureEngine.swift */,
+				CADE5E1EC000000000000001 /* CameraDeviceDescriptor.swift */,
 				AB12CD34EF5601789ABC0DE1 /* RecordingPipeline.swift */,
 				AB12CD34EF5601789ABC0DE5 /* FrameStreamingCoordinator.swift */,
 				AB12CD34EF5601789ABC0DE7 /* CameraScreenView.swift */,
@@ -546,6 +553,8 @@
 				47C3D2AB20DA09223CE0EF3D /* ControllerWiringTests.swift */,
 				58B23042ABDA0FD46696039B /* MonitorPresenterTests.swift */,
 				A342ACE91A767718D76C4C60 /* CaptureEngineTests.swift */,
+				CADE5E1EC000000000000003 /* CameraDeviceSelectionTests.swift */,
+				CADE5E1EC000000000000005 /* CaptureIntegrationTests.swift */,
 				AB12CD34EF5601789ABC0DE3 /* RecordingPipelineTests.swift */,
 				AB12CD34EF5601789ABC0DE9 /* CameraScreenSnapshotTests.swift */,
 				AB12CD34EF5601789ABC0DFB /* SessionTestSupport.swift */,
@@ -1128,6 +1137,7 @@
 				4259A755DF0013E098FD3CCC /* ScannerLobby.swift in Sources */,
 				99F50887F138FD71CF957A08 /* CameraControlling.swift in Sources */,
 				9667E6BB6F62D30AB6928304 /* CaptureEngine.swift in Sources */,
+				CADE5E1EC000000000000002 /* CameraDeviceDescriptor.swift in Sources */,
 				AB12CD34EF5601789ABC0DE2 /* RecordingPipeline.swift in Sources */,
 				AB12CD34EF5601789ABC0DE6 /* FrameStreamingCoordinator.swift in Sources */,
 				AB12CD34EF5601789ABC0DE8 /* CameraScreenView.swift in Sources */,
@@ -1155,6 +1165,8 @@
 				531BD3C020987337266B50EC /* ControllerWiringTests.swift in Sources */,
 				8FC594E5A315D918BE429895 /* MonitorPresenterTests.swift in Sources */,
 				E1660E880D768347CB5B3297 /* CaptureEngineTests.swift in Sources */,
+				CADE5E1EC000000000000004 /* CameraDeviceSelectionTests.swift in Sources */,
+				CADE5E1EC000000000000006 /* CaptureIntegrationTests.swift in Sources */,
 				AB12CD34EF5601789ABC0DE4 /* RecordingPipelineTests.swift in Sources */,
 				AB12CD34EF5601789ABC0DEA /* CameraScreenSnapshotTests.swift in Sources */,
 				AB12CD34EF5601789ABC0DFC /* SessionTestSupport.swift in Sources */,
@@ -1236,6 +1248,7 @@
 		F9BE2447CA8A8A4E4BC91CD6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = RemoteShutterWatch;
+			platformFilter = ios;
 			target = 95689A3D40F14A2997A50972 /* RemoteShutterWatch */;
 			targetProxy = 149314AE20875A710CF3EA3D /* PBXContainerItemProxy */;
 		};
@@ -1292,13 +1305,14 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = YES;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,6";
 			};
 			name = Debug;
 		};
@@ -1332,12 +1346,13 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = YES;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,6";
 			};
 			name = Release;
 		};
@@ -1347,6 +1362,9 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				SUPPORTS_MACCATALYST = YES;
+				"TEST_HOST[sdk=macosx*]" = "$(BUILT_PRODUCTS_DIR)/RemoteShutter.app/Contents/MacOS/RemoteShutter";
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = RemoteCamTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -1369,6 +1387,9 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				SUPPORTS_MACCATALYST = YES;
+				"TEST_HOST[sdk=macosx*]" = "$(BUILT_PRODUCTS_DIR)/RemoteShutter.app/Contents/MacOS/RemoteShutter";
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = RemoteCamTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;


### PR DESCRIPTION
## What

Remote Shutter becomes a first-class Mac app via **Mac Catalyst** (same target, universal purchase — existing IAPs carry over). A Mac can take **either role**, and camera identity is now a **device list** (built-in, Continuity, USB/UVC, virtual cameras) rather than front/back:

- **Local picker** on the Mac camera screen; **adaptive switch control** on the monitor: 1 camera → hidden, 2 → classic flip button, 3+/suspended-present → device menu (tap to open). Active camera's name overlays the preview.
- **Remote camera switching**: the monitor selects the peer's camera by name over the wire.
- **Suspended cameras** (clamshell built-in) are advertised, grayed out, and excluded from selection/toggle/fallback.
- **Frame-confirmed switches**: a camera that accepts the swap but never delivers a frame returns a visible error naming the device; the first-frame watchdog restores a working camera.

## Wire compatibility (guaranteed)

- All schema changes are **append-only** FlatBuffers fields + one new table; old peers see absent fields.
- `SelectCameraDevice` is **gated**: only sent to peers whose capabilities advertised a device list — old decoders read unknown command actions as `TakePicture` (gate pinned by loopback test `testSelectCameraDeviceIsNeverSentToLegacyPeer`).
- `.unspecified` positions serialize as `Back + has_unspecified_position` — legacy monitors render Mac frames unmirrored.

## Capture engine hardening (AVCam reference patterns + hardware probes on a 6-camera Mac)

- Frame durations clamp into the `AVFrameRateRange`'s **own CMTimes** — UVC "60 fps" is really 60.00024; integer durations throw on DAL hardware and silently wedge software cameras (was a crash + a stall in the wild).
- Input-swap-only camera changes with `canAddInput` guard/restore; runtime-error + interruption resume; stop/start bounce for sessions that started on a never-delivering source (sandboxed-out OBS).
- Preview attaches to the **idle** session before configure/start (AVCam ordering); capability probing moved after session start — this removed the multi-second Mac preview delay.
- Frames always ride `.unreliable`; MC's datagram channel is warmed at peer connect so its ~10s negotiation overlaps role selection instead of the first seconds of preview.
- Never rotate landscape-native Mac connections (fixed the sideways stream); Macs report fixed landscape.

## Tests

- Unit matrices: `resolveSelection`, `nextToggleSelection`, `resolveFrameRate` (incl. fractional-UVC case), switch-control policy.
- Loopback protocol suites: select round-trip, legacy-peer gating, busy rejection, suspension advertising + rejection, dead-camera error naming, hot-plug capabilities rebroadcast, datagram warm-up ping.
- **`CaptureIntegrationTests`** — rig-level tests against real cameras (auto-skip on simulator/CI): verified on physical hardware — startup recovery from a poisoned system camera preference (~6s), all-device cycling, toggling, and a live hot-plug of a new USB camera mid-run. Run: `xcodebuild test … -destination 'platform=macOS,variant=Mac Catalyst' -only-testing:RemoteShutterTests/CaptureIntegrationTests`
- Full iOS suite green (TSan-clean per repo policy); CI gains a Catalyst build-only job.

## Reviewer manual checklist

- [ ] Mac ↔ iPhone in both roles; preview starts immediately after connect
- [ ] Device menu on the phone lists the Mac's cameras; switching works; suspended (lid-closed) camera grayed
- [ ] Selecting a dead virtual camera (e.g. OBS w/o OBS running) shows the named error and auto-recovers
- [ ] Photos/videos from the Mac land upright

Mac App Store delivery (certs/lane) ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)