### PR TITLE
Monitor screen: don't draw under the Mac toolbar

### DIFF
--- a/RemoteCam/MonitorView.swift
+++ b/RemoteCam/MonitorView.swift
@@ -40,8 +40,20 @@ struct MonitorView: View {
                 }
             }
         }
-        .ignoresSafeArea(edges: .top)
+        .ignoresSafeArea(edges: Self.topBleedEdges)
         .statusBarHidden()
+    }
+
+    /// iPhone/iPad draw the preview full-bleed under the notch/status bar.
+    /// The Mac's toolbar (Back button, window title) is opaque chrome — the
+    /// screen must never draw under it, or the active-camera label and timer
+    /// land on top of the Back button.
+    private static var topBleedEdges: Edge.Set {
+        #if targetEnvironment(macCatalyst)
+        []
+        #else
+        .top
+        #endif
     }
     
     // MARK: - Camera Preview Section


### PR DESCRIPTION
## What

On Mac Catalyst, the monitor screen's top overlays (active-camera name label, recording timer) rendered on top of the toolbar's Back button.

## Why

`MonitorView` applies `.ignoresSafeArea(edges: .top)` unconditionally — correct on iPhone/iPad (full-bleed preview under the notch/status bar), wrong on the Mac where the toolbar is opaque chrome. Measured live via accessibility frames: the toolbar occupies the window's top 52pt, and the label sat at y≈20 inside it.

## How

Platform-conditional bleed edges: `[]` on Catalyst, `.top` elsewhere — one policy point, fixes every top overlay at once (label, timer, zoom controls). Matches the repo's existing Catalyst shim conventions.

Verified: full iOS test suite green (snapshots included), Mac Catalyst build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)