### PR TITLE
Fix Watch pairing stuck on "Found your iPhone. Getting ready…"

### DIFF
--- a/RemoteCam/SessionCoordinator.swift
+++ b/RemoteCam/SessionCoordinator.swift
@@ -928,6 +928,9 @@ public actor SessionCoordinator {
             ctrl = become.ctrl
             await transition(to: .watchCamera)
 
+        case let request as UICmd.RequestWatchStateReply:
+            await replyWithWatchState(request)
+
         case let rejected as UICmd.BecomeCamera:
             rejected.ctrl.exitCamera()
 
@@ -1696,6 +1699,34 @@ public actor SessionCoordinator {
     }
 
     // MARK: - Watch state snapshot
+
+    /// True while the machine is in any Watch Remote camera state.
+    private var isInWatchState: Bool {
+        switch state {
+        case .watchCamera, .watchCameraTakingPic, .watchCameraStartingVideo, .watchCameraRecordingVideo:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Answers a Watch `.requeststate` command authoritatively. In a watch state the
+    /// reply carries `Ok` plus the full camera snapshot (freshly epoch-stamped, like
+    /// `pushCameraState`); otherwise it truthfully reports `.notinwatchmode`. This is
+    /// the one place the "phone is ready" verdict and the snapshot travel together, so
+    /// the Watch never receives an Ok that isn't backed by state.
+    private func replyWithWatchState(_ request: UICmd.RequestWatchStateReply) async {
+        guard isInWatchState, let ctrl else {
+            request.reply(WatchStateReplyEncoder.encode(status: .notinwatchmode, snapshot: nil))
+            return
+        }
+        var snapshot = await Self.watchStateSnapshot(
+            ctrl: ctrl,
+            isBackgrounded: isPhoneBackgrounded(),
+            countdownRemaining: watchCountdownRemaining)
+        snapshot.stateEpochMs = UInt64(Date().timeIntervalSince1970 * 1000)
+        request.reply(WatchStateReplyEncoder.encode(status: .ok, snapshot: snapshot))
+    }
 
     func pushWatchState(event: RemoteShutter_WatchEventType = .unknown) async {
         guard let ctrl else { return }

--- a/RemoteCam/UICmds.swift
+++ b/RemoteCam/UICmds.swift
@@ -614,6 +614,20 @@ extension UICmd {
     /// Sent by WatchRemoteCameraController when exiting Watch Remote mode.
     public class UnbecomeWatchCamera: Message, @unchecked Sendable {}
 
+    /// A Watch `.requeststate` command routed into the coordinator so the reply is
+    /// authoritative: the coordinator answers `reply` with an encoded ack+state
+    /// message (Ok + snapshot in a watch state, `.notinwatchmode` otherwise). The
+    /// FIFO inbox guarantees the answer reflects the machine's real state, so an
+    /// Ok can never precede — and then lose — a separately-channelled state push.
+    public class RequestWatchStateReply: Message, @unchecked Sendable {
+        let reply: (Data) -> Void
+
+        init(reply: @escaping (Data) -> Void) {
+            self.reply = reply
+            super.init(sender: nil)
+        }
+    }
+
     /// Watch-initiated photo/video mode switch.
     public class SetWatchCameraMode: Message, @unchecked Sendable {
         let mode: RecordingMode

--- a/RemoteCam/WatchRemoteCameraController.swift
+++ b/RemoteCam/WatchRemoteCameraController.swift
@@ -66,7 +66,6 @@ public class WatchRemoteCameraController: UIViewController {
         setupActors()
         setupCameraScreen()
         setupWatchStatusOverlay()
-        bindToWatchManager()
     }
 
     public override func viewDidAppear(_ animated: Bool) {
@@ -153,7 +152,12 @@ public class WatchRemoteCameraController: UIViewController {
 
     // MARK: - Watch Manager Binding
 
+    /// Bound in `viewWillAppear` (not `viewDidLoad`) so a cancelled interactive
+    /// swipe-back — which fires `viewWillDisappear` → `unbindFromWatchManager` —
+    /// re-binds when the screen settles back. Idempotent: re-binding to the same
+    /// controller is a no-op.
     private func bindToWatchManager() {
+        guard WatchSessionManager.shared.cameraController !== self else { return }
         WatchSessionManager.shared.cameraController = self
     }
 
@@ -168,6 +172,7 @@ public class WatchRemoteCameraController: UIViewController {
 
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        bindToWatchManager()
         navigationController?.setNavigationBarHidden(false, animated: animated)
         navigationItem.title = NSLocalizedString("Watch Remote", comment: "")
         navigationController?.navigationBar.prefersLargeTitles = false
@@ -314,5 +319,12 @@ public class WatchRemoteCameraController: UIViewController {
         guard cameraHost != nil else { return }
         let session = remoteCamSession
         session ! RemoteCmd.RequestCameraCapabilities()
+    }
+
+    /// Routes a Watch `.requeststate` command into the coordinator so the reply is
+    /// authoritative (see `UICmd.RequestWatchStateReply`). `reply` is the WCSession
+    /// `replyHandler`; the coordinator calls it once with the encoded ack+state.
+    func requestWatchStateReply(_ reply: @escaping (Data) -> Void) {
+        remoteCamSession ! UICmd.RequestWatchStateReply(reply: reply)
     }
 }

--- a/RemoteCam/WatchSessionManager.swift
+++ b/RemoteCam/WatchSessionManager.swift
@@ -199,7 +199,23 @@ class WatchSessionManager: NSObject, ObservableObject, WCSessionDelegate {
                  didReceiveMessageData messageData: Data,
                  replyHandler: @escaping (Data) -> Void) {
         debugLog("WatchSessionManager: didReceiveMessageData WITH reply (\(messageData.count) bytes)")
-        // Always reply — a dropped replyHandler surfaces as a timeout error on the Watch.
+
+        // The reply to `.requeststate` IS the state: route it into the coordinator
+        // so the answer is computed from the machine's real state (Ok + snapshot in
+        // a watch state, `.notinwatchmode` otherwise). This replaces the old
+        // synchronous Ok, which could "lie" — acking before a state push that a
+        // reachability race then silently dropped, stranding the Watch on "connecting".
+        if let decoded = WatchCommandEncoder.decode(messageData), decoded.action == .requeststate {
+            guard let controller = cameraController else {
+                replyHandler(WatchStateReplyEncoder.encode(status: .notinwatchmode, snapshot: nil))
+                return
+            }
+            controller.requestWatchStateReply(replyHandler)
+            return
+        }
+
+        // Every other command keeps its fast synchronous ack — a dropped replyHandler
+        // surfaces as a timeout error on the Watch.
         replyHandler(handleIncomingData(messageData))
     }
 

--- a/RemoteCamTests/WatchRemoteCamStateTests.swift
+++ b/RemoteCamTests/WatchRemoteCamStateTests.swift
@@ -429,6 +429,56 @@ class WatchRemoteCamStateTests: XCTestCase {
         XCTAssertEqual(snapshot.event, .recordingstarted)
     }
 
+    // MARK: - Authoritative state reply (the reply IS the state)
+
+    /// In a watch state the coordinator answers `.requeststate` with Ok plus a
+    /// decodable, ready snapshot — one message the Watch applies like a live push.
+    func testRequestWatchStateReplyInWatchStateCarriesOkAndReadySnapshot() async {
+        await enterWatchCamera()
+
+        let box = Locked<Data?>(nil)
+        await deliver(UICmd.RequestWatchStateReply { box.value = $0 })
+
+        guard let reply = box.value else { return XCTFail("coordinator must answer the reply") }
+
+        let snapshot = WatchStateReplyEncoder.decodeState(reply)
+        XCTAssertNotNil(snapshot, "an in-watch-state reply must carry a snapshot")
+        XCTAssertEqual(snapshot?.readiness, .ready)
+        XCTAssertGreaterThan(snapshot?.stateEpochMs ?? 0, 0, "reply snapshot must be epoch-stamped")
+
+        let ack = WatchAckEncoder.decode(reply)
+        XCTAssertEqual(ack?.status, .ok)
+        XCTAssertEqual(ack?.action, .requeststate)
+    }
+
+    /// Outside any watch state the reply is a truthful `.notinwatchmode` with no
+    /// snapshot — no more false Ok stranding the Watch on "connecting".
+    func testRequestWatchStateReplyOutsideWatchStateIsNotInWatchMode() async {
+        // Never entered a watch state — the machine sits at its idle floor.
+        let box = Locked<Data?>(nil)
+        await deliver(UICmd.RequestWatchStateReply { box.value = $0 })
+
+        guard let reply = box.value else { return XCTFail("coordinator must answer the reply") }
+        XCTAssertNil(WatchStateReplyEncoder.decodeState(reply),
+                     "a non-watch-state reply must not carry a snapshot")
+        XCTAssertEqual(WatchAckEncoder.decode(reply)?.status, .notinwatchmode)
+    }
+
+    /// A backgrounded phone that's still in a watch state replies Ok, but the
+    /// snapshot reports not-ready — the reply never claims ready falsely.
+    func testRequestWatchStateReplyReportsBackgroundedReadiness() async {
+        await coordinator.setIsPhoneBackgrounded { true }
+        await enterWatchCamera()
+
+        let box = Locked<Data?>(nil)
+        await deliver(UICmd.RequestWatchStateReply { box.value = $0 })
+
+        guard let reply = box.value else { return XCTFail("coordinator must answer the reply") }
+        XCTAssertEqual(WatchStateReplyEncoder.decodeState(reply)?.readiness, .phonebackgrounded)
+        XCTAssertEqual(WatchAckEncoder.decode(reply)?.status, .ok,
+                       "the phone is in watch mode, so the ack is still Ok")
+    }
+
     // MARK: - Readiness (backgrounded / locked phone)
 
     func testSnapshotReadyWhenForegrounded() async {

--- a/RemoteCamTests/WatchSerializationTests.swift
+++ b/RemoteCamTests/WatchSerializationTests.swift
@@ -187,6 +187,51 @@ final class WatchSerializationTests: XCTestCase {
         XCTAssertNil(WatchStateEncoder.decode(WatchAckEncoder.encode(status: .ok)))
     }
 
+    // MARK: - Authoritative State Reply (iPhone -> Watch, reply to `.requeststate`)
+
+    /// An Ok reply carries the full snapshot in the same message — the reply IS the
+    /// state, so the Watch never gets an Ok that isn't backed by state.
+    func testStateReplyOkCarriesDecodableSnapshot() throws {
+        let snapshot = WatchCameraStateSnapshot(
+            readiness: .ready,
+            currentZoomFactor: 2.0,
+            currentMode: .video,
+            currentLensType: .telephoto,
+            availableLensTypes: [.wideangle, .telephoto],
+            stateEpochMs: 1_765_000_000_123)
+        let data = WatchStateReplyEncoder.encode(status: .ok, snapshot: snapshot)
+
+        let decoded = try XCTUnwrap(WatchStateReplyEncoder.decodeState(data),
+                                    "an Ok reply must carry a decodable snapshot")
+        XCTAssertEqual(decoded.readiness, .ready)
+        XCTAssertEqual(decoded.currentZoomFactor, 2.0, accuracy: 0.0001)
+        XCTAssertEqual(decoded.currentMode, .video)
+        XCTAssertEqual(decoded.currentLensType, .telephoto)
+        XCTAssertEqual(decoded.availableLensTypes, [.wideangle, .telephoto])
+        XCTAssertEqual(decoded.stateEpochMs, 1_765_000_000_123)
+
+        // The ack half is still readable for older-phone-style handling.
+        let ack = try XCTUnwrap(WatchAckEncoder.decode(data))
+        XCTAssertEqual(ack.status, .ok)
+        XCTAssertEqual(ack.action, .requeststate)
+    }
+
+    /// A `.notinwatchmode` reply carries no state table: `decodeState` returns nil
+    /// and the ack tells the Watch the phone truthfully isn't in Watch Remote mode.
+    func testStateReplyNotInWatchModeCarriesNoState() throws {
+        let data = WatchStateReplyEncoder.encode(status: .notinwatchmode, snapshot: nil)
+        XCTAssertNil(WatchStateReplyEncoder.decodeState(data),
+                     "a notinwatchmode reply must not carry a snapshot")
+        let ack = try XCTUnwrap(WatchAckEncoder.decode(data))
+        XCTAssertEqual(ack.status, .notinwatchmode)
+    }
+
+    /// A bare ack (older phone, or any non-reply ack) has no state to extract.
+    func testReplyStateDecodeRejectsBareAck() {
+        XCTAssertNil(WatchStateReplyEncoder.decodeState(WatchAckEncoder.encode(status: .ok)))
+        XCTAssertNil(WatchStateReplyEncoder.decodeState(WatchCommandEncoder.encode(action: .requeststate)))
+    }
+
     // MARK: - Live Preview Frame (iPhone -> Watch)
 
     func testPreviewFrameRoundTripPreservesPayloadCodecAndEpoch() throws {
@@ -337,5 +382,50 @@ final class ZoomSendThrottleTests: XCTestCase {
     func testFireTrailingWithNothingPendingReturnsNil() {
         var throttle = ZoomSendThrottle(interval: 0.05)
         XCTAssertNil(throttle.fireTrailing(now: Date()))
+    }
+}
+
+// MARK: - Watch State Poll Policy
+
+final class WatchStatePollPolicyTests: XCTestCase {
+
+    /// Fixed 2s cadence, no backoff — the single source of truth for the poll rate.
+    func testCadenceIsFixedTwoSeconds() {
+        XCTAssertEqual(WatchStatePollPolicy.interval, 2.0, accuracy: 0.0001)
+    }
+
+    /// The only combination that polls: still connecting, reachable, and active.
+    func testPollsOnlyWhileConnectingReachableAndActive() {
+        XCTAssertTrue(WatchStatePollPolicy.shouldPoll(
+            phase: .connecting, isReachable: true, isActive: true))
+    }
+
+    /// Once a snapshot is applied the phase leaves `.connecting`, so polling stops.
+    func testStopsOnceStateApplied() {
+        for phase: WatchConnectionPhase in [.ready, .phoneNotReady, .phoneNotInWatchMode, .inactive] {
+            XCTAssertFalse(WatchStatePollPolicy.shouldPoll(
+                phase: phase, isReachable: true, isActive: true),
+                "\(phase) must not poll — only .connecting does")
+        }
+    }
+
+    func testStopsWhenUnreachable() {
+        XCTAssertFalse(WatchStatePollPolicy.shouldPoll(
+            phase: .connecting, isReachable: false, isActive: true))
+    }
+
+    func testStopsWhenInactive() {
+        XCTAssertFalse(WatchStatePollPolicy.shouldPoll(
+            phase: .connecting, isReachable: true, isActive: false))
+    }
+
+    /// There is no give-up budget: the same inputs always yield the same verdict,
+    /// no matter how many times the decision is taken (infinite polling).
+    func testIsStatelessSoPollingNeverGivesUp() {
+        for _ in 0..<1_000 {
+            XCTAssertTrue(WatchStatePollPolicy.shouldPoll(
+                phase: .connecting, isReachable: true, isActive: true),
+                "polling must never exhaust a retry budget")
+        }
     }
 }

--- a/RemoteShutterWatch/RemoteShutterWatchApp.swift
+++ b/RemoteShutterWatch/RemoteShutterWatchApp.swift
@@ -21,12 +21,11 @@ struct RemoteShutterWatchApp: App {
                 .environmentObject(appDelegate.sessionDelegate)
         }
         .onChange(of: scenePhase) { _, newPhase in
-            // Reopening the app must re-sync: activation/reachability callbacks
-            // don't fire when the app resumes while the phone stayed reachable,
-            // and whatever state we last showed may be long stale.
-            if newPhase == .active {
-                appDelegate.sessionDelegate.requestState()
-            }
+            // Drive the state poll loop from the scene phase. Reopening must re-sync
+            // (activation/reachability callbacks don't fire when the app resumes while
+            // the phone stayed reachable, and the last state shown may be long stale);
+            // deactivating stops polling so the Watch isn't chattering in the pocket.
+            appDelegate.sessionDelegate.setActive(newPhase == .active)
         }
     }
 }

--- a/RemoteShutterWatch/WatchSessionDelegate.swift
+++ b/RemoteShutterWatch/WatchSessionDelegate.swift
@@ -6,7 +6,7 @@
 //  Sends FlatBuffer-encoded commands to iPhone via sendMessageData with
 //  per-command acks; receives state via live messages and applicationContext.
 //
-//  Threading: all mutable state (retry bookkeeping) is confined to the main
+//  Threading: all mutable state (poll bookkeeping) is confined to the main
 //  queue — WCSession delegate callbacks hop there before touching it.
 //
 
@@ -25,11 +25,14 @@ class WatchSessionDelegate: NSObject, ObservableObject, WCSessionDelegate {
     /// a stale decoder by itself.
     private let vp9Decoder = WatchVP9PreviewDecoder()
 
-    // Main-queue confined.
-    private var retryCount = 0
-    private let maxRetries = 10
-    /// Armed after a requestState is acked Ok; fires if no state arrives.
-    private var stateArrivalCheck: DispatchWorkItem?
+    // MARK: - Poll bookkeeping (main-queue confined)
+
+    /// Whether the app is foreground-active. Polling only runs while active; the
+    /// scene phase drives this via `setActive(_:)`.
+    private var isActive = true
+    /// True while a poll tick is scheduled, so overlapping kicks can't spin up a
+    /// second concurrent loop.
+    private var pollScheduled = false
 
     init(viewModel: WatchCameraViewModel) {
         self.viewModel = viewModel
@@ -64,8 +67,7 @@ class WatchSessionDelegate: NSObject, ObservableObject, WCSessionDelegate {
                 self.viewModel.update(from: state)
             }
             if activationState == .activated && reachable {
-                self.retryCount = 0
-                self.retryRequestState()
+                self.kickPolling()
             }
         }
     }
@@ -77,55 +79,84 @@ class WatchSessionDelegate: NSObject, ObservableObject, WCSessionDelegate {
             guard let self else { return }
             self.viewModel.isPhoneReachable = reachable
             if reachable {
-                self.retryCount = 0
-                self.retryRequestState()
+                self.kickPolling()
             }
         }
     }
 
-    // MARK: - Retry Logic (main-queue confined)
+    // MARK: - State Polling (fixed-rate, infinite; main-queue confined)
 
-    private func retryRequestState() {
+    /// Starts the poll loop if it isn't already running. Idempotent — the
+    /// `pollScheduled` guard keeps overlapping kicks from spinning up a second loop.
+    private func kickPolling() {
         dispatchPrecondition(condition: .onQueue(.main))
-        guard retryCount < maxRetries else { return }
+        guard !pollScheduled else { return }
+        pollTick()
+    }
+
+    /// One poll tick: if the policy still says to poll, send `.requeststate` and
+    /// schedule the next tick at the fixed cadence. When the policy says stop
+    /// (state applied, unreachable, or inactive), the loop simply ends.
+    private func pollTick() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard WatchStatePollPolicy.shouldPoll(
+            phase: viewModel.phase,
+            isReachable: wcSession?.isReachable ?? false,
+            isActive: isActive) else {
+            pollScheduled = false
+            return
+        }
+
+        sendRequestState()
+        pollScheduled = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + WatchStatePollPolicy.interval) { [weak self] in
+            self?.pollTick()
+        }
+    }
+
+    private func sendRequestState() {
+        dispatchPrecondition(condition: .onQueue(.main))
         guard let session = wcSession, session.isReachable else { return }
-
-        let attempt = retryCount
-        retryCount += 1
-        debugLog("WatchSession: requestState attempt \(attempt + 1)")
-
         let data = WatchCommandEncoder.encode(action: .requeststate)
         session.sendMessageData(data, replyHandler: { [weak self] reply in
-            self?.handleAck(reply, action: .requeststate)
-        }, errorHandler: { [weak self] error in
-            debugLog("WatchSession: requestState attempt \(attempt + 1) failed: \(error.localizedDescription)")
-            let delay = min(Double(attempt + 1) * 2.0, 10.0)
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-                self?.retryRequestState()
-            }
+            self?.handleStateReply(reply)
+        }, errorHandler: { error in
+            // No manual re-arm: the fixed-rate poll loop sends again on its own tick.
+            debugLog("WatchSession: requestState failed: \(error.localizedDescription)")
         })
+    }
+
+    /// Foreground/background from the scene phase. Deactivating stops the loop on
+    /// its next tick; reactivating re-kicks it.
+    func setActive(_ active: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.isActive = active
+            if active { self.kickPolling() }
+        }
     }
 
     func manualRetry() {
         DispatchQueue.main.async { [weak self] in
-            self?.retryCount = 0
+            guard let self else { return }
             // Drop any stale readiness verdict — back to "connecting" until the
             // phone answers.
-            self?.viewModel.readiness = .unknown
-            self?.retryRequestState()
+            self.viewModel.readiness = .unknown
+            self.kickPolling()
         }
     }
 
-    /// The phone acked a state request but never pushed state — ask again.
-    private func armStateArrivalCheck() {
-        dispatchPrecondition(condition: .onQueue(.main))
-        stateArrivalCheck?.cancel()
-        let work = DispatchWorkItem { [weak self] in
-            debugLog("WatchSession: state never arrived after Ok ack, re-requesting")
-            self?.retryRequestState()
+    /// The authoritative reply to `.requeststate`: an Ok carries the full snapshot
+    /// (apply it exactly like a live push, honoring the epoch guard); a
+    /// `.notinwatchmode` reply carries no state and falls through to the ack path.
+    private func handleStateReply(_ data: Data) {
+        if let snapshot = WatchStateReplyEncoder.decodeState(data) {
+            DispatchQueue.main.async { [weak self] in
+                self?.viewModel.update(from: snapshot)
+            }
+            return
         }
-        stateArrivalCheck = work
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0, execute: work)
+        handleAck(data, action: .requeststate)
     }
 
     // MARK: - Receiving State from iPhone
@@ -146,10 +177,7 @@ class WatchSessionDelegate: NSObject, ObservableObject, WCSessionDelegate {
             return
         }
         DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            self.retryCount = 0
-            self.stateArrivalCheck?.cancel()
-            self.viewModel.update(from: state)
+            self?.viewModel.update(from: state)
         }
     }
 
@@ -187,9 +215,7 @@ class WatchSessionDelegate: NSObject, ObservableObject, WCSessionDelegate {
         guard let stateData = applicationContext[WatchContextKeys.state] as? Data,
               let state = WatchStateEncoder.decode(stateData) else { return }
         DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            self.stateArrivalCheck?.cancel()
-            self.viewModel.update(from: state)
+            self?.viewModel.update(from: state)
         }
     }
 
@@ -205,9 +231,6 @@ class WatchSessionDelegate: NSObject, ObservableObject, WCSessionDelegate {
                 // answered from the Watch Remote screen; its state push follows.
                 if self.viewModel.readiness == .notinwatchmode {
                     self.viewModel.readiness = .unknown
-                }
-                if action == .requeststate {
-                    self.armStateArrivalCheck()
                 }
             case .notinwatchmode:
                 self.viewModel.notePhoneNotInWatchMode()
@@ -255,12 +278,6 @@ class WatchSessionDelegate: NSObject, ObservableObject, WCSessionDelegate {
         })
     }
 
-    func requestState() {
-        DispatchQueue.main.async { [weak self] in
-            self?.retryCount = 0
-            self?.retryRequestState()
-        }
-    }
     func setZoom(_ factor: Double) { sendCommand(action: .setzoom, zoomFactor: factor, critical: false) }
     func takePicture(timerSeconds: Int = 0) { sendCommand(action: .takepicture, timerSeconds: Int32(timerSeconds)) }
     func startRecording(timerSeconds: Int = 0) {

--- a/Shared/WatchSharedTypes.swift
+++ b/Shared/WatchSharedTypes.swift
@@ -100,11 +100,25 @@ struct WatchStateEncoder {
 
     static func encode(_ snapshot: WatchCameraStateSnapshot) -> Data {
         var fbb = FlatBufferBuilder()
+        let state = buildState(snapshot, into: &fbb)
+        let msg = RemoteShutter_WatchMessage.createWatchMessage(
+            &fbb,
+            type: .watchstatemsg,
+            stateOffset: state
+        )
+        fbb.finish(offset: msg)
+        return fbb.data
+    }
 
+    /// Appends a `WatchCameraState` table to an in-flight builder and returns its
+    /// offset. Shared by the plain state push and the `.requeststate` reply (which
+    /// carries the state alongside its ack in one `WatchMessage`).
+    static func buildState(_ snapshot: WatchCameraStateSnapshot,
+                           into fbb: inout FlatBufferBuilder) -> Offset {
         let lensVec = fbb.createVector(snapshot.availableLensTypes.map { $0.rawValue })
         let stopsVec = fbb.createVector(snapshot.zoomStops)
 
-        let state = RemoteShutter_WatchCameraState.createWatchCameraState(
+        return RemoteShutter_WatchCameraState.createWatchCameraState(
             &fbb,
             readiness: snapshot.readiness,
             event: snapshot.event,
@@ -122,13 +136,6 @@ struct WatchStateEncoder {
             wideAngleZoomFactor: snapshot.wideAngleZoomFactor,
             stateEpochMs: snapshot.stateEpochMs
         )
-        let msg = RemoteShutter_WatchMessage.createWatchMessage(
-            &fbb,
-            type: .watchstatemsg,
-            stateOffset: state
-        )
-        fbb.finish(offset: msg)
-        return fbb.data
     }
 
     static func decode(_ data: Data) -> WatchCameraStateSnapshot? {
@@ -138,7 +145,12 @@ struct WatchStateEncoder {
             return nil
         }
         guard msg.type == .watchstatemsg, let state = msg.state else { return nil }
+        return snapshot(from: state)
+    }
 
+    /// Maps a decoded `WatchCameraState` table into the plain-value snapshot.
+    /// Shared by the plain state decode and the `.requeststate` reply decode.
+    static func snapshot(from state: RemoteShutter_WatchCameraState) -> WatchCameraStateSnapshot {
         var lenses: [RemoteShutter_CameraLensType] = []
         for i in 0..<state.availableLensTypesCount {
             if let lens = state.availableLensTypes(at: i) {
@@ -168,6 +180,52 @@ struct WatchStateEncoder {
             wideAngleZoomFactor: state.wideAngleZoomFactor,
             stateEpochMs: state.stateEpochMs
         )
+    }
+}
+
+// MARK: - Authoritative reply to a `.requeststate` command (iPhone -> Watch)
+
+/// The reply to a Watch `.requeststate` command IS the camera state. The phone
+/// computes it inside the `SessionCoordinator` (whose FIFO inbox guarantees the
+/// answer reflects the machine's real state), so an Ok can never precede — and
+/// then lose — a separate state push. One `WatchMessage` carries both the ack and,
+/// when the phone is in a watch state, the full `WatchCameraState` snapshot.
+struct WatchStateReplyEncoder {
+
+    /// `snapshot == nil` (paired with a `.notinwatchmode` status) is the truthful
+    /// "phone isn't on the Watch Remote screen" reply — no state table is written.
+    static func encode(status: RemoteShutter_WatchAckStatus,
+                       snapshot: WatchCameraStateSnapshot?) -> Data {
+        var fbb = FlatBufferBuilder()
+        let stateOffset: Offset = snapshot.map { WatchStateEncoder.buildState($0, into: &fbb) } ?? Offset()
+        let ack = RemoteShutter_WatchCommandAck.createWatchCommandAck(
+            &fbb,
+            status: status,
+            action: .requeststate,
+            detailOffset: Offset()
+        )
+        let msg = RemoteShutter_WatchMessage.createWatchMessage(
+            &fbb,
+            type: .watchcommandackmsg,
+            stateOffset: stateOffset,
+            ackOffset: ack
+        )
+        fbb.finish(offset: msg)
+        return fbb.data
+    }
+
+    /// Extracts the camera snapshot a reply carried, or `nil` when it carried none
+    /// (a `.notinwatchmode` reply, or a bare ack from an older phone). Unlike
+    /// `WatchStateEncoder.decode`, it reads the `state` table regardless of the
+    /// message `type`, since a reply is typed as an ack message.
+    static func decodeState(_ data: Data) -> WatchCameraStateSnapshot? {
+        let bytes = [UInt8](data)
+        var buffer = ByteBuffer(bytes: bytes)
+        guard let msg: RemoteShutter_WatchMessage = try? getCheckedRoot(byteBuffer: &buffer),
+              let state = msg.state else {
+            return nil
+        }
+        return WatchStateEncoder.snapshot(from: state)
     }
 }
 
@@ -325,6 +383,27 @@ enum WatchConnectionPhase: Equatable {
         case .notinwatchmode: return .phoneNotInWatchMode
         case .unknown: return .connecting
         }
+    }
+}
+
+// MARK: - Watch State Poll Policy
+
+/// Decides whether the Watch should keep asking the phone for camera state.
+///
+/// Fixed-rate, infinite polling with no backoff and no give-up budget: while the
+/// UI is still trying to connect (`.connecting`), the phone is reachable, and the
+/// app is active, the Watch re-sends `.requeststate` at a steady cadence. It stops
+/// the instant any of those stops holding — a snapshot arrives (phase leaves
+/// `.connecting`), reachability drops, or the app deactivates. Pure so the decision
+/// is unit-testable without WCSession or a run loop.
+enum WatchStatePollPolicy {
+    /// Seconds between polls. No backoff — every tick is the same.
+    static let interval: TimeInterval = 2.0
+
+    static func shouldPoll(phase: WatchConnectionPhase,
+                           isReachable: Bool,
+                           isActive: Bool) -> Bool {
+        phase == .connecting && isReachable && isActive
     }
 }
 


### PR DESCRIPTION
## Problem

The Watch app could get permanently stuck on "Found your iPhone. Getting ready…". Root cause: the reply to a `requeststate` command and the actual camera-state snapshot traveled on two different channels, and the ack could lie:

- The phone acked `Ok` from a shallow check on the WCSession delegate queue ("is a controller bound?") before the state machine ever saw the request — which could then silently drop it (controller binds in `viewDidLoad`, but `BecomeWatchCamera` fires in `viewDidAppear`).
- The state push itself was skipped whenever *phone-side* `isReachable` was false; phone-side and watch-side reachability are asymmetric right as the watch app wakes.
- The watch retried at most 10 times, then went silent forever.

## Fix

1. **The reply IS the state.** `requeststate` routes through the `SessionCoordinator` actor (`UICmd.RequestWatchStateReply`), which answers the WCSession reply asynchronously: `Ok` + a full epoch-stamped snapshot in watch states, a truthful `notinwatchmode` otherwise. The watch applies state straight from the reply. No schema change — `WatchMessage` already carries both `ack` and `state` tables.
2. **Fixed-rate infinite polling.** `maxRetries`/3s-arm-check machinery deleted; a pure `WatchStatePollPolicy` re-sends `requeststate` every 2s while phase is `.connecting` + phone reachable + app active. Stops on state applied / unreachable / inactive; re-kicked by activation, reachability, scene-active, and manual Retry.
3. **Bind symmetry.** `bindToWatchManager()` moved to `viewWillAppear` so a cancelled interactive swipe-back can no longer orphan the controller binding.

## Verification

- Full suite under Thread Sanitizer: 467 tests, 0 failures
- New tests: coordinator reply path (Ok+ready snapshot in watch state, `notinwatchmode` outside, backgrounded readiness), `WatchStatePollPolicyTests`, combined ack+state round-trip
- iOS Simulator and Mac Catalyst builds succeed
- Not yet smoke-tested on a physical watch — recommended before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)