### PR TITLE
release_mac: fix Catalyst archive destination; one dispatch delivers both platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       platform:
-        description: "Which app to release"
+        description: "Which app to release (default: both)"
         type: choice
-        options: [ios, mac]
-        default: ios
+        options: [both, ios, mac]
+        default: both
 
 permissions:
   contents: read
@@ -30,9 +30,12 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
 
-      - name: Build and upload to App Store
+      # The two lanes run sequentially on one runner: match writes to the
+      # same signing repo, so parallel jobs could race on the first run.
+      - name: Build and upload iOS to App Store
+        if: ${{ inputs.platform != 'mac' }}
         timeout-minutes: 30
-        run: bundle exec fastlane ${{ inputs.platform == 'mac' && 'release_mac' || 'release' }}
+        run: bundle exec fastlane release
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
@@ -41,12 +44,25 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
 
-      - name: Upload IPA artifact
+      - name: Build and upload Mac to App Store
+        if: ${{ inputs.platform != 'ios' }}
+        timeout-minutes: 30
+        run: bundle exec fastlane release_mac
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_CONTENT: ${{ secrets.ASC_KEY_CONTENT }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+
+      - name: Upload build artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: RemoteShutter.ipa
+          name: RemoteShutter-builds
           path: |
             **/*.ipa
+            **/*.pkg
             **/*.dSYM
           retention-days: 30

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -175,6 +175,11 @@ platform :ios do
     build_app(
       workspace: "RemoteShutter.xcworkspace",
       scheme: "RemoteCam",
+      # catalyst_platform alone does NOT pick the archive destination — gym
+      # archives for native macOS (no UIKit) and dependency scanning fails
+      # with "Unable to find module dependency: 'UIKit'" (run 29180954433).
+      # The Catalyst variant must be requested explicitly, same as ios-ci.yml.
+      destination: "generic/platform=macOS,variant=Mac Catalyst",
       catalyst_platform: "macos",
       export_method: "app-store",
       clean: true,


### PR DESCRIPTION
Two fixes for the Mac release path:

## 1. Archive the Mac Catalyst variant, not native macOS

First `release_mac` dispatch (run 29180954433) failed in `build_app` with `Unable to find module dependency: 'UIKit'` — gym's `catalyst_platform: "macos"` does not select the archive destination, so xcodebuild archived for **native macOS**, where UIKit/WatchConnectivity don't exist. Fix: pass `destination: "generic/platform=macOS,variant=Mac Catalyst"` explicitly — the same destination the green `Build Mac Catalyst` CI job uses.

Note: `match` already minted the Catalyst certs/profile successfully in that run, so signing is in a working state.

## 2. One dispatch ships both platforms

The `platform` input now defaults to `both`: the workflow runs `release` (iOS) then `release_mac` sequentially on one runner (sequential because match writes to the shared signing repo — parallel jobs could race). `ios` / `mac` remain as options for re-running one side after a partial failure. The artifact step now also captures the Mac `.pkg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)