### PR TITLE
VP9 video streaming for camera→monitor live preview (iOS + Mac Catalyst)

### DIFF
--- a/RemoteCam/CameraRig.swift
+++ b/RemoteCam/CameraRig.swift
@@ -44,7 +44,6 @@ final class CameraRig: @unchecked Sendable {
         orientationProvider: { [weak self] in self?.orientation ?? .portrait },
         isWatchRemoteMode: { [weak self] in self?.isWatchRemoteMode ?? false },
         frameSink: { [frameSender] frame in frameSender.send(frame) },
-        peerVP9Enabled: { [frameSender] in frameSender.peerSupportsVP9.value },
         frameCreditAvailable: { [frameSender] in frameSender.hasCredit() },
         takePeerKeyframeRequest: { [frameSender] in frameSender.takeKeyframeRequest() })
 

--- a/RemoteCam/CameraRig.swift
+++ b/RemoteCam/CameraRig.swift
@@ -43,7 +43,10 @@ final class CameraRig: @unchecked Sendable {
         pipeline: pipeline,
         orientationProvider: { [weak self] in self?.orientation ?? .portrait },
         isWatchRemoteMode: { [weak self] in self?.isWatchRemoteMode ?? false },
-        frameSink: { [frameSender] frame in frameSender.send(frame) })
+        frameSink: { [frameSender] frame in frameSender.send(frame) },
+        peerVP9Enabled: { [frameSender] in frameSender.peerSupportsVP9.value },
+        frameCreditAvailable: { [frameSender] in frameSender.hasCredit() },
+        takePeerKeyframeRequest: { [frameSender] in frameSender.takeKeyframeRequest() })
 
     var isRecording: Bool { pipeline.isRecording }
 

--- a/RemoteCam/FlatBufferSchemas.fbs
+++ b/RemoteCam/FlatBufferSchemas.fbs
@@ -28,9 +28,14 @@ enum CommandAction : byte {
     TimerCountdown = 16,
     SyncMonitorSettings = 17,
     SetAspectRatio = 18,
-    SelectCameraDevice = 19    // never sent to peers that did not advertise
+    SelectCameraDevice = 19,   // never sent to peers that did not advertise
                                // camera_devices — old decoders read unknown
                                // actions as TakePicture (the field default)
+    RequestKeyframe = 20       // monitor -> camera: force the next VP9 preview
+                               // frame to be a keyframe (decoder desync
+                               // recovery). Only sent to a peer that has
+                               // already delivered a VP9 frame — old decoders
+                               // read unknown actions as TakePicture.
 }
 
 enum CameraPosition : byte {
@@ -136,6 +141,11 @@ table CommandParameters {
     aspect_ratio: AspectRatioEnum;
     // Appended fields only below this line (FlatBuffers schema evolution).
     device_unique_id: string;        // payload for SelectCameraDevice
+    // A monitor advertises here (on PeerBecameMonitor) that it can decode the
+    // VP9 preview stream. Absent/false on legacy monitors, so the camera keeps
+    // sending HEIC/JPEG stills to them. The camera only enables VP9 encoding
+    // when this is true AND its own runtime VP9 codec is available.
+    supports_vp9_preview: bool;
 }
 
 // MARK: - Command Structure

--- a/RemoteCam/FlatBufferSchemas.fbs
+++ b/RemoteCam/FlatBufferSchemas.fbs
@@ -141,11 +141,6 @@ table CommandParameters {
     aspect_ratio: AspectRatioEnum;
     // Appended fields only below this line (FlatBuffers schema evolution).
     device_unique_id: string;        // payload for SelectCameraDevice
-    // A monitor advertises here (on PeerBecameMonitor) that it can decode the
-    // VP9 preview stream. Absent/false on legacy monitors, so the camera keeps
-    // sending HEIC/JPEG stills to them. The camera only enables VP9 encoding
-    // when this is true AND its own runtime VP9 codec is available.
-    supports_vp9_preview: bool;
 }
 
 // MARK: - Command Structure

--- a/RemoteCam/FlatBufferSchemas_generated.swift
+++ b/RemoteCam/FlatBufferSchemas_generated.swift
@@ -28,8 +28,9 @@ public enum RemoteShutter_CommandAction: Int8, Enum, Verifiable {
   case syncmonitorsettings = 17
   case setaspectratio = 18
   case selectcameradevice = 19
+  case requestkeyframe = 20
 
-  public static var max: RemoteShutter_CommandAction { return .selectcameradevice }
+  public static var max: RemoteShutter_CommandAction { return .requestkeyframe }
   public static var min: RemoteShutter_CommandAction { return .takepicture }
 }
 
@@ -310,6 +311,7 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
     case recordingMode = 30
     case aspectRatio = 32
     case deviceUniqueId = 34
+    case supportsVp9Preview = 36
     var v: Int32 { Int32(self.rawValue) }
     var p: VOffset { self.rawValue }
   }
@@ -333,7 +335,8 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
   public var aspectRatio: RemoteShutter_AspectRatioEnum { let o = _accessor.offset(VTOFFSET.aspectRatio.v); return o == 0 ? .unknown : RemoteShutter_AspectRatioEnum(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .unknown }
   public var deviceUniqueId: String? { let o = _accessor.offset(VTOFFSET.deviceUniqueId.v); return o == 0 ? nil : _accessor.string(at: o) }
   public var deviceUniqueIdSegmentArray: [UInt8]? { return _accessor.getVector(at: VTOFFSET.deviceUniqueId.v) }
-  public static func startCommandParameters(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 16) }
+  public var supportsVp9Preview: Bool { let o = _accessor.offset(VTOFFSET.supportsVp9Preview.v); return o == 0 ? false : _accessor.readBuffer(of: Bool.self, at: o) }
+  public static func startCommandParameters(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 17) }
   public static func add(sendToRemote: Bool, _ fbb: inout FlatBufferBuilder) { fbb.add(element: sendToRemote, def: false,
    at: VTOFFSET.sendToRemote.p) }
   public static func add(zoomFactor: Double, _ fbb: inout FlatBufferBuilder) { fbb.add(element: zoomFactor, def: 0.0, at: VTOFFSET.zoomFactor.p) }
@@ -351,6 +354,8 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
   public static func add(recordingMode: RemoteShutter_RecordingModeEnum, _ fbb: inout FlatBufferBuilder) { fbb.add(element: recordingMode.rawValue, def: 0, at: VTOFFSET.recordingMode.p) }
   public static func add(aspectRatio: RemoteShutter_AspectRatioEnum, _ fbb: inout FlatBufferBuilder) { fbb.add(element: aspectRatio.rawValue, def: 0, at: VTOFFSET.aspectRatio.p) }
   public static func add(deviceUniqueId: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: deviceUniqueId, at: VTOFFSET.deviceUniqueId.p) }
+  public static func add(supportsVp9Preview: Bool, _ fbb: inout FlatBufferBuilder) { fbb.add(element: supportsVp9Preview, def: false,
+   at: VTOFFSET.supportsVp9Preview.p) }
   public static func endCommandParameters(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createCommandParameters(
     _ fbb: inout FlatBufferBuilder,
@@ -369,7 +374,8 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
     countdownValue: Int32 = 0,
     recordingMode: RemoteShutter_RecordingModeEnum = .unknown,
     aspectRatio: RemoteShutter_AspectRatioEnum = .unknown,
-    deviceUniqueIdOffset deviceUniqueId: Offset = Offset()
+    deviceUniqueIdOffset deviceUniqueId: Offset = Offset(),
+    supportsVp9Preview: Bool = false
   ) -> Offset {
     let __start = RemoteShutter_CommandParameters.startCommandParameters(&fbb)
     RemoteShutter_CommandParameters.add(sendToRemote: sendToRemote, &fbb)
@@ -388,6 +394,7 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
     RemoteShutter_CommandParameters.add(recordingMode: recordingMode, &fbb)
     RemoteShutter_CommandParameters.add(aspectRatio: aspectRatio, &fbb)
     RemoteShutter_CommandParameters.add(deviceUniqueId: deviceUniqueId, &fbb)
+    RemoteShutter_CommandParameters.add(supportsVp9Preview: supportsVp9Preview, &fbb)
     return RemoteShutter_CommandParameters.endCommandParameters(&fbb, start: __start)
   }
 
@@ -409,6 +416,7 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
     try _v.visit(field: VTOFFSET.recordingMode.p, fieldName: "recordingMode", required: false, type: RemoteShutter_RecordingModeEnum.self)
     try _v.visit(field: VTOFFSET.aspectRatio.p, fieldName: "aspectRatio", required: false, type: RemoteShutter_AspectRatioEnum.self)
     try _v.visit(field: VTOFFSET.deviceUniqueId.p, fieldName: "deviceUniqueId", required: false, type: ForwardOffset<String>.self)
+    try _v.visit(field: VTOFFSET.supportsVp9Preview.p, fieldName: "supportsVp9Preview", required: false, type: Bool.self)
     _v.finish()
   }
 }

--- a/RemoteCam/FlatBufferSchemas_generated.swift
+++ b/RemoteCam/FlatBufferSchemas_generated.swift
@@ -311,7 +311,6 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
     case recordingMode = 30
     case aspectRatio = 32
     case deviceUniqueId = 34
-    case supportsVp9Preview = 36
     var v: Int32 { Int32(self.rawValue) }
     var p: VOffset { self.rawValue }
   }
@@ -335,8 +334,7 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
   public var aspectRatio: RemoteShutter_AspectRatioEnum { let o = _accessor.offset(VTOFFSET.aspectRatio.v); return o == 0 ? .unknown : RemoteShutter_AspectRatioEnum(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .unknown }
   public var deviceUniqueId: String? { let o = _accessor.offset(VTOFFSET.deviceUniqueId.v); return o == 0 ? nil : _accessor.string(at: o) }
   public var deviceUniqueIdSegmentArray: [UInt8]? { return _accessor.getVector(at: VTOFFSET.deviceUniqueId.v) }
-  public var supportsVp9Preview: Bool { let o = _accessor.offset(VTOFFSET.supportsVp9Preview.v); return o == 0 ? false : _accessor.readBuffer(of: Bool.self, at: o) }
-  public static func startCommandParameters(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 17) }
+  public static func startCommandParameters(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 16) }
   public static func add(sendToRemote: Bool, _ fbb: inout FlatBufferBuilder) { fbb.add(element: sendToRemote, def: false,
    at: VTOFFSET.sendToRemote.p) }
   public static func add(zoomFactor: Double, _ fbb: inout FlatBufferBuilder) { fbb.add(element: zoomFactor, def: 0.0, at: VTOFFSET.zoomFactor.p) }
@@ -354,8 +352,6 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
   public static func add(recordingMode: RemoteShutter_RecordingModeEnum, _ fbb: inout FlatBufferBuilder) { fbb.add(element: recordingMode.rawValue, def: 0, at: VTOFFSET.recordingMode.p) }
   public static func add(aspectRatio: RemoteShutter_AspectRatioEnum, _ fbb: inout FlatBufferBuilder) { fbb.add(element: aspectRatio.rawValue, def: 0, at: VTOFFSET.aspectRatio.p) }
   public static func add(deviceUniqueId: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: deviceUniqueId, at: VTOFFSET.deviceUniqueId.p) }
-  public static func add(supportsVp9Preview: Bool, _ fbb: inout FlatBufferBuilder) { fbb.add(element: supportsVp9Preview, def: false,
-   at: VTOFFSET.supportsVp9Preview.p) }
   public static func endCommandParameters(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createCommandParameters(
     _ fbb: inout FlatBufferBuilder,
@@ -374,8 +370,7 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
     countdownValue: Int32 = 0,
     recordingMode: RemoteShutter_RecordingModeEnum = .unknown,
     aspectRatio: RemoteShutter_AspectRatioEnum = .unknown,
-    deviceUniqueIdOffset deviceUniqueId: Offset = Offset(),
-    supportsVp9Preview: Bool = false
+    deviceUniqueIdOffset deviceUniqueId: Offset = Offset()
   ) -> Offset {
     let __start = RemoteShutter_CommandParameters.startCommandParameters(&fbb)
     RemoteShutter_CommandParameters.add(sendToRemote: sendToRemote, &fbb)
@@ -394,7 +389,6 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
     RemoteShutter_CommandParameters.add(recordingMode: recordingMode, &fbb)
     RemoteShutter_CommandParameters.add(aspectRatio: aspectRatio, &fbb)
     RemoteShutter_CommandParameters.add(deviceUniqueId: deviceUniqueId, &fbb)
-    RemoteShutter_CommandParameters.add(supportsVp9Preview: supportsVp9Preview, &fbb)
     return RemoteShutter_CommandParameters.endCommandParameters(&fbb, start: __start)
   }
 
@@ -416,7 +410,6 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
     try _v.visit(field: VTOFFSET.recordingMode.p, fieldName: "recordingMode", required: false, type: RemoteShutter_RecordingModeEnum.self)
     try _v.visit(field: VTOFFSET.aspectRatio.p, fieldName: "aspectRatio", required: false, type: RemoteShutter_AspectRatioEnum.self)
     try _v.visit(field: VTOFFSET.deviceUniqueId.p, fieldName: "deviceUniqueId", required: false, type: ForwardOffset<String>.self)
-    try _v.visit(field: VTOFFSET.supportsVp9Preview.p, fieldName: "supportsVp9Preview", required: false, type: Bool.self)
     _v.finish()
   }
 }

--- a/RemoteCam/FrameCodecs.swift
+++ b/RemoteCam/FrameCodecs.swift
@@ -12,6 +12,40 @@
 import Foundation
 import CoreImage
 import CoreVideo
+import VideocallCodecs
+
+/// Whether the pure-Rust VP9 codec (VideocallCodecs) can actually run on this
+/// device. The framework ships arm64-only slices; on any architecture where the
+/// codec can't initialize this is false, both peers advertise no VP9 support,
+/// and the preview falls back to the HEIC/JPEG still path. Probed once by
+/// constructing a tiny encoder — capability advertisement must reflect what
+/// runs at runtime, not what happened to compile (CLAUDE.md Catalyst rule).
+enum VP9Support {
+    static let isAvailable: Bool = probe()
+
+    private static func probe() -> Bool {
+        do {
+            _ = try Vp9Encoder(width: 16, height: 16, fps: 30, bitrateKbps: 100,
+                               keyframeInterval: 30, minQuantizer: 40, maxQuantizer: 60, cpuUsed: 8)
+            return true
+        } catch {
+            StreamLog.encode.info("VP9 codec unavailable at runtime (\(error)) — preview falls back to stills")
+            return false
+        }
+    }
+}
+
+/// Pure negotiation decision for the peer (phone→phone-monitor) VP9 preview
+/// stream. Isolated and side-effect-free so the policy is unit-tested directly.
+enum VP9Negotiation {
+    /// The camera may encode/send VP9 preview frames only when the monitor
+    /// advertised VP9 decode support (in its `PeerBecameMonitor` capabilities)
+    /// AND this device's own VP9 encoder is available at runtime. Either false
+    /// keeps the stream on HEIC/JPEG stills, which every released peer decodes.
+    static func cameraShouldSendVP9(peerAdvertisedVP9: Bool, localVP9Available: Bool) -> Bool {
+        peerAdvertisedVP9 && localVP9Available
+    }
+}
 
 /// Outcome of one encode attempt. Stills only ever produce `.encoded` or
 /// `.failed`; a stateful video encoder (VP9) may also consume a frame without
@@ -38,6 +72,14 @@ struct EncodedFrame {
 protocol FrameEncoding: AnyObject {
     var codec: RemoteCmd.StreamCodec { get }
     func encode(pixelBuffer: CVPixelBuffer) -> FrameEncodeResult
+}
+
+/// A stateful video encoder whose delta frames depend on the previous frame
+/// (VP9). Adds keyframe control so a desynced receiver can be re-synced on
+/// demand. Capture-queue confined like `FrameEncoding`.
+protocol StreamVideoEncoding: FrameEncoding {
+    /// Force the next encoded frame to be a keyframe.
+    func forceKeyframe()
 }
 
 /// Encodes with the first working encoder in `chain`, permanently dropping

--- a/RemoteCam/FrameCodecs.swift
+++ b/RemoteCam/FrameCodecs.swift
@@ -35,15 +35,24 @@ enum VP9Support {
     }
 }
 
-/// Pure negotiation decision for the peer (phone→phone-monitor) VP9 preview
-/// stream. Isolated and side-effect-free so the policy is unit-tested directly.
-enum VP9Negotiation {
-    /// The camera may encode/send VP9 preview frames only when the monitor
-    /// advertised VP9 decode support (in its `PeerBecameMonitor` capabilities)
-    /// AND this device's own VP9 encoder is available at runtime. Either false
-    /// keeps the stream on HEIC/JPEG stills, which every released peer decodes.
-    static func cameraShouldSendVP9(peerAdvertisedVP9: Bool, localVP9Available: Bool) -> Bool {
-        peerAdvertisedVP9 && localVP9Available
+/// Compatibility policy for the peer (phone→phone-monitor) VP9 preview stream.
+/// The camera streams VP9 (never stills) to a monitor, so a monitor that is too
+/// old to decode VP9 must be told to update rather than shown a broken preview.
+/// The gate is the peer's `bundleVersion`, carried on `PeerBecameCamera`/
+/// `PeerBecameMonitor` — no per-connection capability handshake. Pure and
+/// side-effect-free so the policy is a single unit-tested decision.
+enum VP9PreviewCompatibility {
+    /// CFBundleVersion of the first release that can decode the peer VP9 preview
+    /// stream (this build's CURRENT_PROJECT_VERSION when the feature landed). A
+    /// monitor below this renders VP9 as garbage, so the camera routes it to the
+    /// existing "app out of date" flow instead.
+    static let minimumPeerBundleVersion = 100
+
+    /// Whether a peer at `bundleVersion` can decode the VP9 preview stream.
+    /// `bundleVersion <= 0` (unknown/legacy peer) also returns false, so one
+    /// check covers both the legacy and the too-old cases.
+    static func peerCanDecodeVP9Preview(bundleVersion: Int) -> Bool {
+        bundleVersion >= minimumPeerBundleVersion
     }
 }
 

--- a/RemoteCam/FrameSender.swift
+++ b/RemoteCam/FrameSender.swift
@@ -67,10 +67,12 @@ final class FrameSender {
     /// Binds the streaming target. Re-binding (each time the camera state is
     /// re-entered) resets the credit window, matching the old re-become.
     func setSession(peer: MCPeerID, transport: any MultipeerServiceProtocol) {
-        // A re-bind is a fresh connection: the new monitor re-advertises VP9
-        // (or doesn't), so drop the previous negotiation until it does.
-        peerSupportsVP9.value = false
-        keyframeRequestPending.value = false
+        // NOTE: this re-binds on every camera-state (re-)entry — e.g. after
+        // taking a photo — within the SAME connection, so it must NOT touch the
+        // VP9 negotiation. That is per-connection state (the monitor advertises
+        // it once, on PeerBecameMonitor) and is reset by the coordinator on
+        // popToScanning, not here; clearing it here would drop VP9 after the
+        // first photo and never recover.
         queue.async {
             if self.hasSession {
                 self.window.reset()

--- a/RemoteCam/FrameSender.swift
+++ b/RemoteCam/FrameSender.swift
@@ -47,11 +47,6 @@ final class FrameSender {
     /// queue. Updated inside `queue` on every window change.
     private let creditAvailableMirror = Locked<Bool>(true)
 
-    /// The connected monitor advertised VP9 decode support (negotiation).
-    /// Written by the coordinator when it decodes `PeerBecameMonitor`; read on
-    /// the capture queue by the frame streamer. Reset on each session re-bind.
-    let peerSupportsVP9 = Locked<Bool>(false)
-
     /// Set by the coordinator when the monitor requests a keyframe (decoder
     /// re-sync); read-and-cleared once by the frame streamer on the capture
     /// queue, which forces the next VP9 frame to be a keyframe.
@@ -67,12 +62,6 @@ final class FrameSender {
     /// Binds the streaming target. Re-binding (each time the camera state is
     /// re-entered) resets the credit window, matching the old re-become.
     func setSession(peer: MCPeerID, transport: any MultipeerServiceProtocol) {
-        // NOTE: this re-binds on every camera-state (re-)entry — e.g. after
-        // taking a photo — within the SAME connection, so it must NOT touch the
-        // VP9 negotiation. That is per-connection state (the monitor advertises
-        // it once, on PeerBecameMonitor) and is reset by the coordinator on
-        // popToScanning, not here; clearing it here would drop VP9 after the
-        // first photo and never recover.
         queue.async {
             if self.hasSession {
                 self.window.reset()

--- a/RemoteCam/FrameSender.swift
+++ b/RemoteCam/FrameSender.swift
@@ -42,6 +42,21 @@ final class FrameSender {
     private var transport: (any MultipeerServiceProtocol)?
     private var hasSession = false
 
+    /// Cross-queue mirror of `window.hasCredit`, so the capture-queue frame
+    /// streamer can gate VP9 encoding on back-pressure without hopping onto this
+    /// queue. Updated inside `queue` on every window change.
+    private let creditAvailableMirror = Locked<Bool>(true)
+
+    /// The connected monitor advertised VP9 decode support (negotiation).
+    /// Written by the coordinator when it decodes `PeerBecameMonitor`; read on
+    /// the capture queue by the frame streamer. Reset on each session re-bind.
+    let peerSupportsVP9 = Locked<Bool>(false)
+
+    /// Set by the coordinator when the monitor requests a keyframe (decoder
+    /// re-sync); read-and-cleared once by the frame streamer on the capture
+    /// queue, which forces the next VP9 frame to be a keyframe.
+    private let keyframeRequestPending = Locked<Bool>(false)
+
     /// Send failures pop the session to scanning (via the inbox).
     weak var coordinator: SessionCoordinator?
 
@@ -52,6 +67,10 @@ final class FrameSender {
     /// Binds the streaming target. Re-binding (each time the camera state is
     /// re-entered) resets the credit window, matching the old re-become.
     func setSession(peer: MCPeerID, transport: any MultipeerServiceProtocol) {
+        // A re-bind is a fresh connection: the new monitor re-advertises VP9
+        // (or doesn't), so drop the previous negotiation until it does.
+        peerSupportsVP9.value = false
+        keyframeRequestPending.value = false
         queue.async {
             if self.hasSession {
                 self.window.reset()
@@ -59,7 +78,23 @@ final class FrameSender {
             self.hasSession = true
             self.peer = peer
             self.transport = transport
+            self.refreshCreditMirror()
         }
+    }
+
+    /// Whether the credit window currently has room. Safe to call from any
+    /// thread (reads the lock-boxed mirror); the capture-queue frame streamer
+    /// uses it to gate VP9 encoding.
+    func hasCredit() -> Bool { creditAvailableMirror.value }
+
+    /// The monitor asked for a keyframe — arm it. Safe from any thread.
+    func requestKeyframe() { keyframeRequestPending.value = true }
+
+    /// Reads-and-clears a pending keyframe request (capture queue).
+    func takeKeyframeRequest() -> Bool {
+        var pending = false
+        keyframeRequestPending.mutate { pending = $0; $0 = false }
+        return pending
     }
 
     /// Offer a frame; sends if the credit window allows, drops otherwise.
@@ -67,18 +102,32 @@ final class FrameSender {
     func send(_ frame: RemoteCmd.SendFrame) {
         queue.async {
             guard self.hasSession, let peer = self.peer, let transport = self.transport else { return }
-            guard self.window.hasCredit else { return } // back-pressure: drop until a credit frees
-            // ALWAYS .unreliable for frames: a live viewfinder shows the
-            // newest frame or nothing — reliable mode queues and retransmits,
-            // turning any network hiccup into an ever-staler laggy stream.
-            // MC's datagram channel negotiates for ~10s after "Connected" and
-            // drops sends until ready; that is solved by warming the channel
-            // at session connect, never by switching frames to reliable.
-            if transport.send(frame, to: [peer], mode: .unreliable).isFailure() {
+            let isVideo = frame.codec == .vp9
+            if !isVideo {
+                // Stills are independent frames: drop under back-pressure so a
+                // network hiccup can't build a stale queue. VP9 is gated BEFORE
+                // encode (FrameStreamer only encodes with credit), so a VP9
+                // frame reaching here already has room — dropping it would
+                // corrupt the stateful stream, so it is never dropped here.
+                guard self.window.hasCredit else { return }
+            }
+            // Transport mode is codec-specific:
+            //  • Stills go .unreliable — a live viewfinder shows the newest
+            //    frame or nothing; reliable mode would queue+retransmit stale
+            //    frames, turning any hiccup into an ever-staler laggy stream.
+            //  • VP9 is a stateful stream: a dropped delta frame corrupts decode
+            //    until a keyframe, so it goes .reliable. The credit window
+            //    (applied at encode time) keeps the reliable queue from ever
+            //    building up, and a lost-ack watchdog frees it if acks stop.
+            // MC's datagram channel negotiates for ~10s after "Connected"; that
+            // is solved by warming the channel at peer connect.
+            let mode: MCSessionSendDataMode = isVideo ? .reliable : .unreliable
+            if transport.send(frame, to: [peer], mode: mode).isFailure() {
                 self.coordinator?.tell(FrameSendFailed())
                 return
             }
             self.window.acquire()
+            self.refreshCreditMirror()
             self.armAckWatchdog()
         }
     }
@@ -87,6 +136,7 @@ final class FrameSender {
     func receiveAck(_ request: RemoteCmd.RequestFrame) {
         queue.async {
             self.window.release()
+            self.refreshCreditMirror()
             // Keep guarding any frames still outstanding; stand the watchdog
             // down (by bumping the generation) once the window is empty.
             if self.window.isEmpty {
@@ -95,6 +145,13 @@ final class FrameSender {
                 self.armAckWatchdog()
             }
         }
+    }
+
+    /// Republishes the credit-available mirror. Call inside `queue` after every
+    /// window mutation.
+    private func refreshCreditMirror() {
+        dispatchPrecondition(condition: .onQueue(queue))
+        creditAvailableMirror.value = window.hasCredit
     }
 
     private func armAckWatchdog() {
@@ -112,6 +169,7 @@ final class FrameSender {
         StreamLog.transport.info(
             "ack watchdog fired after \(Self.ackTimeout, format: .fixed(precision: 1))s — resetting window")
         window.reset()
+        refreshCreditMirror()
     }
 
     // MARK: - Test support

--- a/RemoteCam/FrameStreamReceiver.swift
+++ b/RemoteCam/FrameStreamReceiver.swift
@@ -7,11 +7,16 @@
 //  stallTimeout -> onStall so the state machine re-requests one), recovers on
 //  foreground, and logs sequence gaps + per-second stream stats.
 //
-//  UIImage(data:) sniffs the container from magic bytes, so JPEG and HEIC
-//  frames (and frames from legacy peers) all decode through the same path.
+//  Stills (JPEG/HEIC, and frames from legacy peers) decode through
+//  UIImage(data:), which sniffs the container from magic bytes. VP9 is a
+//  stateful video stream, decoded by `PeerVP9PreviewDecoder`; an undecodable
+//  VP9 frame (joined mid-stream, transient loss) asks the camera for a keyframe
+//  via `onKeyframeNeeded`, rate-limited, so the decoder re-syncs.
 //
 
 import UIKit
+import Accelerate
+import VideocallCodecs
 
 final class FrameStreamReceiver {
 
@@ -21,6 +26,10 @@ final class FrameStreamReceiver {
     /// No frame has arrived for `config.stallTimeout`. Called on the decode
     /// queue, at most once per timeout while the stall persists.
     var onStall: (() -> Void)?
+    /// The VP9 decoder is desynced (undecodable frame) — the camera should send a
+    /// keyframe. Called on the decode queue, rate-limited to at most once per
+    /// `config.keyframeRequestInterval` while the desync persists.
+    var onKeyframeNeeded: (() -> Void)?
 
     private let config: StreamingConfig
     private let now: () -> TimeInterval
@@ -37,6 +46,9 @@ final class FrameStreamReceiver {
     private var statsFrames = 0
     private var statsBytes = 0
     private var statsWindowStart: TimeInterval = 0
+    private var lastKeyframeRequestAt: TimeInterval = 0
+    /// Stateful VP9 decoder, confined to `decodeQueue` (single-threaded).
+    private lazy var vp9Decoder = PeerVP9PreviewDecoder()
 
     init(config: StreamingConfig = .default,
          now: @escaping () -> TimeInterval = { Date().timeIntervalSinceReferenceDate },
@@ -96,12 +108,32 @@ final class FrameStreamReceiver {
         trackSequence(frame)
         trackStats(frame, at: time)
 
+        if frame.codec == .vp9 {
+            if let image = vp9Decoder.decode(frame.data) {
+                onImage?(image)
+            } else {
+                requestKeyframe(at: time)
+            }
+            return
+        }
+
+        // Stills (JPEG/HEIC/legacy): UIImage(data:) sniffs the container.
         guard let image = UIImage(data: frame.data) else {
             StreamLog.decode.error(
                 "undecodable frame seq=\(frame.sequenceNumber) codec=\(String(describing: frame.codec)) bytes=\(frame.data.count)")
             return
         }
         onImage?(image)
+    }
+
+    /// Asks the camera for a keyframe when the VP9 decoder can't decode, but no
+    /// more than once per `keyframeRequestInterval` — a burst of undecodable
+    /// delta frames all point at the same missing keyframe.
+    private func requestKeyframe(at time: TimeInterval) {
+        guard time - lastKeyframeRequestAt > config.keyframeRequestInterval else { return }
+        lastKeyframeRequestAt = time
+        StreamLog.decode.info("VP9 decoder desynced — requesting keyframe")
+        onKeyframeNeeded?()
     }
 
     /// Sequence gaps are expected occasionally (frames ride .unreliable); for
@@ -145,5 +177,124 @@ final class FrameStreamReceiver {
     private func resetStallClock() {
         lastFrameAt = now()
         lastStallReportAt = 0
+    }
+}
+
+/// Decodes the camera's VP9 preview stream with the pure-Rust `Vp9Decoder`
+/// (VideocallCodecs). The decoder is stateful — it needs a keyframe first, then
+/// inter frames in order — so it follows a drop-but-recover policy: an
+/// undecodable frame (monitor joined mid-stream, a delta frame was lost) returns
+/// nil, the caller asks the camera for a keyframe, and the stream re-syncs. A
+/// failure streak longer than one keyframe interval recreates the decoder to
+/// drain any poisoned state.
+///
+/// Not thread-safe: confined to the caller's serial queue (the
+/// `FrameStreamReceiver.decodeQueue`), mirroring the Watch's decoder.
+///
+/// Output frames are tightly-packed I420; vImage converts them to ARGB with the
+/// same full-range ITU-R 601 tables the camera used on the way in
+/// (`VP9FrameEncoder`).
+final class PeerVP9PreviewDecoder {
+
+    private var decoder = Vp9Decoder()
+    private var failureStreak = 0
+    private let maxFailureStreak: Int
+    private var announcedStreamLive = false
+    private var conversion = vImage_YpCbCrToARGB()
+    private let identityPermute: [UInt8] = [0, 1, 2, 3]
+
+    init(maxFailureStreak: Int = 30) {
+        self.maxFailureStreak = maxFailureStreak
+
+        // Full-range 8-bit YpCbCr — identical range to VP9FrameEncoder's output.
+        var pixelRange = vImage_YpCbCrPixelRange(
+            Yp_bias: 0, CbCr_bias: 128,
+            YpRangeMax: 255, CbCrRangeMax: 255,
+            YpMax: 255, YpMin: 1,
+            CbCrMax: 255, CbCrMin: 0)
+        vImageConvert_YpCbCrToARGB_GenerateConversion(
+            kvImage_YpCbCrToARGBMatrix_ITU_R_601_4,
+            &pixelRange,
+            &conversion,
+            kvImage420Yp8_Cb8_Cr8,
+            kvImageARGB8888,
+            vImage_Flags(kvImageNoFlags))
+    }
+
+    /// Decodes one VP9 frame on the caller's queue. Returns the rendered image,
+    /// or nil for a dropped/undecodable frame (the caller then requests a
+    /// keyframe). A long failure streak recreates the decoder.
+    func decode(_ frame: Data) -> UIImage? {
+        do {
+            let decoded = try decoder.decode(frame: frame)
+            failureStreak = 0
+            if !announcedStreamLive {
+                announcedStreamLive = true
+                StreamLog.decode.info("VP9 preview stream live (\(decoded.width)x\(decoded.height))")
+            }
+            return makeImage(from: decoded)
+        } catch {
+            failureStreak += 1
+            StreamLog.decode.debug("dropped undecodable VP9 frame (streak \(self.failureStreak)): \(error)")
+            if failureStreak >= maxFailureStreak {
+                StreamLog.decode.info("VP9 failure streak exceeded keyframe interval — resetting decoder")
+                decoder = Vp9Decoder()
+                failureStreak = 0
+                announcedStreamLive = false
+            }
+            return nil
+        }
+    }
+
+    /// Tightly-packed I420 -> ARGB8888 -> CGImage -> UIImage.
+    private func makeImage(from decoded: DecodedFrame) -> UIImage? {
+        let width = Int(decoded.width)
+        let height = Int(decoded.height)
+        let chromaWidth = (width + 1) / 2
+        let chromaHeight = (height + 1) / 2
+        let lumaBytes = width * height
+        let chromaBytes = chromaWidth * chromaHeight
+        guard width > 0, height > 0,
+              decoded.data.count >= lumaBytes + 2 * chromaBytes else { return nil }
+
+        var argb = Data(count: width * height * 4)
+        let converted: Bool = argb.withUnsafeMutableBytes { dstRaw in
+            guard let dstBase = dstRaw.baseAddress else { return false }
+            return decoded.data.withUnsafeBytes { srcRaw -> Bool in
+                guard let srcBase = srcRaw.baseAddress else { return false }
+                var yp = vImage_Buffer(data: UnsafeMutableRawPointer(mutating: srcBase),
+                                       height: vImagePixelCount(height),
+                                       width: vImagePixelCount(width),
+                                       rowBytes: width)
+                var cb = vImage_Buffer(data: UnsafeMutableRawPointer(mutating: srcBase + lumaBytes),
+                                       height: vImagePixelCount(chromaHeight),
+                                       width: vImagePixelCount(chromaWidth),
+                                       rowBytes: chromaWidth)
+                var cr = vImage_Buffer(data: UnsafeMutableRawPointer(mutating: srcBase + lumaBytes + chromaBytes),
+                                       height: vImagePixelCount(chromaHeight),
+                                       width: vImagePixelCount(chromaWidth),
+                                       rowBytes: chromaWidth)
+                var dst = vImage_Buffer(data: dstBase,
+                                        height: vImagePixelCount(height),
+                                        width: vImagePixelCount(width),
+                                        rowBytes: width * 4)
+                return vImageConvert_420Yp8_Cb8_Cr8ToARGB8888(
+                    &yp, &cb, &cr, &dst, &conversion, identityPermute, 255,
+                    vImage_Flags(kvImageNoFlags)) == kvImageNoError
+            }
+        }
+        guard converted else { return nil }
+
+        guard let provider = CGDataProvider(data: argb as CFData),
+              let cgImage = CGImage(
+                width: width, height: height,
+                bitsPerComponent: 8, bitsPerPixel: 32,
+                bytesPerRow: width * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.noneSkipFirst.rawValue),
+                provider: provider, decode: nil,
+                shouldInterpolate: false,
+                intent: .defaultIntent) else { return nil }
+        return UIImage(cgImage: cgImage)
     }
 }

--- a/RemoteCam/FrameStreamReceiver.swift
+++ b/RemoteCam/FrameStreamReceiver.swift
@@ -202,6 +202,13 @@ final class PeerVP9PreviewDecoder {
     private var announcedStreamLive = false
     private var conversion = vImage_YpCbCrToARGB()
     private let identityPermute: [UInt8] = [0, 1, 2, 3]
+    /// Reused ARGB destination for every frame — allocating a multi-MB buffer
+    /// per frame at stream rate churns memory. vImage converts into the
+    /// context's backing store in place; `makeImage()` snapshots it with
+    /// copy-on-write pages, so overwriting it for the next frame cannot corrupt
+    /// an image already handed out. Recreated only when the stream dimensions
+    /// change. Queue-confined like the decoder.
+    private var argbContext: CGContext?
 
     init(maxFailureStreak: Int = 30) {
         self.maxFailureStreak = maxFailureStreak
@@ -257,44 +264,40 @@ final class PeerVP9PreviewDecoder {
         guard width > 0, height > 0,
               decoded.data.count >= lumaBytes + 2 * chromaBytes else { return nil }
 
-        var argb = Data(count: width * height * 4)
-        let converted: Bool = argb.withUnsafeMutableBytes { dstRaw in
-            guard let dstBase = dstRaw.baseAddress else { return false }
-            return decoded.data.withUnsafeBytes { srcRaw -> Bool in
-                guard let srcBase = srcRaw.baseAddress else { return false }
-                var yp = vImage_Buffer(data: UnsafeMutableRawPointer(mutating: srcBase),
-                                       height: vImagePixelCount(height),
-                                       width: vImagePixelCount(width),
-                                       rowBytes: width)
-                var cb = vImage_Buffer(data: UnsafeMutableRawPointer(mutating: srcBase + lumaBytes),
-                                       height: vImagePixelCount(chromaHeight),
-                                       width: vImagePixelCount(chromaWidth),
-                                       rowBytes: chromaWidth)
-                var cr = vImage_Buffer(data: UnsafeMutableRawPointer(mutating: srcBase + lumaBytes + chromaBytes),
-                                       height: vImagePixelCount(chromaHeight),
-                                       width: vImagePixelCount(chromaWidth),
-                                       rowBytes: chromaWidth)
-                var dst = vImage_Buffer(data: dstBase,
-                                        height: vImagePixelCount(height),
-                                        width: vImagePixelCount(width),
-                                        rowBytes: width * 4)
-                return vImageConvert_420Yp8_Cb8_Cr8ToARGB8888(
-                    &yp, &cb, &cr, &dst, &conversion, identityPermute, 255,
-                    vImage_Flags(kvImageNoFlags)) == kvImageNoError
-            }
-        }
-        guard converted else { return nil }
-
-        guard let provider = CGDataProvider(data: argb as CFData),
-              let cgImage = CGImage(
+        if argbContext == nil || argbContext?.width != width || argbContext?.height != height {
+            argbContext = CGContext(
+                data: nil,                       // CG owns (and reuses) the buffer
                 width: width, height: height,
-                bitsPerComponent: 8, bitsPerPixel: 32,
-                bytesPerRow: width * 4,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,                  // CG picks an aligned stride
                 space: CGColorSpaceCreateDeviceRGB(),
-                bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.noneSkipFirst.rawValue),
-                provider: provider, decode: nil,
-                shouldInterpolate: false,
-                intent: .defaultIntent) else { return nil }
+                bitmapInfo: CGImageAlphaInfo.noneSkipFirst.rawValue)
+        }
+        guard let context = argbContext, let dstBase = context.data else { return nil }
+
+        let converted: Bool = decoded.data.withUnsafeBytes { srcRaw -> Bool in
+            guard let srcBase = srcRaw.baseAddress else { return false }
+            var yp = vImage_Buffer(data: UnsafeMutableRawPointer(mutating: srcBase),
+                                   height: vImagePixelCount(height),
+                                   width: vImagePixelCount(width),
+                                   rowBytes: width)
+            var cb = vImage_Buffer(data: UnsafeMutableRawPointer(mutating: srcBase + lumaBytes),
+                                   height: vImagePixelCount(chromaHeight),
+                                   width: vImagePixelCount(chromaWidth),
+                                   rowBytes: chromaWidth)
+            var cr = vImage_Buffer(data: UnsafeMutableRawPointer(mutating: srcBase + lumaBytes + chromaBytes),
+                                   height: vImagePixelCount(chromaHeight),
+                                   width: vImagePixelCount(chromaWidth),
+                                   rowBytes: chromaWidth)
+            var dst = vImage_Buffer(data: dstBase,
+                                    height: vImagePixelCount(height),
+                                    width: vImagePixelCount(width),
+                                    rowBytes: context.bytesPerRow)
+            return vImageConvert_420Yp8_Cb8_Cr8ToARGB8888(
+                &yp, &cb, &cr, &dst, &conversion, identityPermute, 255,
+                vImage_Flags(kvImageNoFlags)) == kvImageNoError
+        }
+        guard converted, let cgImage = context.makeImage() else { return nil }
         return UIImage(cgImage: cgImage)
     }
 }

--- a/RemoteCam/FrameStreamer.swift
+++ b/RemoteCam/FrameStreamer.swift
@@ -2,10 +2,20 @@
 //  FrameStreamer.swift
 //  RemoteShutter
 //
-//  Camera-side streaming pipeline: paces capture callbacks, encodes with the
-//  first working codec from StreamingConfig.preferredCodecs (permanent
-//  fallback on encoder failure), stamps sequence numbers, and hands the
-//  result to the FrameSender actor for ack-gated transport.
+//  Camera-side streaming pipeline: paces capture callbacks, encodes, stamps
+//  sequence numbers, and hands the result to the FrameSender actor for
+//  ack-gated transport.
+//
+//  Two codec strategies share one pacer:
+//   • Stills (HEIC with JPEG fallback) — independent frames, sent .unreliable.
+//     Encoded eagerly; the FrameSender drops under back-pressure because a lost
+//     still just means the viewfinder shows the previous one.
+//   • VP9 (a stateful video stream) — enabled only once the monitor advertises
+//     VP9 decode support. A dropped delta frame corrupts decode until a
+//     keyframe, so VP9 must NOT be encoded-then-dropped: it is encoded LAZILY,
+//     only when the credit window has room, and sent .reliable so the transport
+//     never drops it either. Skipping a frame before the encoder sees it keeps
+//     the stream continuous (the encoder just runs at a lower frame rate).
 //
 //  Confined to the capture queue: `handle` must only be called from the
 //  AVCaptureVideoDataOutput callback queue (same contract as
@@ -22,7 +32,7 @@ final class FrameStreamer {
     private let config: StreamingConfig
     private let send: Send
 
-    /// Remaining codec chain; first entry is the active encoder.
+    /// Remaining still-codec chain; first entry is the active still encoder.
     private var encoders: [FrameEncoding]
     private var frameCount = 0
     private var sequenceNumber: UInt32 = 0
@@ -30,20 +40,51 @@ final class FrameStreamer {
     /// Console without per-frame chatter. Capture-queue confined.
     private var lastAnnouncedCodec: RemoteCmd.StreamCodec?
 
-    /// - Parameter encoders: injectable for tests; nil builds the chain from
-    ///   `config.preferredCodecs`.
+    /// True once the monitor has advertised VP9 decode support (negotiation) —
+    /// read per frame on the capture queue.
+    private let vp9Enabled: () -> Bool
+    /// True when the credit window has room for another in-flight frame — the
+    /// lazy back-pressure gate for the stateful VP9 stream.
+    private let creditAvailable: () -> Bool
+    /// Reads-and-clears a pending keyframe request from the monitor (decoder
+    /// re-sync). Returns true at most once per request.
+    private let takeKeyframeRequest: () -> Bool
+    /// Builds the VP9 encoder on first use; nil when VP9 is unavailable at
+    /// runtime (excluded arch) or in tests that don't exercise VP9.
+    private let makeVP9Encoder: () -> StreamVideoEncoding?
+    private var vp9Encoder: StreamVideoEncoding?
+    /// Latched when the VP9 encoder fails on this hardware: never retried, the
+    /// stream stays on stills for the rest of the connection.
+    private var vp9Failed = false
+
+    /// - Parameters:
+    ///   - encoders: injectable still chain for tests; nil builds it from
+    ///     `config.preferredCodecs`.
+    ///   - vp9Enabled/creditAvailable/takeKeyframeRequest/makeVP9Encoder: the
+    ///     VP9 seams; their defaults disable VP9 entirely (stills only), which
+    ///     is the behavior the still-path tests pin.
     init(config: StreamingConfig = .default,
          encoders: [FrameEncoding]? = nil,
+         vp9Enabled: @escaping () -> Bool = { false },
+         creditAvailable: @escaping () -> Bool = { true },
+         takeKeyframeRequest: @escaping () -> Bool = { false },
+         makeVP9Encoder: @escaping () -> StreamVideoEncoding? = { nil },
          send: @escaping Send) {
         self.config = config
         self.send = send
         self.encoders = encoders ?? Self.makeEncoders(config: config)
+        self.vp9Enabled = vp9Enabled
+        self.creditAvailable = creditAvailable
+        self.takeKeyframeRequest = takeKeyframeRequest
+        self.makeVP9Encoder = makeVP9Encoder
     }
 
+    /// The active still-codec head (used by tests). The VP9 stream, when
+    /// enabled, is a separate path and not reflected here.
     var activeCodec: RemoteCmd.StreamCodec? { encoders.first?.codec }
 
-    /// Capture-queue only. Encodes and sends this frame unless pacing skips it
-    /// or every codec in the chain has failed.
+    /// Capture-queue only. Encodes and sends this frame unless pacing skips it,
+    /// back-pressure gates the VP9 stream, or every codec has failed.
     func handle(pixelBuffer: CVPixelBuffer,
                 position: AVCaptureDevice.Position,
                 orientation: UIInterfaceOrientation,
@@ -51,22 +92,73 @@ final class FrameStreamer {
         frameCount += 1
         guard frameCount % config.frameDivisor == 0 else { return }
 
-        guard let frame = encodeWithFallback(&encoders, pixelBuffer: pixelBuffer) else { return }
+        if useVP9 {
+            handleVP9(pixelBuffer: pixelBuffer, position: position, orientation: orientation, fps: fps)
+        } else {
+            handleStill(pixelBuffer: pixelBuffer, position: position, orientation: orientation, fps: fps)
+        }
+    }
 
-        if frame.codec != lastAnnouncedCodec {
-            lastAnnouncedCodec = frame.codec
-            StreamLog.encode.info("peer preview stream codec selected: \(String(describing: frame.codec))")
+    /// Whether the VP9 stream is active for this frame (negotiated, not failed,
+    /// encoder constructible). Builds the encoder lazily on first use.
+    private var useVP9: Bool {
+        guard vp9Enabled(), !vp9Failed else { return false }
+        if vp9Encoder == nil { vp9Encoder = makeVP9Encoder() }
+        return vp9Encoder != nil
+    }
+
+    private func handleVP9(pixelBuffer: CVPixelBuffer,
+                           position: AVCaptureDevice.Position,
+                           orientation: UIInterfaceOrientation,
+                           fps: Int) {
+        guard let vp9 = vp9Encoder else { return }
+        // Lazy back-pressure: skip BEFORE feeding the encoder when the window is
+        // full. Encoding then dropping would advance the encoder past a frame
+        // the monitor never receives, corrupting every delta frame until the
+        // next keyframe. Skipping keeps the encoded stream continuous.
+        guard creditAvailable() else { return }
+        if takeKeyframeRequest() { vp9.forceKeyframe() }
+
+        switch vp9.encode(pixelBuffer: pixelBuffer) {
+        case .encoded(let data):
+            emit(data: data, codec: .vp9, position: position, orientation: orientation, fps: fps)
+        case .skipped:
+            return // encoder buffered the frame: no wire frame, no credit consumed
+        case .failed:
+            vp9Failed = true
+            vp9Encoder = nil
+            StreamLog.encode.error("peer VP9 encoder failed — falling back to stills for this connection")
+            handleStill(pixelBuffer: pixelBuffer, position: position, orientation: orientation, fps: fps)
+        }
+    }
+
+    private func handleStill(pixelBuffer: CVPixelBuffer,
+                             position: AVCaptureDevice.Position,
+                             orientation: UIInterfaceOrientation,
+                             fps: Int) {
+        guard let frame = encodeWithFallback(&encoders, pixelBuffer: pixelBuffer) else { return }
+        emit(data: frame.data, codec: frame.codec, position: position, orientation: orientation, fps: fps)
+    }
+
+    private func emit(data: Data,
+                      codec: RemoteCmd.StreamCodec,
+                      position: AVCaptureDevice.Position,
+                      orientation: UIInterfaceOrientation,
+                      fps: Int) {
+        if codec != lastAnnouncedCodec {
+            lastAnnouncedCodec = codec
+            StreamLog.encode.info("peer preview stream codec selected: \(String(describing: codec))")
         }
         sequenceNumber &+= 1
         StreamLog.encode.debug(
-            "frame seq=\(self.sequenceNumber) codec=\(String(describing: frame.codec)) bytes=\(frame.data.count)")
+            "frame seq=\(self.sequenceNumber) codec=\(String(describing: codec)) bytes=\(data.count)")
         send(RemoteCmd.SendFrame(
-            data: frame.data,
+            data: data,
             sender: nil,
             fps: fps,
             camPosition: position,
             camOrientation: orientation,
-            codec: frame.codec,
+            codec: codec,
             sequenceNumber: sequenceNumber
         ))
     }
@@ -81,7 +173,7 @@ final class FrameStreamer {
             case .hevc:
                 return nil // video codec: follow-up PR (HEVCFrameEncoder)
             case .vp9:
-                return nil // Watch-preview codec today; peer-monitor VP9 is a follow-up
+                return nil // VP9 is the stateful video path, managed separately (not a still)
             }
         }
     }

--- a/RemoteCam/FrameStreamer.swift
+++ b/RemoteCam/FrameStreamer.swift
@@ -6,16 +6,22 @@
 //  sequence numbers, and hands the result to the FrameSender actor for
 //  ack-gated transport.
 //
-//  Two codec strategies share one pacer:
-//   • Stills (HEIC with JPEG fallback) — independent frames, sent .unreliable.
-//     Encoded eagerly; the FrameSender drops under back-pressure because a lost
-//     still just means the viewfinder shows the previous one.
-//   • VP9 (a stateful video stream) — enabled only once the monitor advertises
-//     VP9 decode support. A dropped delta frame corrupts decode until a
-//     keyframe, so VP9 must NOT be encoded-then-dropped: it is encoded LAZILY,
-//     only when the credit window has room, and sent .reliable so the transport
-//     never drops it either. Skipping a frame before the encoder sees it keeps
-//     the stream continuous (the encoder just runs at a lower frame rate).
+//  A new camera streams VP9 to every peer monitor (the monitor is version-gated
+//  by SessionCoordinator before any frame flows — an out-of-date monitor is sent
+//  to the update-required flow, not shown stills). Two codec strategies share
+//  one pacer:
+//   • VP9 (a stateful video stream) — the normal path. A dropped delta frame
+//     corrupts decode until a keyframe, so VP9 must NOT be encoded-then-dropped:
+//     it is encoded LAZILY, only when the credit window has room, and sent
+//     .reliable so the transport never drops it either. Skipping a frame before
+//     the encoder sees it keeps the stream continuous (the encoder just runs at
+//     a lower frame rate).
+//   • Stills (HEIC with JPEG fallback) — a DEV-ONLY fallback for the case where
+//     the VP9 codec is unavailable at runtime (`makeVP9Encoder` returns nil,
+//     e.g. a broken/absent VideocallCodecs slice). Every shipping arm64 config
+//     has VP9, so this path does not run in production; it only keeps the
+//     preview alive on an odd build. Stills are independent frames, sent
+//     .unreliable; the FrameSender drops them under back-pressure.
 //
 //  Confined to the capture queue: `handle` must only be called from the
 //  AVCaptureVideoDataOutput callback queue (same contract as
@@ -40,9 +46,6 @@ final class FrameStreamer {
     /// Console without per-frame chatter. Capture-queue confined.
     private var lastAnnouncedCodec: RemoteCmd.StreamCodec?
 
-    /// True once the monitor has advertised VP9 decode support (negotiation) —
-    /// read per frame on the capture queue.
-    private let vp9Enabled: () -> Bool
     /// True when the credit window has room for another in-flight frame — the
     /// lazy back-pressure gate for the stateful VP9 stream.
     private let creditAvailable: () -> Bool
@@ -60,12 +63,13 @@ final class FrameStreamer {
     /// - Parameters:
     ///   - encoders: injectable still chain for tests; nil builds it from
     ///     `config.preferredCodecs`.
-    ///   - vp9Enabled/creditAvailable/takeKeyframeRequest/makeVP9Encoder: the
-    ///     VP9 seams; their defaults disable VP9 entirely (stills only), which
-    ///     is the behavior the still-path tests pin.
+    ///   - makeVP9Encoder: builds the VP9 encoder on first use; its default
+    ///     (nil) disables VP9 (stills only), the behavior the still-path tests
+    ///     pin. Production passes a factory gated on `VP9Support.isAvailable`.
+    ///   - creditAvailable/takeKeyframeRequest: the VP9 back-pressure and
+    ///     keyframe seams.
     init(config: StreamingConfig = .default,
          encoders: [FrameEncoding]? = nil,
-         vp9Enabled: @escaping () -> Bool = { false },
          creditAvailable: @escaping () -> Bool = { true },
          takeKeyframeRequest: @escaping () -> Bool = { false },
          makeVP9Encoder: @escaping () -> StreamVideoEncoding? = { nil },
@@ -73,7 +77,6 @@ final class FrameStreamer {
         self.config = config
         self.send = send
         self.encoders = encoders ?? Self.makeEncoders(config: config)
-        self.vp9Enabled = vp9Enabled
         self.creditAvailable = creditAvailable
         self.takeKeyframeRequest = takeKeyframeRequest
         self.makeVP9Encoder = makeVP9Encoder
@@ -99,10 +102,12 @@ final class FrameStreamer {
         }
     }
 
-    /// Whether the VP9 stream is active for this frame (negotiated, not failed,
-    /// encoder constructible). Builds the encoder lazily on first use.
+    /// Whether the VP9 stream is active for this frame: not permanently failed
+    /// and the encoder is constructible (VP9 available at runtime). Built lazily
+    /// on first use; nil means VP9 is unavailable and the dev-only still
+    /// fallback runs instead.
     private var useVP9: Bool {
-        guard vp9Enabled(), !vp9Failed else { return false }
+        guard !vp9Failed else { return false }
         if vp9Encoder == nil { vp9Encoder = makeVP9Encoder() }
         return vp9Encoder != nil
     }

--- a/RemoteCam/FrameStreamingCoordinator.swift
+++ b/RemoteCam/FrameStreamingCoordinator.swift
@@ -30,6 +30,12 @@ final class FrameStreamingCoordinator: NSObject {
     private let orientationProvider: () -> UIInterfaceOrientation
     /// True when the Apple Watch is the remote (no MultipeerConnectivity peer).
     private let isWatchRemoteMode: () -> Bool
+    /// The connected monitor advertised VP9 decode support (negotiation gate).
+    private let peerVP9Enabled: () -> Bool
+    /// The credit window has room — the lazy back-pressure gate for VP9.
+    private let frameCreditAvailable: () -> Bool
+    /// Reads-and-clears a monitor keyframe request (decoder re-sync).
+    private let takePeerKeyframeRequest: () -> Bool
 
     /// Dedicated context for the tiny Apple Watch preview, kept off the recording
     /// pipeline's crop context to avoid cross-queue contention.
@@ -40,10 +46,23 @@ final class FrameStreamingCoordinator: NSObject {
         queue: engine.dataOutputQueue,
         maxInFlight: StreamingConfig.default.watchPreviewMaxInFlight,
         ackTimeout: StreamingConfig.default.watchPreviewAckTimeout)
-    /// Streams preview frames to the phone monitor: paces, encodes (HEIC with
-    /// JPEG fallback), and hands frames to the FrameSender actor.
+    /// Streams preview frames to the phone monitor: paces, encodes, and hands
+    /// frames to the FrameSender actor. Uses VP9 (a stateful video stream, lazy
+    /// + credit-gated) once the monitor advertises VP9 decode support and the
+    /// codec is available at runtime; otherwise HEIC with JPEG fallback.
     /// Runs on `videoDataOutputQueue`.
-    private lazy var frameStreamer = FrameStreamer(send: frameSink)
+    private lazy var frameStreamer = FrameStreamer(
+        vp9Enabled: peerVP9Enabled,
+        creditAvailable: frameCreditAvailable,
+        takeKeyframeRequest: takePeerKeyframeRequest,
+        makeVP9Encoder: {
+            // Runtime-gated: nil on any arch without the VP9 codec, so the
+            // stream stays on stills there.
+            guard VP9Support.isAvailable else { return nil }
+            let config = StreamingConfig.default
+            return VP9FrameEncoder(maxLongEdge: config.maxLongEdge, settings: config.peerVP9)
+        },
+        send: frameSink)
     /// Encoder chain for the Watch preview, built from
     /// `StreamingConfig.watchPreferredCodecs` (VP9 video stream first, with
     /// permanent HEIC-then-JPEG still fallback).
@@ -73,12 +92,18 @@ final class FrameStreamingCoordinator: NSObject {
          pipeline: RecordingPipeline,
          orientationProvider: @escaping () -> UIInterfaceOrientation,
          isWatchRemoteMode: @escaping () -> Bool,
-         frameSink: @escaping FrameStreamer.Send) {
+         frameSink: @escaping FrameStreamer.Send,
+         peerVP9Enabled: @escaping () -> Bool = { false },
+         frameCreditAvailable: @escaping () -> Bool = { true },
+         takePeerKeyframeRequest: @escaping () -> Bool = { false }) {
         self.engine = engine
         self.pipeline = pipeline
         self.orientationProvider = orientationProvider
         self.isWatchRemoteMode = isWatchRemoteMode
         self.frameSink = frameSink
+        self.peerVP9Enabled = peerVP9Enabled
+        self.frameCreditAvailable = frameCreditAvailable
+        self.takePeerKeyframeRequest = takePeerKeyframeRequest
     }
 
     /// The Watch acked the in-flight preview frame — let the streamer send the next.

--- a/RemoteCam/FrameStreamingCoordinator.swift
+++ b/RemoteCam/FrameStreamingCoordinator.swift
@@ -30,8 +30,6 @@ final class FrameStreamingCoordinator: NSObject {
     private let orientationProvider: () -> UIInterfaceOrientation
     /// True when the Apple Watch is the remote (no MultipeerConnectivity peer).
     private let isWatchRemoteMode: () -> Bool
-    /// The connected monitor advertised VP9 decode support (negotiation gate).
-    private let peerVP9Enabled: () -> Bool
     /// The credit window has room — the lazy back-pressure gate for VP9.
     private let frameCreditAvailable: () -> Bool
     /// Reads-and-clears a monitor keyframe request (decoder re-sync).
@@ -48,16 +46,17 @@ final class FrameStreamingCoordinator: NSObject {
         ackTimeout: StreamingConfig.default.watchPreviewAckTimeout)
     /// Streams preview frames to the phone monitor: paces, encodes, and hands
     /// frames to the FrameSender actor. Uses VP9 (a stateful video stream, lazy
-    /// + credit-gated) once the monitor advertises VP9 decode support and the
-    /// codec is available at runtime; otherwise HEIC with JPEG fallback.
+    /// + credit-gated) whenever the codec is available at runtime — the monitor
+    /// is version-gated by the coordinator, so it can always decode VP9. Falls
+    /// back to HEIC/JPEG stills only when VP9 is unavailable at runtime (dev-only).
     /// Runs on `videoDataOutputQueue`.
     private lazy var frameStreamer = FrameStreamer(
-        vp9Enabled: peerVP9Enabled,
         creditAvailable: frameCreditAvailable,
         takeKeyframeRequest: takePeerKeyframeRequest,
         makeVP9Encoder: {
             // Runtime-gated: nil on any arch without the VP9 codec, so the
-            // stream stays on stills there.
+            // stream falls back to stills there (dev-only; every shipping arm64
+            // config has VP9).
             guard VP9Support.isAvailable else { return nil }
             let config = StreamingConfig.default
             return VP9FrameEncoder(maxLongEdge: config.maxLongEdge, settings: config.peerVP9)
@@ -93,7 +92,6 @@ final class FrameStreamingCoordinator: NSObject {
          orientationProvider: @escaping () -> UIInterfaceOrientation,
          isWatchRemoteMode: @escaping () -> Bool,
          frameSink: @escaping FrameStreamer.Send,
-         peerVP9Enabled: @escaping () -> Bool = { false },
          frameCreditAvailable: @escaping () -> Bool = { true },
          takePeerKeyframeRequest: @escaping () -> Bool = { false }) {
         self.engine = engine
@@ -101,7 +99,6 @@ final class FrameStreamingCoordinator: NSObject {
         self.orientationProvider = orientationProvider
         self.isWatchRemoteMode = isWatchRemoteMode
         self.frameSink = frameSink
-        self.peerVP9Enabled = peerVP9Enabled
         self.frameCreditAvailable = frameCreditAvailable
         self.takePeerKeyframeRequest = takePeerKeyframeRequest
     }

--- a/RemoteCam/MonitorViewController.swift
+++ b/RemoteCam/MonitorViewController.swift
@@ -112,6 +112,11 @@ public class MonitorViewController: UIViewController {
                 session ! UICmd.StreamStalled()
             }
         }
+        frameStreamReceiver.onKeyframeNeeded = { [weak self] in
+            if let session = self?.session {
+                session ! UICmd.RequestVideoKeyframe()
+            }
+        }
         frameStreamReceiver.start()
         
         // Setup SwiftUI view instead of storyboard

--- a/RemoteCam/RemoteCmdFlatBuffers.swift
+++ b/RemoteCam/RemoteCmdFlatBuffers.swift
@@ -682,8 +682,7 @@ extension RemoteCmd.PeerBecameMonitor {
             &fbb,
             bundleVersion: Int32(bundleVersion),
             shortVersionOffset: shortVersionOffset,
-            platformOffset: platformOffset,
-            supportsVp9Preview: supportsVP9Preview
+            platformOffset: platformOffset
         )
         return buildCommand(&fbb, action: .peerbecamemonitor, parameters: params)
     }
@@ -1026,8 +1025,7 @@ extension RemoteCmd {
             return PeerBecameMonitor(
                 bundleVersion: Int(params?.bundleVersion ?? 0),
                 shortVersion: params?.shortVersion ?? "0",
-                platform: params?.platform ?? "0",
-                supportsVP9Preview: params?.supportsVp9Preview ?? false
+                platform: params?.platform ?? "0"
             )
 
         case .requestkeyframe:

--- a/RemoteCam/RemoteCmdFlatBuffers.swift
+++ b/RemoteCam/RemoteCmdFlatBuffers.swift
@@ -28,6 +28,7 @@ func serializeToFlatBuffer(_ msg: Message) -> Data? {
     case let m as RemoteCmd.TakePicResp: return m.toFlatBuffer()
     case let m as RemoteCmd.SendFrame: return m.toFlatBuffer()
     case let m as RemoteCmd.RequestFrame: return m.toFlatBuffer()
+    case let m as RemoteCmd.RequestKeyframe: return m.toFlatBuffer()
     case let m as RemoteCmd.SetZoom: return m.toFlatBuffer()
     case let m as RemoteCmd.SetZoomResp: return m.toFlatBuffer()
     case let m as RemoteCmd.CameraCapabilitiesResp: return m.toFlatBuffer()
@@ -681,9 +682,17 @@ extension RemoteCmd.PeerBecameMonitor {
             &fbb,
             bundleVersion: Int32(bundleVersion),
             shortVersionOffset: shortVersionOffset,
-            platformOffset: platformOffset
+            platformOffset: platformOffset,
+            supportsVp9Preview: supportsVP9Preview
         )
         return buildCommand(&fbb, action: .peerbecamemonitor, parameters: params)
+    }
+}
+
+extension RemoteCmd.RequestKeyframe {
+    func toFlatBuffer() -> Data {
+        var fbb = FlatBufferBuilder()
+        return buildCommand(&fbb, action: .requestkeyframe)
     }
 }
 
@@ -1017,8 +1026,12 @@ extension RemoteCmd {
             return PeerBecameMonitor(
                 bundleVersion: Int(params?.bundleVersion ?? 0),
                 shortVersion: params?.shortVersion ?? "0",
-                platform: params?.platform ?? "0"
+                platform: params?.platform ?? "0",
+                supportsVP9Preview: params?.supportsVp9Preview ?? false
             )
+
+        case .requestkeyframe:
+            return RequestKeyframe(sender: nil)
 
         case .toggleflash:
             return ToggleFlash()

--- a/RemoteCam/RemoteCmds.swift
+++ b/RemoteCam/RemoteCmds.swift
@@ -421,24 +421,16 @@ public class RemoteCmd: Message, @unchecked Sendable {
 
     public class PeerBecameMonitor: Message, @unchecked Sendable {
         let bundleVersion: Int, shortVersion: String, platform: String
-        /// This monitor advertises that it can decode the VP9 preview stream.
-        /// The camera peer only enables VP9 encoding when this is true (and its
-        /// own codec is available); false on legacy monitors keeps the camera
-        /// on the HEIC/JPEG still path. Absent on the wire decodes as false.
-        let supportsVP9Preview: Bool
 
-        class func createWithDefaults(supportsVP9Preview: Bool) -> PeerBecameMonitor {
+        class func createWithDefaults() -> PeerBecameMonitor {
             let (bundleVersion, shortVersion, platform) = getDeviceInfo()
-            return PeerBecameMonitor(bundleVersion: bundleVersion, shortVersion: shortVersion,
-                                     platform: platform, supportsVP9Preview: supportsVP9Preview)
+            return PeerBecameMonitor(bundleVersion: bundleVersion, shortVersion: shortVersion, platform: platform)
         }
 
-        public init(bundleVersion: Int, shortVersion: String, platform: String,
-                    supportsVP9Preview: Bool = false) {
+        public init(bundleVersion: Int, shortVersion: String, platform: String) {
             self.bundleVersion = bundleVersion
             self.shortVersion = shortVersion
             self.platform = platform
-            self.supportsVP9Preview = supportsVP9Preview
             super.init(sender: nil)
         }
     }

--- a/RemoteCam/RemoteCmds.swift
+++ b/RemoteCam/RemoteCmds.swift
@@ -181,6 +181,18 @@ public class RemoteCmd: Message, @unchecked Sendable {
         }
     }
 
+    /// Monitor -> camera: force the next VP9 preview frame to be a keyframe so a
+    /// desynced decoder (joined mid-stream, dropped a delta frame) can re-sync
+    /// without waiting for the camera's periodic keyframe. The monitor only
+    /// sends this after it has received at least one VP9 frame, which proves the
+    /// peer is a VP9-speaking build — old decoders read the unknown action as
+    /// TakePicture, so the gate mirrors the SelectCameraDevice precedent.
+    public class RequestKeyframe: Message, @unchecked Sendable {
+        public override init(sender: AnyObject?) {
+            super.init(sender: sender)
+        }
+    }
+
     public class OnFrame: Message, @unchecked Sendable {
         public let data: Data
         public let peerId: MCPeerID
@@ -409,16 +421,24 @@ public class RemoteCmd: Message, @unchecked Sendable {
 
     public class PeerBecameMonitor: Message, @unchecked Sendable {
         let bundleVersion: Int, shortVersion: String, platform: String
+        /// This monitor advertises that it can decode the VP9 preview stream.
+        /// The camera peer only enables VP9 encoding when this is true (and its
+        /// own codec is available); false on legacy monitors keeps the camera
+        /// on the HEIC/JPEG still path. Absent on the wire decodes as false.
+        let supportsVP9Preview: Bool
 
-        class func createWithDefaults() -> PeerBecameMonitor {
+        class func createWithDefaults(supportsVP9Preview: Bool) -> PeerBecameMonitor {
             let (bundleVersion, shortVersion, platform) = getDeviceInfo()
-            return PeerBecameMonitor(bundleVersion: bundleVersion, shortVersion: shortVersion, platform: platform)
+            return PeerBecameMonitor(bundleVersion: bundleVersion, shortVersion: shortVersion,
+                                     platform: platform, supportsVP9Preview: supportsVP9Preview)
         }
 
-        public init(bundleVersion: Int, shortVersion: String, platform: String) {
+        public init(bundleVersion: Int, shortVersion: String, platform: String,
+                    supportsVP9Preview: Bool = false) {
             self.bundleVersion = bundleVersion
             self.shortVersion = shortVersion
             self.platform = platform
+            self.supportsVP9Preview = supportsVP9Preview
             super.init(sender: nil)
         }
     }

--- a/RemoteCam/SessionCoordinator.swift
+++ b/RemoteCam/SessionCoordinator.swift
@@ -177,6 +177,27 @@ public actor SessionCoordinator {
     /// actions as TakePicture (the FlatBuffers field default).
     private var peerAdvertisedCameraDevices = false
 
+    /// Camera side: the connected monitor advertised VP9 decode support AND this
+    /// device can encode VP9 — the gate for streaming VP9 preview frames.
+    /// Mirrored onto the FrameSender so the capture-queue streamer reads it.
+    private var peerSupportsVP9Preview = false
+
+    /// Monitor side: at least one VP9 preview frame has arrived. Proves the
+    /// camera peer speaks VP9, which gates sending `RemoteCmd.RequestKeyframe`
+    /// (old decoders read that unknown action as TakePicture — same precedent as
+    /// SelectCameraDevice).
+    private var monitorReceivedVP9Frame = false
+
+    /// Whether this device's VP9 codec is available at runtime. Drives both the
+    /// monitor's advertised decode support and the camera's encode decision.
+    /// Overridable in tests to simulate a legacy (VP9-less) peer.
+    var localVP9Available = VP9Support.isAvailable
+    func setLocalVP9Available(_ available: Bool) { localVP9Available = available }
+
+    /// Test support.
+    func peerSupportsVP9PreviewForTesting() -> Bool { peerSupportsVP9Preview }
+    func monitorReceivedVP9FrameForTesting() -> Bool { monitorReceivedVP9Frame }
+
     /// Test support: the generation of the most recently armed timeout.
     func currentTimeoutGeneration() -> Int { timeoutGeneration }
 
@@ -377,6 +398,9 @@ public actor SessionCoordinator {
     /// restart discovery via `.scanning`'s entry behavior.
     func popToScanning() async {
         peerAdvertisedCameraDevices = false
+        peerSupportsVP9Preview = false
+        monitorReceivedVP9Frame = false
+        frameSender?.peerSupportsVP9.value = false
         switch state {
         case .scanning:
             // Already there — re-entering would restart discovery and reset
@@ -518,7 +542,8 @@ public actor SessionCoordinator {
         case let become as UICmd.BecomeMonitor:
             monitor = become.presenter
             await transition(to: .monitor(mode: become.mode == .Photo ? .photo : .video))
-            await sendOrGoToScanning(RemoteCmd.PeerBecameMonitor.createWithDefaults())
+            await sendOrGoToScanning(RemoteCmd.PeerBecameMonitor.createWithDefaults(
+                supportsVP9Preview: localVP9Available))
 
         case let became as RemoteCmd.PeerBecameCamera:
             if became.bundleVersion <= 0 {
@@ -531,6 +556,9 @@ public actor SessionCoordinator {
             if became.bundleVersion <= 0 {
                 await showIncompatibilityMessage()
             }
+            // Record VP9 negotiation even before this device becomes the camera,
+            // so it's in place if the role is picked after the monitor announces.
+            recordPeerVP9Support(became)
 
         case is Disconnect:
             await popToScanning()
@@ -555,8 +583,17 @@ public actor SessionCoordinator {
         }
 
         switch msg {
-        case is RemoteCmd.PeerBecameMonitor, is RemoteCmd.RequestCameraCapabilities:
+        case let became as RemoteCmd.PeerBecameMonitor:
+            recordPeerVP9Support(became)
             await attemptToSendCapabilities(attempt: 0)
+
+        case is RemoteCmd.RequestCameraCapabilities:
+            await attemptToSendCapabilities(attempt: 0)
+
+        case is RemoteCmd.RequestKeyframe:
+            // The monitor's VP9 decoder desynced — force the next preview frame
+            // to be a keyframe. Straight to the streamer; no state change.
+            frameSender?.requestKeyframe()
 
         case is RemoteCmd.RequestFrame, is RemoteCmd.SendFrame:
             break // frame plumbing is FrameSender's job
@@ -736,6 +773,37 @@ public actor SessionCoordinator {
         }
     }
 
+    /// Camera side: decide whether to stream VP9 to this monitor and publish the
+    /// decision onto the FrameSender, which the capture-queue streamer reads. VP9
+    /// is enabled only when the monitor advertised decode support AND this device
+    /// can encode it — otherwise the stream stays on stills that every peer
+    /// understands (the negotiation gate, mirroring SelectCameraDevice).
+    private func recordPeerVP9Support(_ became: RemoteCmd.PeerBecameMonitor) {
+        peerSupportsVP9Preview = VP9Negotiation.cameraShouldSendVP9(
+            peerAdvertisedVP9: became.supportsVP9Preview,
+            localVP9Available: localVP9Available)
+        frameSender?.peerSupportsVP9.value = peerSupportsVP9Preview
+        StreamLog.encode.info("peer VP9 preview \(self.peerSupportsVP9Preview ? "enabled" : "disabled") "
+            + "(monitor advertised: \(became.supportsVP9Preview), local codec: \(self.localVP9Available))")
+    }
+
+    /// Monitor side: latch that a VP9 frame arrived, which proves the camera
+    /// peer speaks VP9 and unlocks `RemoteCmd.RequestKeyframe`.
+    private func noteMonitorFrame(_ frame: RemoteCmd.OnFrame) {
+        if frame.codec == .vp9 { monitorReceivedVP9Frame = true }
+    }
+
+    /// Monitor side: ask the camera for a keyframe, but only once it has proven
+    /// itself a VP9-speaking peer (else the unknown action decodes as
+    /// TakePicture on an old camera). Sent `.reliable` so recovery isn't lost.
+    private func requestKeyframeIfVP9() {
+        guard monitorReceivedVP9Frame else {
+            debugLog("RequestKeyframe dropped: peer has not sent a VP9 frame")
+            return
+        }
+        sendMessage(RemoteCmd.RequestKeyframe(sender: nil), mode: .reliable)
+    }
+
     private func inCameraTakingPic(_ msg: Message, sendMediaToPeer: Bool, generation: Int) async {
         switch msg {
         case let timeout as UICmd.StateTimeout:
@@ -807,6 +875,11 @@ public actor SessionCoordinator {
                 await sendOrGoToScanning(RemoteCmd.SwitchLensResp(
                     lensType: nil, availableLenses: nil, currentZoom: nil, zoomRange: nil, error: error as NSError))
             }
+
+        case is RemoteCmd.RequestKeyframe:
+            // The preview stream keeps flowing while recording, so a desynced
+            // monitor decoder can ask for a keyframe here too.
+            frameSender?.requestKeyframe()
 
         case let ack as RemoteCmd.StartRecordingVideoAck:
             // The pipeline's success ack, carrying the recording start time for
@@ -1085,11 +1158,15 @@ public actor SessionCoordinator {
     private func inMonitor(_ msg: Message, mode: MonitorMode) async {
         switch msg {
         case let frame as RemoteCmd.OnFrame:
+            noteMonitorFrame(frame)
             monitor?.show(frame: frame)
             await requestFrame()
 
         case is UICmd.StreamStalled:
             await requestFrame()
+
+        case is UICmd.RequestVideoKeyframe:
+            requestKeyframeIfVP9()
 
         case is UICmd.UnbecomeMonitor:
             await transition(to: .connected)
@@ -1387,11 +1464,15 @@ public actor SessionCoordinator {
     private func inMonitorRecordingVideo(_ msg: Message) async {
         switch msg {
         case let frame as RemoteCmd.OnFrame:
+            noteMonitorFrame(frame)
             monitor?.show(frame: frame)
             await requestFrame()
 
         case is UICmd.StreamStalled:
             await requestFrame()
+
+        case is UICmd.RequestVideoKeyframe:
+            requestKeyframeIfVP9()
 
         case let ack as RemoteCmd.StartRecordingVideoAck:
             if let error = ack.error {

--- a/RemoteCam/SessionCoordinator.swift
+++ b/RemoteCam/SessionCoordinator.swift
@@ -783,8 +783,10 @@ public actor SessionCoordinator {
             peerAdvertisedVP9: became.supportsVP9Preview,
             localVP9Available: localVP9Available)
         frameSender?.peerSupportsVP9.value = peerSupportsVP9Preview
-        StreamLog.encode.info("peer VP9 preview \(self.peerSupportsVP9Preview ? "enabled" : "disabled") "
-            + "(monitor advertised: \(became.supportsVP9Preview), local codec: \(self.localVP9Available))")
+        StreamLog.encode.info("""
+            peer VP9 preview \(self.peerSupportsVP9Preview ? "enabled" : "disabled") \
+            (monitor advertised: \(became.supportsVP9Preview), local codec: \(self.localVP9Available))
+            """)
     }
 
     /// Monitor side: latch that a VP9 frame arrived, which proves the camera

--- a/RemoteCam/SessionCoordinator.swift
+++ b/RemoteCam/SessionCoordinator.swift
@@ -177,25 +177,13 @@ public actor SessionCoordinator {
     /// actions as TakePicture (the FlatBuffers field default).
     private var peerAdvertisedCameraDevices = false
 
-    /// Camera side: the connected monitor advertised VP9 decode support AND this
-    /// device can encode VP9 — the gate for streaming VP9 preview frames.
-    /// Mirrored onto the FrameSender so the capture-queue streamer reads it.
-    private var peerSupportsVP9Preview = false
-
     /// Monitor side: at least one VP9 preview frame has arrived. Proves the
     /// camera peer speaks VP9, which gates sending `RemoteCmd.RequestKeyframe`
     /// (old decoders read that unknown action as TakePicture — same precedent as
     /// SelectCameraDevice).
     private var monitorReceivedVP9Frame = false
 
-    /// Whether this device's VP9 codec is available at runtime. Drives both the
-    /// monitor's advertised decode support and the camera's encode decision.
-    /// Overridable in tests to simulate a legacy (VP9-less) peer.
-    var localVP9Available = VP9Support.isAvailable
-    func setLocalVP9Available(_ available: Bool) { localVP9Available = available }
-
     /// Test support.
-    func peerSupportsVP9PreviewForTesting() -> Bool { peerSupportsVP9Preview }
     func monitorReceivedVP9FrameForTesting() -> Bool { monitorReceivedVP9Frame }
 
     /// Test support: the generation of the most recently armed timeout.
@@ -398,9 +386,7 @@ public actor SessionCoordinator {
     /// restart discovery via `.scanning`'s entry behavior.
     func popToScanning() async {
         peerAdvertisedCameraDevices = false
-        peerSupportsVP9Preview = false
         monitorReceivedVP9Frame = false
-        frameSender?.peerSupportsVP9.value = false
         switch state {
         case .scanning:
             // Already there — re-entering would restart discovery and reset
@@ -542,23 +528,23 @@ public actor SessionCoordinator {
         case let become as UICmd.BecomeMonitor:
             monitor = become.presenter
             await transition(to: .monitor(mode: become.mode == .Photo ? .photo : .video))
-            await sendOrGoToScanning(RemoteCmd.PeerBecameMonitor.createWithDefaults(
-                supportsVP9Preview: localVP9Available))
+            await sendOrGoToScanning(RemoteCmd.PeerBecameMonitor.createWithDefaults())
 
         case let became as RemoteCmd.PeerBecameCamera:
             if became.bundleVersion <= 0 {
                 await showIncompatibilityMessage()
             }
+            // NOTE: a monitor never version-gates the camera — an old camera
+            // streams HEIC/JPEG stills, which this monitor still decodes. Only
+            // the `<= 0` incompatibility (unknown build) is reported, as before.
             // (Auto-role-follow forwarding was wired to an actor that was never
             // registered; the dead send is not reproduced.)
 
         case let became as RemoteCmd.PeerBecameMonitor:
-            if became.bundleVersion <= 0 {
-                await showIncompatibilityMessage()
-            }
-            // Record VP9 negotiation even before this device becomes the camera,
-            // so it's in place if the role is picked after the monitor announces.
-            recordPeerVP9Support(became)
+            // This device is the camera-to-be; a monitor too old to decode VP9
+            // must update rather than see a broken preview. One check covers
+            // both the legacy (`<= 0`) and too-old cases.
+            await enforceMonitorVP9Compatibility(became)
 
         case is Disconnect:
             await popToScanning()
@@ -584,7 +570,10 @@ public actor SessionCoordinator {
 
         switch msg {
         case let became as RemoteCmd.PeerBecameMonitor:
-            recordPeerVP9Support(became)
+            // Version-gate the monitor before answering: a monitor too old to
+            // decode VP9 is sent to the update-required flow (this pops out of
+            // the camera state), so we don't stream it an undecodable preview.
+            guard await enforceMonitorVP9Compatibility(became) else { break }
             await attemptToSendCapabilities(attempt: 0)
 
         case is RemoteCmd.RequestCameraCapabilities:
@@ -773,20 +762,24 @@ public actor SessionCoordinator {
         }
     }
 
-    /// Camera side: decide whether to stream VP9 to this monitor and publish the
-    /// decision onto the FrameSender, which the capture-queue streamer reads. VP9
-    /// is enabled only when the monitor advertised decode support AND this device
-    /// can encode it — otherwise the stream stays on stills that every peer
-    /// understands (the negotiation gate, mirroring SelectCameraDevice).
-    private func recordPeerVP9Support(_ became: RemoteCmd.PeerBecameMonitor) {
-        peerSupportsVP9Preview = VP9Negotiation.cameraShouldSendVP9(
-            peerAdvertisedVP9: became.supportsVP9Preview,
-            localVP9Available: localVP9Available)
-        frameSender?.peerSupportsVP9.value = peerSupportsVP9Preview
-        StreamLog.encode.info("""
-            peer VP9 preview \(self.peerSupportsVP9Preview ? "enabled" : "disabled") \
-            (monitor advertised: \(became.supportsVP9Preview), local codec: \(self.localVP9Available))
-            """)
+    /// Camera side: a new camera always streams VP9, so a monitor too old to
+    /// decode it must be told to update rather than shown a broken preview.
+    /// Routes an out-of-date (or unknown-build, `<= 0`) monitor to the existing
+    /// incompatibility flow — a single, version-in/verdict-out policy
+    /// (`VP9PreviewCompatibility.peerCanDecodeVP9Preview`). Returns true when the
+    /// monitor is compatible and the caller should continue, false when it
+    /// popped to scanning. No per-connection capability handshake.
+    @discardableResult
+    private func enforceMonitorVP9Compatibility(_ became: RemoteCmd.PeerBecameMonitor) async -> Bool {
+        guard VP9PreviewCompatibility.peerCanDecodeVP9Preview(bundleVersion: became.bundleVersion) else {
+            StreamLog.encode.info("""
+                monitor bundleVersion \(became.bundleVersion) < \
+                \(VP9PreviewCompatibility.minimumPeerBundleVersion) — too old for VP9 preview, requesting update
+                """)
+            await showIncompatibilityMessage()
+            return false
+        }
+        return true
     }
 
     /// Monitor side: latch that a VP9 frame arrived, which proves the camera

--- a/RemoteCam/StreamingConfig.swift
+++ b/RemoteCam/StreamingConfig.swift
@@ -12,12 +12,17 @@ import CoreGraphics
 
 struct StreamingConfig {
 
-    /// Still codecs to try for the phone-monitor (peer) stream, in order. The
-    /// streamer permanently falls back to the next entry when an encoder fails
-    /// (e.g. HEIC on hardware without an HEVC encoder). VP9 is NOT in this
-    /// chain: it is a stateful video stream managed separately (lazy,
-    /// credit-gated) and only enabled once the monitor advertises VP9 decode
-    /// support — an old peer would render VP9 bytes as a broken still.
+    /// Still codecs to try for the phone-monitor (peer) stream, in order. This
+    /// chain only holds self-contained encodings of a single frame, which makes
+    /// per-frame fallback meaningful: when an encoder fails (e.g. HEIC on
+    /// hardware without an HEVC encoder) the streamer re-encodes that same
+    /// frame with the next entry and steps down permanently. VP9 is NOT in
+    /// this chain because a VP9 frame is a delta against decoder state, not a
+    /// standalone picture — no still can substitute for it, and mixing codecs
+    /// mid-stream corrupts the decode. Whether to stream VP9 at all is a
+    /// per-session mode decision made elsewhere (runtime encoder availability
+    /// + the peer bundleVersion gate in VP9PreviewCompatibility); this chain
+    /// is what runs when that mode is off.
     var preferredCodecs: [RemoteCmd.StreamCodec] = [.heic, .jpeg]
 
     /// Long edge of the frame sent to the phone monitor. Replaces the old

--- a/RemoteCam/StreamingConfig.swift
+++ b/RemoteCam/StreamingConfig.swift
@@ -10,6 +10,34 @@
 import Foundation
 import CoreGraphics
 
+/// Tuning for one VP9 preview stream (videocall-codecs / libvpx realtime).
+/// Every field is deliberately defaulted-free: each stream (peer, Watch)
+/// states its full configuration at the construction site, so the two can be
+/// compared side by side in `StreamingConfig` instead of hiding behind
+/// struct defaults.
+struct VP9Settings {
+    /// Target bitrate of the encoded stream.
+    var bitrateKbps: UInt32
+    /// Encoder timebase fps. Actual delivery is paced by the transport's
+    /// ack/credit round-trips, not by this value.
+    var fps: UInt32
+    /// Forced keyframe every N frames. Bounds decoder re-sync latency after
+    /// any desync: a receiver recovers in at most N frames even if its
+    /// keyframe request is lost.
+    var keyframeInterval: UInt32
+    /// VP9 quantizer window, valid 0–63; lower = better quality, more bits.
+    /// The encoder moves inside [min, max] to hold `bitrateKbps`.
+    var minQuantizer: UInt32
+    var maxQuantizer: UInt32
+    /// libvpx speed preset (`VP9E_SET_CPUUSED`). Valid realtime range 0–9:
+    /// higher = faster encode at lower quality per bit, and values >= 5
+    /// additionally enable realtime-only shortcuts. Both previews encode on
+    /// the capture queue, so this stays near the fast end (7) — dropping it
+    /// below ~5 risks stalling frame delivery for quality the preview
+    /// doesn't need.
+    var cpuUsed: UInt8
+}
+
 struct StreamingConfig {
 
     /// Still codecs to try for the phone-monitor (peer) stream, in order. This
@@ -31,20 +59,25 @@ struct StreamingConfig {
     var heicQuality: CGFloat = 0.5
     var jpegQuality: CGFloat = 0.6
 
-    /// VP9 tuning for the phone-monitor (peer) preview: a bigger frame (960 px)
-    /// and a higher bitrate than the Watch's 320 px stream. The first frame of
-    /// every encoder session is a keyframe, and a forced keyframe every
-    /// `keyframeInterval` bounds decoder re-sync latency after any desync.
-    var peerVP9 = VP9Settings(bitrateKbps: 800, fps: 30, keyframeInterval: 30,
-                              minQuantizer: 32, maxQuantizer: 56, cpuUsed: 7)
+    /// VP9 tuning for the phone-monitor (peer) preview at 960 px
+    /// (`maxLongEdge`). Values tuned on hardware: 300 kbps holds a smooth
+    /// preview over MultipeerConnectivity without queue growth.
+    var peerVP9 = VP9Settings(
+        bitrateKbps: 300,
+        fps: 30,
+        keyframeInterval: 30,
+        minQuantizer: 40,
+        maxQuantizer: 56,
+        cpuUsed: 7)
 
-    /// Send every Nth capture callback (30fps capture / 2 = 15fps offered).
-    var frameDivisor: Int = 2
+    /// Offer every Nth capture callback to the peer stream (1 = full capture
+    /// rate; the credit window, not this divisor, is the real pacing).
+    var frameDivisor: Int = 1
 
     /// Phone-monitor (peer) frame back-pressure window: how many frames may be in
-    /// flight (sent, not yet acked via `RemoteCmd.RequestFrame`) at once. Mirrors the
-    /// Watch preview window — see `watchPreviewMaxInFlight`.
-    var peerMaxInFlight: Int = 5
+    /// flight (sent, not yet acked via `RemoteCmd.RequestFrame`) at once. Same
+    /// mechanism as `watchPreviewMaxInFlight`, tuned independently.
+    var peerMaxInFlight: Int = 10
     /// Re-opens the peer window if no `RequestFrame` ack arrives within this long, so a
     /// lost ack can't wedge the stream.
     var peerAckTimeout: TimeInterval = 1.0
@@ -60,24 +93,16 @@ struct StreamingConfig {
     var watchHEICQuality: CGFloat = 0.5
     var watchJPEGQuality: CGFloat = 0.55
 
-    /// VP9 tuning for the Watch preview stream (videocall-codecs). Inter frames
-    /// are a fraction of a still's size, so the same WCSession byte budget
-    /// carries more frames per second than HEIC/JPEG stills.
-    struct VP9Settings {
-        /// Target bitrate for the ~320 px preview.
-        var bitrateKbps: UInt32 = 300
-        /// Encoder timebase fps (WCSession round-trips pace actual delivery).
-        var fps: UInt32 = 30
-        /// Forced keyframe every N frames: after a dropped/undecodable frame the
-        /// Watch re-syncs in at most N frames (~3 s at ~10 fps delivered).
-        var keyframeInterval: UInt32 = 30
-        /// VP9 quantizer window (0-63, lower = better quality).
-        var minQuantizer: UInt32 = 40
-        var maxQuantizer: UInt32 = 60
-        /// Fastest speed preset — encode runs on the capture queue.
-        var cpuUsed: UInt8 = 7
-    }
-    var watchVP9 = VP9Settings()
+    /// VP9 tuning for the Watch preview stream at 320 px (`watchMaxLongEdge`).
+    /// Inter frames are a fraction of a still's size, so the same WCSession
+    /// byte budget carries more frames per second than HEIC/JPEG stills.
+    var watchVP9 = VP9Settings(
+        bitrateKbps: 300,
+        fps: 30,
+        keyframeInterval: 30,
+        minQuantizer: 40,
+        maxQuantizer: 60,
+        cpuUsed: 7)
 
     /// Apple Watch preview back-pressure window: how many frames may be in flight
     /// (sent, not yet acked) at once. >1 keeps the pipe full while acks travel back

--- a/RemoteCam/StreamingConfig.swift
+++ b/RemoteCam/StreamingConfig.swift
@@ -12,18 +12,26 @@ import CoreGraphics
 
 struct StreamingConfig {
 
-    /// Codecs to try for the phone-monitor (peer) stream, in order. The
-    /// streamer permanently falls back to the next entry when an encoder
-    /// fails (e.g. HEIC on hardware without an HEVC encoder). `.vp9` is
-    /// skipped on this path until the peer monitor grows a VP9 decode path
-    /// (follow-up PR) — old peers would render VP9 bytes as a broken still.
-    var preferredCodecs: [RemoteCmd.StreamCodec] = [.vp9, .heic, .jpeg]
+    /// Still codecs to try for the phone-monitor (peer) stream, in order. The
+    /// streamer permanently falls back to the next entry when an encoder fails
+    /// (e.g. HEIC on hardware without an HEVC encoder). VP9 is NOT in this
+    /// chain: it is a stateful video stream managed separately (lazy,
+    /// credit-gated) and only enabled once the monitor advertises VP9 decode
+    /// support — an old peer would render VP9 bytes as a broken still.
+    var preferredCodecs: [RemoteCmd.StreamCodec] = [.heic, .jpeg]
 
     /// Long edge of the frame sent to the phone monitor. Replaces the old
     /// full-sensor-resolution JPEG at quality 0.1.
     var maxLongEdge: CGFloat = 960
     var heicQuality: CGFloat = 0.5
     var jpegQuality: CGFloat = 0.6
+
+    /// VP9 tuning for the phone-monitor (peer) preview: a bigger frame (960 px)
+    /// and a higher bitrate than the Watch's 320 px stream. The first frame of
+    /// every encoder session is a keyframe, and a forced keyframe every
+    /// `keyframeInterval` bounds decoder re-sync latency after any desync.
+    var peerVP9 = VP9Settings(bitrateKbps: 800, fps: 30, keyframeInterval: 30,
+                              minQuantizer: 32, maxQuantizer: 56, cpuUsed: 7)
 
     /// Send every Nth capture callback (30fps capture / 2 = 15fps offered).
     var frameDivisor: Int = 2
@@ -81,6 +89,11 @@ struct StreamingConfig {
     var stallTimeout: TimeInterval = 2.0
     /// How often the stall watchdog wakes up to check.
     var stallCheckInterval: TimeInterval = 1.0
+
+    /// Monitor-side VP9 recovery: rate-limits `RemoteCmd.RequestKeyframe` while
+    /// the decoder is desynced (undecodable frames), so a burst of bad frames
+    /// asks for at most one keyframe per interval instead of flooding the wire.
+    var keyframeRequestInterval: TimeInterval = 0.5
 
     static let `default` = StreamingConfig()
 }

--- a/RemoteCam/StreamingConfig.swift
+++ b/RemoteCam/StreamingConfig.swift
@@ -39,7 +39,7 @@ struct StreamingConfig {
     /// Phone-monitor (peer) frame back-pressure window: how many frames may be in
     /// flight (sent, not yet acked via `RemoteCmd.RequestFrame`) at once. Mirrors the
     /// Watch preview window — see `watchPreviewMaxInFlight`.
-    var peerMaxInFlight: Int = 3
+    var peerMaxInFlight: Int = 5
     /// Re-opens the peer window if no `RequestFrame` ack arrives within this long, so a
     /// lost ack can't wedge the stream.
     var peerAckTimeout: TimeInterval = 1.0

--- a/RemoteCam/UICmds.swift
+++ b/RemoteCam/UICmds.swift
@@ -595,6 +595,17 @@ public class UICmd {
             super.init(sender: nil)
         }
     }
+
+    /// Raised by the monitor's frame receiver when the VP9 preview decoder
+    /// desyncs (an undecodable frame, or a sequence gap on the stateful stream).
+    /// The monitor state forwards it as `RemoteCmd.RequestKeyframe` — but only to
+    /// a peer that has already delivered a VP9 frame, since old peers decode the
+    /// unknown action as TakePicture.
+    public class RequestVideoKeyframe: Message, @unchecked Sendable {
+        public init() {
+            super.init(sender: nil)
+        }
+    }
 }
 
 

--- a/RemoteCam/VP9FrameEncoder.swift
+++ b/RemoteCam/VP9FrameEncoder.swift
@@ -23,7 +23,7 @@ import CoreVideo
 import Accelerate
 import VideocallCodecs
 
-final class VP9FrameEncoder: FrameEncoding {
+final class VP9FrameEncoder: StreamVideoEncoding {
 
     let codec: RemoteCmd.StreamCodec = .vp9
 
@@ -68,6 +68,17 @@ final class VP9FrameEncoder: FrameEncoding {
 
     deinit {
         scaledBGRA?.deallocate()
+    }
+
+    /// Forces the next encoded frame to be a keyframe by dropping the current
+    /// Rust session; `encode` remakes it on the next call and a fresh session's
+    /// first frame is always a keyframe. Capture-queue confined like `encode` —
+    /// answers a monitor's RequestKeyframe so a desynced decoder re-syncs
+    /// immediately instead of waiting for the periodic keyframe.
+    func forceKeyframe() {
+        session = nil
+        sessionWidth = 0
+        sessionHeight = 0
     }
 
     func encode(pixelBuffer: CVPixelBuffer) -> FrameEncodeResult {

--- a/RemoteCam/VP9FrameEncoder.swift
+++ b/RemoteCam/VP9FrameEncoder.swift
@@ -28,7 +28,7 @@ final class VP9FrameEncoder: StreamVideoEncoding {
     let codec: RemoteCmd.StreamCodec = .vp9
 
     private let maxLongEdge: Int
-    private let settings: StreamingConfig.VP9Settings
+    private let settings: VP9Settings
 
     /// BGRA -> planar YpCbCr conversion tables, generated once.
     private var conversion = vImage_ARGBToYpCbCr()
@@ -46,7 +46,7 @@ final class VP9FrameEncoder: StreamVideoEncoding {
     private var scaledBGRACapacity = 0
     private var i420 = Data()
 
-    init(maxLongEdge: CGFloat, settings: StreamingConfig.VP9Settings) {
+    init(maxLongEdge: CGFloat, settings: VP9Settings) {
         self.maxLongEdge = Int(maxLongEdge)
         self.settings = settings
 

--- a/RemoteCamTests/FrameStreamingTests.swift
+++ b/RemoteCamTests/FrameStreamingTests.swift
@@ -156,11 +156,12 @@ final class FrameStreamerTests: XCTestCase {
         XCTAssertEqual(sentFrames[0].data, Data([7]))
     }
 
-    // MARK: - VP9 path (negotiation + lazy credit gate + keyframe)
+    // MARK: - VP9 path (always-on when available + lazy credit gate + keyframe)
 
-    private func makeVP9Streamer(vp9: FakeVideoEncoder,
+    /// - Parameter vp9: the VP9 encoder the factory returns; nil models VP9
+    ///   unavailable at runtime (the dev-only stills fallback).
+    private func makeVP9Streamer(vp9: FakeVideoEncoder?,
                                  stillEncoders: [FrameEncoding],
-                                 vp9Enabled: @escaping () -> Bool,
                                  creditAvailable: @escaping () -> Bool = { true },
                                  takeKeyframeRequest: @escaping () -> Bool = { false }) -> FrameStreamer {
         var config = StreamingConfig.default
@@ -168,27 +169,28 @@ final class FrameStreamerTests: XCTestCase {
         return FrameStreamer(
             config: config,
             encoders: stillEncoders,
-            vp9Enabled: vp9Enabled,
             creditAvailable: creditAvailable,
             takeKeyframeRequest: takeKeyframeRequest,
             makeVP9Encoder: { vp9 }
         ) { [weak self] frame in self?.sentFrames.append(frame) }
     }
 
-    func testUsesStillsUntilVP9Negotiated() {
+    func testStreamsVP9WhenTheEncoderIsAvailable() {
         let vp9 = FakeVideoEncoder()
-        var enabled = false
-        let still = FakeEncoder(codec: .heic, result: Data([1]))
-        let streamer = makeVP9Streamer(vp9: vp9, stillEncoders: [still], vp9Enabled: { enabled })
+        let streamer = makeVP9Streamer(vp9: vp9, stillEncoders: [FakeEncoder(codec: .heic, result: Data([1]))])
 
         streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
-        XCTAssertEqual(vp9.encodeCount, 0, "no VP9 before the monitor advertises it")
+        XCTAssertEqual(vp9.encodeCount, 1, "a new camera streams VP9 to every (version-gated) monitor")
+        XCTAssertEqual(sentFrames.map(\.codec), [.vp9])
+    }
+
+    /// Dev-only fallback: when VP9 is unavailable at runtime (factory returns
+    /// nil) the stream stays alive on stills. No per-peer negotiation involved.
+    func testFallsBackToStillsWhenVP9Unavailable() {
+        let streamer = makeVP9Streamer(vp9: nil, stillEncoders: [FakeEncoder(codec: .heic, result: Data([1]))])
+
+        streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
         XCTAssertEqual(sentFrames.map(\.codec), [.heic])
-
-        enabled = true
-        streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
-        XCTAssertEqual(vp9.encodeCount, 1, "VP9 kicks in once negotiated")
-        XCTAssertEqual(sentFrames.map(\.codec), [.heic, .vp9])
     }
 
     /// The core stateful-stream invariant: with no credit, VP9 must NOT be
@@ -197,7 +199,7 @@ final class FrameStreamerTests: XCTestCase {
         let vp9 = FakeVideoEncoder()
         var credit = false
         let streamer = makeVP9Streamer(vp9: vp9, stillEncoders: [FakeEncoder(codec: .heic, result: Data([1]))],
-                                       vp9Enabled: { true }, creditAvailable: { credit })
+                                       creditAvailable: { credit })
 
         streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
         XCTAssertEqual(vp9.encodeCount, 0, "no credit: the encoder must not even see the frame")
@@ -211,8 +213,7 @@ final class FrameStreamerTests: XCTestCase {
 
     func testVP9SkippedResultSendsNothingButKeepsStream() {
         let vp9 = FakeVideoEncoder(result: .skipped)
-        let streamer = makeVP9Streamer(vp9: vp9, stillEncoders: [FakeEncoder(codec: .heic, result: Data([1]))],
-                                       vp9Enabled: { true })
+        let streamer = makeVP9Streamer(vp9: vp9, stillEncoders: [FakeEncoder(codec: .heic, result: Data([1]))])
         streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
         XCTAssertEqual(vp9.encodeCount, 1)
         XCTAssertTrue(sentFrames.isEmpty, "a buffered (skipped) frame produces no wire frame")
@@ -222,7 +223,6 @@ final class FrameStreamerTests: XCTestCase {
         let vp9 = FakeVideoEncoder()
         var pending = true
         let streamer = makeVP9Streamer(vp9: vp9, stillEncoders: [FakeEncoder(codec: .heic, result: Data([1]))],
-                                       vp9Enabled: { true },
                                        takeKeyframeRequest: { defer { pending = false }; return pending })
 
         streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
@@ -234,7 +234,7 @@ final class FrameStreamerTests: XCTestCase {
     func testVP9PermanentFailureLatchesToStills() {
         let vp9 = FakeVideoEncoder(result: .failed)
         let still = FakeEncoder(codec: .heic, result: Data([2]))
-        let streamer = makeVP9Streamer(vp9: vp9, stillEncoders: [still], vp9Enabled: { true })
+        let streamer = makeVP9Streamer(vp9: vp9, stillEncoders: [still])
 
         streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
         streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
@@ -288,6 +288,20 @@ final class FrameStreamReceiverTests: XCTestCase {
     func testDecodesFrameAndEmitsImage() {
         deliver(makeOnFrame(data: validJPEG, sequenceNumber: 1))
         XCTAssertEqual(images.count, 1)
+    }
+
+    /// Old-camera → new-monitor: an old camera streams stills tagged JPEG (a
+    /// legacy sender's absent codec also decodes as JPEG). The monitor must keep
+    /// rendering them through the still path even though it also has a VP9
+    /// decoder — no keyframe request is raised for a still.
+    func testLegacyStillFrameStillRendersOnNewMonitor() {
+        var keyframeRequests = 0
+        receiver.onKeyframeNeeded = { keyframeRequests += 1 }
+
+        deliver(makeOnFrame(data: validJPEG, codec: .jpeg, sequenceNumber: 1))
+
+        XCTAssertEqual(images.count, 1, "a JPEG still from an old camera must render")
+        XCTAssertEqual(keyframeRequests, 0, "stills never trigger a VP9 keyframe request")
     }
 
     func testUndecodableFrameEmitsNothingButCountsAsActivity() {

--- a/RemoteCamTests/FrameStreamingTests.swift
+++ b/RemoteCamTests/FrameStreamingTests.swift
@@ -38,6 +38,23 @@ func encodedData(_ result: FrameEncodeResult) -> Data? {
     return nil
 }
 
+/// Fake stateful VP9 encoder: records encode + forceKeyframe calls so the
+/// streamer's lazy-encode and keyframe wiring can be asserted without the codec.
+private final class FakeVideoEncoder: StreamVideoEncoding {
+    let codec: RemoteCmd.StreamCodec = .vp9
+    var result: FrameEncodeResult
+    private(set) var encodeCount = 0
+    private(set) var forceKeyframeCount = 0
+
+    init(result: FrameEncodeResult = .encoded(Data([9]))) { self.result = result }
+
+    func encode(pixelBuffer: CVPixelBuffer) -> FrameEncodeResult {
+        encodeCount += 1
+        return result
+    }
+    func forceKeyframe() { forceKeyframeCount += 1 }
+}
+
 // MARK: - Helpers
 
 func makePixelBuffer(width: Int = 64, height: Int = 32) -> CVPixelBuffer {
@@ -137,6 +154,93 @@ final class FrameStreamerTests: XCTestCase {
         XCTAssertEqual(sentFrames[0].camOrientation, .landscapeRight)
         XCTAssertEqual(sentFrames[0].fps, 24)
         XCTAssertEqual(sentFrames[0].data, Data([7]))
+    }
+
+    // MARK: - VP9 path (negotiation + lazy credit gate + keyframe)
+
+    private func makeVP9Streamer(vp9: FakeVideoEncoder,
+                                 stillEncoders: [FrameEncoding],
+                                 vp9Enabled: @escaping () -> Bool,
+                                 creditAvailable: @escaping () -> Bool = { true },
+                                 takeKeyframeRequest: @escaping () -> Bool = { false }) -> FrameStreamer {
+        var config = StreamingConfig.default
+        config.frameDivisor = 1
+        return FrameStreamer(
+            config: config,
+            encoders: stillEncoders,
+            vp9Enabled: vp9Enabled,
+            creditAvailable: creditAvailable,
+            takeKeyframeRequest: takeKeyframeRequest,
+            makeVP9Encoder: { vp9 }
+        ) { [weak self] frame in self?.sentFrames.append(frame) }
+    }
+
+    func testUsesStillsUntilVP9Negotiated() {
+        let vp9 = FakeVideoEncoder()
+        var enabled = false
+        let still = FakeEncoder(codec: .heic, result: Data([1]))
+        let streamer = makeVP9Streamer(vp9: vp9, stillEncoders: [still], vp9Enabled: { enabled })
+
+        streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
+        XCTAssertEqual(vp9.encodeCount, 0, "no VP9 before the monitor advertises it")
+        XCTAssertEqual(sentFrames.map(\.codec), [.heic])
+
+        enabled = true
+        streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
+        XCTAssertEqual(vp9.encodeCount, 1, "VP9 kicks in once negotiated")
+        XCTAssertEqual(sentFrames.map(\.codec), [.heic, .vp9])
+    }
+
+    /// The core stateful-stream invariant: with no credit, VP9 must NOT be
+    /// encoded (encoding-then-dropping would corrupt every later delta frame).
+    func testVP9IsNotEncodedWithoutCredit() {
+        let vp9 = FakeVideoEncoder()
+        var credit = false
+        let streamer = makeVP9Streamer(vp9: vp9, stillEncoders: [FakeEncoder(codec: .heic, result: Data([1]))],
+                                       vp9Enabled: { true }, creditAvailable: { credit })
+
+        streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
+        XCTAssertEqual(vp9.encodeCount, 0, "no credit: the encoder must not even see the frame")
+        XCTAssertTrue(sentFrames.isEmpty, "no frame goes out under back-pressure")
+
+        credit = true
+        streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
+        XCTAssertEqual(vp9.encodeCount, 1)
+        XCTAssertEqual(sentFrames.map(\.codec), [.vp9])
+    }
+
+    func testVP9SkippedResultSendsNothingButKeepsStream() {
+        let vp9 = FakeVideoEncoder(result: .skipped)
+        let streamer = makeVP9Streamer(vp9: vp9, stillEncoders: [FakeEncoder(codec: .heic, result: Data([1]))],
+                                       vp9Enabled: { true })
+        streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
+        XCTAssertEqual(vp9.encodeCount, 1)
+        XCTAssertTrue(sentFrames.isEmpty, "a buffered (skipped) frame produces no wire frame")
+    }
+
+    func testKeyframeRequestForcesKeyframeBeforeEncode() {
+        let vp9 = FakeVideoEncoder()
+        var pending = true
+        let streamer = makeVP9Streamer(vp9: vp9, stillEncoders: [FakeEncoder(codec: .heic, result: Data([1]))],
+                                       vp9Enabled: { true },
+                                       takeKeyframeRequest: { defer { pending = false }; return pending })
+
+        streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
+        XCTAssertEqual(vp9.forceKeyframeCount, 1, "a pending request forces a keyframe")
+        streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
+        XCTAssertEqual(vp9.forceKeyframeCount, 1, "consumed once — not re-forced every frame")
+    }
+
+    func testVP9PermanentFailureLatchesToStills() {
+        let vp9 = FakeVideoEncoder(result: .failed)
+        let still = FakeEncoder(codec: .heic, result: Data([2]))
+        let streamer = makeVP9Streamer(vp9: vp9, stillEncoders: [still], vp9Enabled: { true })
+
+        streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
+        streamer.handle(pixelBuffer: makePixelBuffer(), position: .back, orientation: .portrait, fps: 30)
+
+        XCTAssertEqual(vp9.encodeCount, 1, "a failed VP9 encoder is latched off, never retried")
+        XCTAssertEqual(sentFrames.map(\.codec), [.heic, .heic], "the stream falls back to stills")
     }
 }
 

--- a/RemoteCamTests/LoopbackSessionTests.swift
+++ b/RemoteCamTests/LoopbackSessionTests.swift
@@ -578,93 +578,64 @@ class LoopbackSessionTests: XCTestCase {
         XCTAssertEqual(monitorState, .monitor)
     }
 
-    // MARK: - VP9 preview negotiation
+    // MARK: - VP9 preview version gate
 
-    /// A VP9-capable monitor advertises decode support on PeerBecameMonitor; the
-    /// camera peer (also VP9-capable) enables VP9 streaming for the connection.
-    func testVP9CapableMonitorEnablesVP9OnCameraPeer() async {
+    /// Puts the camera-side session into `.camera` with a fake capture device.
+    private func enterCameraState() async -> LoopbackFakeCamera {
         await connectBothSessions()
-        await cameraCoordinator.setLocalVP9Available(true)
-        await monitorCoordinator.setLocalVP9Available(true)
-
         let fakeCamera = LoopbackFakeCamera()
         fakeCamera.coordinator = cameraCoordinator
         cameraCoordinator.tell(UICmd.BecomeCamera(sender: nil, ctrl: fakeCamera))
         await drainBothSessions()
-        await becomeMonitor(mode: .Photo)   // sends PeerBecameMonitor advertising VP9
-
-        let enabled = await cameraCoordinator.peerSupportsVP9PreviewForTesting()
-        XCTAssertTrue(enabled, "camera must enable VP9 for a VP9-capable monitor")
-        // The advertisement really crossed the wire (not a local shortcut).
-        XCTAssertTrue(monitorTransport.sentMessages.contains {
-            ($0 as? RemoteCmd.PeerBecameMonitor)?.supportsVP9Preview == true
-        })
+        cameraTransport.sentMessages.removeAll()
+        return fakeCamera
     }
 
-    /// A legacy monitor (no VP9 decode) advertises false; the camera must keep
-    /// streaming stills — sending VP9 bytes would render as a broken still.
-    func testLegacyMonitorKeepsCameraOnStills() async {
-        await connectBothSessions()
-        await cameraCoordinator.setLocalVP9Available(true)
-        await monitorCoordinator.setLocalVP9Available(false)   // legacy-shaped monitor
+    /// A version-qualified monitor (bundleVersion >= threshold) is answered
+    /// normally: the camera stays in `.camera` and broadcasts capabilities, then
+    /// streams VP9 to it. No capability handshake, no incompatibility.
+    func testQualifiedMonitorIsAcceptedAndAnswered() async {
+        let threshold = VP9PreviewCompatibility.minimumPeerBundleVersion
+        _ = await enterCameraState()
 
-        let fakeCamera = LoopbackFakeCamera()
-        fakeCamera.coordinator = cameraCoordinator
-        cameraCoordinator.tell(UICmd.BecomeCamera(sender: nil, ctrl: fakeCamera))
+        cameraCoordinator.tell(RemoteCmd.PeerBecameMonitor(
+            bundleVersion: threshold, shortVersion: "7.0", platform: "iPhone"))
         await drainBothSessions()
-        await becomeMonitor(mode: .Photo)
 
-        let enabled = await cameraCoordinator.peerSupportsVP9PreviewForTesting()
-        XCTAssertFalse(enabled, "camera must not send VP9 to a monitor that can't decode it")
-        XCTAssertTrue(monitorTransport.sentMessages.contains {
-            ($0 as? RemoteCmd.PeerBecameMonitor)?.supportsVP9Preview == false
-        })
-    }
-
-    /// Even a VP9-capable monitor gets stills if THIS camera can't encode VP9.
-    func testCameraWithoutVP9StreamsStillsToVP9Monitor() async {
-        await connectBothSessions()
-        await cameraCoordinator.setLocalVP9Available(false)   // camera can't encode
-        await monitorCoordinator.setLocalVP9Available(true)
-
-        let fakeCamera = LoopbackFakeCamera()
-        fakeCamera.coordinator = cameraCoordinator
-        cameraCoordinator.tell(UICmd.BecomeCamera(sender: nil, ctrl: fakeCamera))
-        await drainBothSessions()
-        await becomeMonitor(mode: .Photo)
-
-        let enabled = await cameraCoordinator.peerSupportsVP9PreviewForTesting()
-        XCTAssertFalse(enabled, "no VP9 without a local encoder, even to a VP9 monitor")
-    }
-
-    /// VP9 negotiation is per-connection, not per-state-entry: it must survive a
-    /// photo capture (which re-enters .camera and re-binds the FrameSender). A
-    /// regression guard — clearing it on re-bind would kill VP9 after one photo.
-    func testVP9SupportSurvivesPhotoCapture() async {
-        await connectBothSessions()
-        await cameraCoordinator.setLocalVP9Available(true)
-        await monitorCoordinator.setLocalVP9Available(true)
-
-        let fakeCamera = LoopbackFakeCamera()
-        fakeCamera.coordinator = cameraCoordinator
-        let cameraFrameSender = FrameSender(coordinator: cameraCoordinator)
-        cameraCoordinator.setFrameSender(cameraFrameSender)
-        cameraCoordinator.tell(UICmd.BecomeCamera(sender: nil, ctrl: fakeCamera))
-        await drainBothSessions()
-        await becomeMonitor(mode: .Photo)
-
-        XCTAssertTrue(cameraFrameSender.peerSupportsVP9.value, "VP9 enabled after negotiation")
-
-        // Take a photo — the camera walks .camera -> takingPic -> back to .camera.
-        monitorCoordinator.tell(UICmd.TakePicture(sender: nil, sendMediaToRemote: false))
-        await drainBothSessions()
         let cameraState = await cameraCoordinator.currentStateName()
-        XCTAssertEqual(cameraState, .camera)
+        XCTAssertEqual(cameraState, .camera, "a qualified monitor keeps the camera streaming")
+        XCTAssertTrue(cameraTransport.sentMessages.contains { $0 is RemoteCmd.CameraCapabilitiesResp },
+                      "the camera answers a qualified monitor with capabilities")
+    }
 
-        XCTAssertTrue(cameraFrameSender.peerSupportsVP9.value,
-                      "VP9 must still be enabled after a photo re-enters .camera")
-        let stillNegotiated = await cameraCoordinator.peerSupportsVP9PreviewForTesting()
-        XCTAssertTrue(stillNegotiated)
+    /// A monitor too old to decode VP9 (0 < bundleVersion < threshold) is sent to
+    /// the update-required flow: the camera pops to scanning and never answers it
+    /// (no stills fallback, no capability negotiation).
+    func testOutOfDateMonitorIsToldToUpdate() async {
+        let old = VP9PreviewCompatibility.minimumPeerBundleVersion - 1
+        _ = await enterCameraState()
+
+        cameraCoordinator.tell(RemoteCmd.PeerBecameMonitor(
+            bundleVersion: old, shortVersion: "6.9", platform: "iPhone"))
+        await drainBothSessions()
+
+        let cameraState = await cameraCoordinator.currentStateName()
+        XCTAssertEqual(cameraState, .scanning, "an out-of-date monitor sends the camera to update/scanning")
+        XCTAssertFalse(cameraTransport.sentMessages.contains { $0 is RemoteCmd.CameraCapabilitiesResp },
+                       "the camera must not answer a monitor that can't decode its VP9 stream")
+    }
+
+    /// The legacy `bundleVersion <= 0` (unknown build) case behaves as before:
+    /// the same incompatibility flow, now via the single version check.
+    func testUnknownBuildMonitorStillTreatedAsIncompatible() async {
+        _ = await enterCameraState()
+
+        cameraCoordinator.tell(RemoteCmd.PeerBecameMonitor(
+            bundleVersion: 0, shortVersion: "0", platform: "iPhone"))
+        await drainBothSessions()
+
+        let cameraState = await cameraCoordinator.currentStateName()
+        XCTAssertEqual(cameraState, .scanning, "an unknown-build (<= 0) monitor is still incompatible")
     }
 
     // MARK: - VP9 keyframe recovery

--- a/RemoteCamTests/LoopbackSessionTests.swift
+++ b/RemoteCamTests/LoopbackSessionTests.swift
@@ -578,6 +578,125 @@ class LoopbackSessionTests: XCTestCase {
         XCTAssertEqual(monitorState, .monitor)
     }
 
+    // MARK: - VP9 preview negotiation
+
+    /// A VP9-capable monitor advertises decode support on PeerBecameMonitor; the
+    /// camera peer (also VP9-capable) enables VP9 streaming for the connection.
+    func testVP9CapableMonitorEnablesVP9OnCameraPeer() async {
+        await connectBothSessions()
+        await cameraCoordinator.setLocalVP9Available(true)
+        await monitorCoordinator.setLocalVP9Available(true)
+
+        let fakeCamera = LoopbackFakeCamera()
+        fakeCamera.coordinator = cameraCoordinator
+        cameraCoordinator.tell(UICmd.BecomeCamera(sender: nil, ctrl: fakeCamera))
+        await drainBothSessions()
+        await becomeMonitor(mode: .Photo)   // sends PeerBecameMonitor advertising VP9
+
+        let enabled = await cameraCoordinator.peerSupportsVP9PreviewForTesting()
+        XCTAssertTrue(enabled, "camera must enable VP9 for a VP9-capable monitor")
+        // The advertisement really crossed the wire (not a local shortcut).
+        XCTAssertTrue(monitorTransport.sentMessages.contains {
+            ($0 as? RemoteCmd.PeerBecameMonitor)?.supportsVP9Preview == true
+        })
+    }
+
+    /// A legacy monitor (no VP9 decode) advertises false; the camera must keep
+    /// streaming stills — sending VP9 bytes would render as a broken still.
+    func testLegacyMonitorKeepsCameraOnStills() async {
+        await connectBothSessions()
+        await cameraCoordinator.setLocalVP9Available(true)
+        await monitorCoordinator.setLocalVP9Available(false)   // legacy-shaped monitor
+
+        let fakeCamera = LoopbackFakeCamera()
+        fakeCamera.coordinator = cameraCoordinator
+        cameraCoordinator.tell(UICmd.BecomeCamera(sender: nil, ctrl: fakeCamera))
+        await drainBothSessions()
+        await becomeMonitor(mode: .Photo)
+
+        let enabled = await cameraCoordinator.peerSupportsVP9PreviewForTesting()
+        XCTAssertFalse(enabled, "camera must not send VP9 to a monitor that can't decode it")
+        XCTAssertTrue(monitorTransport.sentMessages.contains {
+            ($0 as? RemoteCmd.PeerBecameMonitor)?.supportsVP9Preview == false
+        })
+    }
+
+    /// Even a VP9-capable monitor gets stills if THIS camera can't encode VP9.
+    func testCameraWithoutVP9StreamsStillsToVP9Monitor() async {
+        await connectBothSessions()
+        await cameraCoordinator.setLocalVP9Available(false)   // camera can't encode
+        await monitorCoordinator.setLocalVP9Available(true)
+
+        let fakeCamera = LoopbackFakeCamera()
+        fakeCamera.coordinator = cameraCoordinator
+        cameraCoordinator.tell(UICmd.BecomeCamera(sender: nil, ctrl: fakeCamera))
+        await drainBothSessions()
+        await becomeMonitor(mode: .Photo)
+
+        let enabled = await cameraCoordinator.peerSupportsVP9PreviewForTesting()
+        XCTAssertFalse(enabled, "no VP9 without a local encoder, even to a VP9 monitor")
+    }
+
+    // MARK: - VP9 keyframe recovery
+
+    /// Once the monitor has received a VP9 frame, a decoder desync sends
+    /// RequestKeyframe, which reaches the camera and forces a keyframe.
+    func testKeyframeRequestRoundTripAfterVP9Frame() async {
+        await connectBothSessions()
+        let fakeCamera = LoopbackFakeCamera()
+        fakeCamera.coordinator = cameraCoordinator
+        cameraCoordinator.tell(UICmd.BecomeCamera(sender: nil, ctrl: fakeCamera))
+        await drainBothSessions()
+        await becomeMonitor(mode: .Photo)
+
+        // The camera's FrameSender is where a keyframe request lands.
+        let cameraFrameSender = FrameSender(coordinator: cameraCoordinator)
+        cameraCoordinator.setFrameSender(cameraFrameSender)
+        monitorTransport.sentMessages.removeAll()
+
+        // The monitor received a VP9 frame (as the transport would deliver one).
+        monitorCoordinator.tell(vp9Frame())
+        await drainBothSessions()
+
+        monitorCoordinator.tell(UICmd.RequestVideoKeyframe())
+        await drainBothSessions()
+
+        XCTAssertTrue(monitorTransport.sentMessages.contains { $0 is RemoteCmd.RequestKeyframe },
+                      "a desync after a VP9 frame must send RequestKeyframe")
+        XCTAssertTrue(cameraFrameSender.takeKeyframeRequest(),
+                      "the camera must forward the request to its VP9 streamer")
+        // The camera did not misread it as a photo request.
+        XCTAssertTrue(fakeCamera.takePictureCalls.isEmpty)
+        let cameraState = await cameraCoordinator.currentStateName()
+        XCTAssertEqual(cameraState, .camera)
+    }
+
+    /// The old-peer gate: a keyframe request is NEVER sent before a VP9 frame has
+    /// been seen — an old camera decodes the unknown action as TakePicture.
+    func testKeyframeRequestGatedUntilVP9FrameSeen() async {
+        let fakeCamera = await connectCameraAndMonitor()
+        monitorTransport.sentMessages.removeAll()
+
+        // No VP9 frame has arrived yet.
+        monitorCoordinator.tell(UICmd.RequestVideoKeyframe())
+        await drainBothSessions()
+
+        XCTAssertFalse(monitorTransport.sentMessages.contains { $0 is RemoteCmd.RequestKeyframe },
+                       "RequestKeyframe must be gated on having received a VP9 frame")
+        XCTAssertTrue(fakeCamera.takePictureCalls.isEmpty,
+                      "an ungated request would decode as TakePicture on an old peer")
+        let monitorState = await monitorCoordinator.currentStateName()
+        XCTAssertEqual(monitorState, .monitor)
+    }
+
+    /// Builds an OnFrame the way the transport delivers a camera VP9 frame.
+    private func vp9Frame() -> RemoteCmd.OnFrame {
+        RemoteCmd.OnFrame(
+            data: Data([1, 2, 3]), sender: nil, peerId: cameraTransport.localPeerID,
+            fps: 30, camPosition: .back, camOrientation: .portrait,
+            codec: .vp9, sequenceNumber: 1)
+    }
+
     /// The full 3-step stop protocol across both machines:
     /// StopRecordingVideo → StopRecordingVideoAck → StopRecordingVideoResp.
     func testVideoRecordingStartStopProtocolAcrossTheWire() async {

--- a/RemoteCamTests/LoopbackSessionTests.swift
+++ b/RemoteCamTests/LoopbackSessionTests.swift
@@ -637,6 +637,36 @@ class LoopbackSessionTests: XCTestCase {
         XCTAssertFalse(enabled, "no VP9 without a local encoder, even to a VP9 monitor")
     }
 
+    /// VP9 negotiation is per-connection, not per-state-entry: it must survive a
+    /// photo capture (which re-enters .camera and re-binds the FrameSender). A
+    /// regression guard — clearing it on re-bind would kill VP9 after one photo.
+    func testVP9SupportSurvivesPhotoCapture() async {
+        await connectBothSessions()
+        await cameraCoordinator.setLocalVP9Available(true)
+        await monitorCoordinator.setLocalVP9Available(true)
+
+        let fakeCamera = LoopbackFakeCamera()
+        fakeCamera.coordinator = cameraCoordinator
+        let cameraFrameSender = FrameSender(coordinator: cameraCoordinator)
+        cameraCoordinator.setFrameSender(cameraFrameSender)
+        cameraCoordinator.tell(UICmd.BecomeCamera(sender: nil, ctrl: fakeCamera))
+        await drainBothSessions()
+        await becomeMonitor(mode: .Photo)
+
+        XCTAssertTrue(cameraFrameSender.peerSupportsVP9.value, "VP9 enabled after negotiation")
+
+        // Take a photo — the camera walks .camera -> takingPic -> back to .camera.
+        monitorCoordinator.tell(UICmd.TakePicture(sender: nil, sendMediaToRemote: false))
+        await drainBothSessions()
+        let cameraState = await cameraCoordinator.currentStateName()
+        XCTAssertEqual(cameraState, .camera)
+
+        XCTAssertTrue(cameraFrameSender.peerSupportsVP9.value,
+                      "VP9 must still be enabled after a photo re-enters .camera")
+        let stillNegotiated = await cameraCoordinator.peerSupportsVP9PreviewForTesting()
+        XCTAssertTrue(stillNegotiated)
+    }
+
     // MARK: - VP9 keyframe recovery
 
     /// Once the monitor has received a VP9 frame, a decoder desync sends

--- a/RemoteCamTests/RemoteCmdSerializationTests.swift
+++ b/RemoteCamTests/RemoteCmdSerializationTests.swift
@@ -591,14 +591,6 @@ final class RemoteCmdSerializationTests: XCTestCase {
         XCTAssertEqual(decoded.bundleVersion, 65)
         XCTAssertEqual(decoded.shortVersion, "4.14.1")
         XCTAssertEqual(decoded.platform, "iPad")
-        XCTAssertFalse(decoded.supportsVP9Preview, "default (and legacy) is no VP9 support")
-    }
-
-    func testPeerBecameMonitor_vp9FlagRoundTrips() {
-        let original = RemoteCmd.PeerBecameMonitor(bundleVersion: 65, shortVersion: "4.14.1",
-                                                   platform: "iPad", supportsVP9Preview: true)
-        let decoded: RemoteCmd.PeerBecameMonitor = roundTrip(original)
-        XCTAssertTrue(decoded.supportsVP9Preview, "advertised VP9 decode support must survive the wire")
     }
 
     func testRequestKeyframe_roundTrip() {

--- a/RemoteCamTests/RemoteCmdSerializationTests.swift
+++ b/RemoteCamTests/RemoteCmdSerializationTests.swift
@@ -46,6 +46,7 @@ final class RemoteCmdSerializationTests: XCTestCase {
         case let m as RemoteCmd.TakePicResp: return m.toFlatBuffer()
         case let m as RemoteCmd.SendFrame: return m.toFlatBuffer()
         case let m as RemoteCmd.RequestFrame: return m.toFlatBuffer()
+        case let m as RemoteCmd.RequestKeyframe: return m.toFlatBuffer()
         case let m as RemoteCmd.SetZoom: return m.toFlatBuffer()
         case let m as RemoteCmd.SetZoomResp: return m.toFlatBuffer()
         case let m as RemoteCmd.CameraCapabilitiesResp: return m.toFlatBuffer()
@@ -590,6 +591,20 @@ final class RemoteCmdSerializationTests: XCTestCase {
         XCTAssertEqual(decoded.bundleVersion, 65)
         XCTAssertEqual(decoded.shortVersion, "4.14.1")
         XCTAssertEqual(decoded.platform, "iPad")
+        XCTAssertFalse(decoded.supportsVP9Preview, "default (and legacy) is no VP9 support")
+    }
+
+    func testPeerBecameMonitor_vp9FlagRoundTrips() {
+        let original = RemoteCmd.PeerBecameMonitor(bundleVersion: 65, shortVersion: "4.14.1",
+                                                   platform: "iPad", supportsVP9Preview: true)
+        let decoded: RemoteCmd.PeerBecameMonitor = roundTrip(original)
+        XCTAssertTrue(decoded.supportsVP9Preview, "advertised VP9 decode support must survive the wire")
+    }
+
+    func testRequestKeyframe_roundTrip() {
+        let original = RemoteCmd.RequestKeyframe(sender: nil)
+        let decoded: RemoteCmd.RequestKeyframe = roundTrip(original)
+        XCTAssertNotNil(decoded)
     }
 
     // MARK: - 18. ToggleFlash

--- a/RemoteCamTests/VP9StreamingTests.swift
+++ b/RemoteCamTests/VP9StreamingTests.swift
@@ -15,6 +15,18 @@ import VideocallCodecs
 
 @testable import RemoteShutter
 
+/// One explicit fixture for every encoder test — `VP9Settings` has no field
+/// defaults on purpose (each stream states its full tuning), so tests do too.
+private extension VP9Settings {
+    static let test = VP9Settings(
+        bitrateKbps: 300,
+        fps: 30,
+        keyframeInterval: 30,
+        minQuantizer: 40,
+        maxQuantizer: 60,
+        cpuUsed: 7)
+}
+
 final class VP9StreamingTests: XCTestCase {
 
     // MARK: - Helpers
@@ -98,7 +110,7 @@ final class VP9StreamingTests: XCTestCase {
     // MARK: - VP9FrameEncoder pipeline (BGRA -> I420 -> VP9)
 
     func testFrameEncoderProducesDecodableDownscaledFrame() throws {
-        let encoder = VP9FrameEncoder(maxLongEdge: 100, settings: .init())
+        let encoder = VP9FrameEncoder(maxLongEdge: 100, settings: .test)
         let buffer = makeSolidPixelBuffer(width: 400, height: 200, blue: 128, green: 128, red: 128)
 
         let data = try XCTUnwrap(encodedData(encoder.encode(pixelBuffer: buffer)),
@@ -118,7 +130,7 @@ final class VP9StreamingTests: XCTestCase {
     }
 
     func testFrameEncoderStreamsConsecutiveFrames() throws {
-        let encoder = VP9FrameEncoder(maxLongEdge: 64, settings: .init())
+        let encoder = VP9FrameEncoder(maxLongEdge: 64, settings: .test)
         let decoder = Vp9Decoder()
         var decodedCount = 0
         for shade in [UInt8(60), 120, 180] {
@@ -141,7 +153,7 @@ final class VP9StreamingTests: XCTestCase {
     /// a fresh session whose first frame is a keyframe, so a decoder that joins
     /// at the new geometry (or lost the old stream) re-syncs immediately.
     func testFrameEncoderRestartsWithKeyframeOnGeometryChange() throws {
-        let encoder = VP9FrameEncoder(maxLongEdge: 100, settings: .init())
+        let encoder = VP9FrameEncoder(maxLongEdge: 100, settings: .test)
         let landscape = makeSolidPixelBuffer(width: 400, height: 200, blue: 200, green: 100, red: 50)
         _ = try XCTUnwrap(encodedData(encoder.encode(pixelBuffer: landscape)))
 
@@ -181,7 +193,7 @@ final class VP9StreamingTests: XCTestCase {
     }
 
     func testForceKeyframeMakesNextFrameASelfContainedKeyframe() throws {
-        let encoder = VP9FrameEncoder(maxLongEdge: 64, settings: .init())
+        let encoder = VP9FrameEncoder(maxLongEdge: 64, settings: .test)
         let key = makeSolidPixelBuffer(width: 128, height: 64, blue: 90, green: 90, red: 90)
         _ = try XCTUnwrap(encodedData(encoder.encode(pixelBuffer: key)), "first frame is a keyframe")
 
@@ -216,7 +228,7 @@ final class PeerVP9PreviewDecoderTests: XCTestCase {
     }
 
     func testDecodesKeyframeToImage() throws {
-        let encoder = VP9FrameEncoder(maxLongEdge: 64, settings: .init())
+        let encoder = VP9FrameEncoder(maxLongEdge: 64, settings: .test)
         let data = try XCTUnwrap(encodedData(encoder.encode(
             pixelBuffer: makeSolidPixelBuffer(width: 128, height: 64, shade: 120))))
 

--- a/RemoteCamTests/VP9StreamingTests.swift
+++ b/RemoteCamTests/VP9StreamingTests.swift
@@ -164,4 +164,69 @@ final class VP9StreamingTests: XCTestCase {
         XCTAssertEqual(toFBStreamCodec(.vp9), .vp9)
         XCTAssertEqual(fromFBStreamCodec(.unknown), .jpeg, "legacy senders default to JPEG")
     }
+
+    // MARK: - Negotiation decision
+
+    func testCameraOffersVP9OnlyWhenBothSidesSupportIt() {
+        XCTAssertTrue(VP9Negotiation.cameraShouldSendVP9(peerAdvertisedVP9: true, localVP9Available: true))
+        XCTAssertFalse(VP9Negotiation.cameraShouldSendVP9(peerAdvertisedVP9: true, localVP9Available: false),
+                       "no VP9 without a local encoder")
+        XCTAssertFalse(VP9Negotiation.cameraShouldSendVP9(peerAdvertisedVP9: false, localVP9Available: true),
+                       "no VP9 to a monitor that can't decode it (legacy peer)")
+        XCTAssertFalse(VP9Negotiation.cameraShouldSendVP9(peerAdvertisedVP9: false, localVP9Available: false))
+    }
+
+    func testForceKeyframeMakesNextFrameASelfContainedKeyframe() throws {
+        let encoder = VP9FrameEncoder(maxLongEdge: 64, settings: .init())
+        let key = makeSolidPixelBuffer(width: 128, height: 64, blue: 90, green: 90, red: 90)
+        _ = try XCTUnwrap(encodedData(encoder.encode(pixelBuffer: key)), "first frame is a keyframe")
+
+        // Force a keyframe: the very next encoded frame must decode on a FRESH
+        // decoder (i.e. it is itself a keyframe, not a delta needing history).
+        encoder.forceKeyframe()
+        let next = makeSolidPixelBuffer(width: 128, height: 64, blue: 90, green: 90, red: 90)
+        let data = try XCTUnwrap(encodedData(encoder.encode(pixelBuffer: next)),
+                                 "forced keyframe must encode immediately")
+        XCTAssertNoThrow(try Vp9Decoder().decode(frame: data),
+                         "a forced keyframe must decode without any prior frame")
+    }
+}
+
+// MARK: - Monitor-side peer VP9 decoder
+
+final class PeerVP9PreviewDecoderTests: XCTestCase {
+
+    private func makeSolidPixelBuffer(width: Int, height: Int, shade: UInt8) -> CVPixelBuffer {
+        let buffer = makePixelBuffer(width: width, height: height)
+        CVPixelBufferLockBaseAddress(buffer, [])
+        defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+        let base = CVPixelBufferGetBaseAddress(buffer)!
+        let rowBytes = CVPixelBufferGetBytesPerRow(buffer)
+        for y in 0..<height {
+            let row = base.advanced(by: y * rowBytes).assumingMemoryBound(to: UInt8.self)
+            for x in 0..<width {
+                row[x * 4] = shade; row[x * 4 + 1] = shade; row[x * 4 + 2] = shade; row[x * 4 + 3] = 255
+            }
+        }
+        return buffer
+    }
+
+    func testDecodesKeyframeToImage() throws {
+        let encoder = VP9FrameEncoder(maxLongEdge: 64, settings: .init())
+        let data = try XCTUnwrap(encodedData(encoder.encode(
+            pixelBuffer: makeSolidPixelBuffer(width: 128, height: 64, shade: 120))))
+
+        let decoder = PeerVP9PreviewDecoder()
+        let image = decoder.decode(data)
+        XCTAssertNotNil(image, "a keyframe must render an image")
+    }
+
+    /// A mid-stream delta frame with no keyframe first is undecodable — the
+    /// decoder returns nil (the caller then requests a keyframe), the exact
+    /// desync-recovery contract.
+    func testUndecodableFrameReturnsNil() {
+        let decoder = PeerVP9PreviewDecoder()
+        XCTAssertNil(decoder.decode(Data([0xDE, 0xAD, 0xBE, 0xEF])),
+                     "garbage/mid-stream data must not crash and must return nil")
+    }
 }

--- a/RemoteCamTests/VP9StreamingTests.swift
+++ b/RemoteCamTests/VP9StreamingTests.swift
@@ -165,15 +165,19 @@ final class VP9StreamingTests: XCTestCase {
         XCTAssertEqual(fromFBStreamCodec(.unknown), .jpeg, "legacy senders default to JPEG")
     }
 
-    // MARK: - Negotiation decision
+    // MARK: - Version-gate decision
 
-    func testCameraOffersVP9OnlyWhenBothSidesSupportIt() {
-        XCTAssertTrue(VP9Negotiation.cameraShouldSendVP9(peerAdvertisedVP9: true, localVP9Available: true))
-        XCTAssertFalse(VP9Negotiation.cameraShouldSendVP9(peerAdvertisedVP9: true, localVP9Available: false),
-                       "no VP9 without a local encoder")
-        XCTAssertFalse(VP9Negotiation.cameraShouldSendVP9(peerAdvertisedVP9: false, localVP9Available: true),
-                       "no VP9 to a monitor that can't decode it (legacy peer)")
-        XCTAssertFalse(VP9Negotiation.cameraShouldSendVP9(peerAdvertisedVP9: false, localVP9Available: false))
+    func testPeerCanDecodeVP9PreviewIsBundleVersionGated() {
+        let threshold = VP9PreviewCompatibility.minimumPeerBundleVersion
+        XCTAssertTrue(VP9PreviewCompatibility.peerCanDecodeVP9Preview(bundleVersion: threshold),
+                      "the first VP9 release qualifies at exactly the threshold")
+        XCTAssertTrue(VP9PreviewCompatibility.peerCanDecodeVP9Preview(bundleVersion: threshold + 5),
+                      "newer peers qualify")
+        XCTAssertFalse(VP9PreviewCompatibility.peerCanDecodeVP9Preview(bundleVersion: threshold - 1),
+                       "a peer one build below the threshold cannot decode VP9")
+        XCTAssertFalse(VP9PreviewCompatibility.peerCanDecodeVP9Preview(bundleVersion: 0),
+                       "unknown/legacy build (<= 0) also cannot decode VP9 — one check covers both")
+        XCTAssertFalse(VP9PreviewCompatibility.peerCanDecodeVP9Preview(bundleVersion: -1))
     }
 
     func testForceKeyframeMakesNextFrameASelfContainedKeyframe() throws {

--- a/RemoteShutterWatch/WatchVP9PreviewDecoder.swift
+++ b/RemoteShutterWatch/WatchVP9PreviewDecoder.swift
@@ -39,6 +39,13 @@ final class WatchVP9PreviewDecoder {
     private var conversion = vImage_YpCbCrToARGB()
     /// Identity channel order: emit A,R,G,B exactly as the CGImage expects.
     private let identityPermute: [UInt8] = [0, 1, 2, 3]
+    /// Reused ARGB destination for every frame — allocating a fresh buffer per
+    /// frame at stream rate churns memory. vImage converts into the context's
+    /// backing store in place; `makeImage()` snapshots it with copy-on-write
+    /// pages, so overwriting it for the next frame cannot corrupt an image
+    /// already handed out. Recreated only when the stream dimensions change.
+    /// Queue-confined like the decoder.
+    private var argbContext: CGContext?
 
     init(maxFailureStreak: Int = 30) {
         self.maxFailureStreak = maxFailureStreak
@@ -97,44 +104,40 @@ final class WatchVP9PreviewDecoder {
         guard width > 0, height > 0,
               decoded.data.count >= lumaBytes + 2 * chromaBytes else { return nil }
 
-        var argb = Data(count: width * height * 4)
-        let converted: Bool = argb.withUnsafeMutableBytes { dstRaw in
-            guard let dstBase = dstRaw.baseAddress else { return false }
-            return decoded.data.withUnsafeBytes { srcRaw -> Bool in
-                guard let srcBase = srcRaw.baseAddress else { return false }
-                var yp = vImage_Buffer(data: UnsafeMutableRawPointer(mutating: srcBase),
-                                       height: vImagePixelCount(height),
-                                       width: vImagePixelCount(width),
-                                       rowBytes: width)
-                var cb = vImage_Buffer(data: UnsafeMutableRawPointer(mutating: srcBase + lumaBytes),
-                                       height: vImagePixelCount(chromaHeight),
-                                       width: vImagePixelCount(chromaWidth),
-                                       rowBytes: chromaWidth)
-                var cr = vImage_Buffer(data: UnsafeMutableRawPointer(mutating: srcBase + lumaBytes + chromaBytes),
-                                       height: vImagePixelCount(chromaHeight),
-                                       width: vImagePixelCount(chromaWidth),
-                                       rowBytes: chromaWidth)
-                var dst = vImage_Buffer(data: dstBase,
-                                        height: vImagePixelCount(height),
-                                        width: vImagePixelCount(width),
-                                        rowBytes: width * 4)
-                return vImageConvert_420Yp8_Cb8_Cr8ToARGB8888(
-                    &yp, &cb, &cr, &dst, &conversion, identityPermute, 255,
-                    vImage_Flags(kvImageNoFlags)) == kvImageNoError
-            }
-        }
-        guard converted else { return nil }
-
-        guard let provider = CGDataProvider(data: argb as CFData),
-              let cgImage = CGImage(
+        if argbContext == nil || argbContext?.width != width || argbContext?.height != height {
+            argbContext = CGContext(
+                data: nil,                       // CG owns (and reuses) the buffer
                 width: width, height: height,
-                bitsPerComponent: 8, bitsPerPixel: 32,
-                bytesPerRow: width * 4,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,                  // CG picks an aligned stride
                 space: CGColorSpaceCreateDeviceRGB(),
-                bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.noneSkipFirst.rawValue),
-                provider: provider, decode: nil,
-                shouldInterpolate: false,
-                intent: .defaultIntent) else { return nil }
+                bitmapInfo: CGImageAlphaInfo.noneSkipFirst.rawValue)
+        }
+        guard let context = argbContext, let dstBase = context.data else { return nil }
+
+        let converted: Bool = decoded.data.withUnsafeBytes { srcRaw -> Bool in
+            guard let srcBase = srcRaw.baseAddress else { return false }
+            var yp = vImage_Buffer(data: UnsafeMutableRawPointer(mutating: srcBase),
+                                   height: vImagePixelCount(height),
+                                   width: vImagePixelCount(width),
+                                   rowBytes: width)
+            var cb = vImage_Buffer(data: UnsafeMutableRawPointer(mutating: srcBase + lumaBytes),
+                                   height: vImagePixelCount(chromaHeight),
+                                   width: vImagePixelCount(chromaWidth),
+                                   rowBytes: chromaWidth)
+            var cr = vImage_Buffer(data: UnsafeMutableRawPointer(mutating: srcBase + lumaBytes + chromaBytes),
+                                   height: vImagePixelCount(chromaHeight),
+                                   width: vImagePixelCount(chromaWidth),
+                                   rowBytes: chromaWidth)
+            var dst = vImage_Buffer(data: dstBase,
+                                    height: vImagePixelCount(height),
+                                    width: vImagePixelCount(width),
+                                    rowBytes: context.bytesPerRow)
+            return vImageConvert_420Yp8_Cb8_Cr8ToARGB8888(
+                &yp, &cb, &cr, &dst, &conversion, identityPermute, 255,
+                vImage_Flags(kvImageNoFlags)) == kvImageNoError
+        }
+        guard converted, let cgImage = context.makeImage() else { return nil }
         return UIImage(cgImage: cgImage)
     }
 }


### PR DESCRIPTION
## What

Replaces the HEIC/JPEG still-frame peer preview with a VP9 video stream between camera and monitor over MultipeerConnectivity, reusing the VideocallCodecs (Rust) encoder infrastructure the watch path already uses.

## Design

- **Encode:** the camera's `FrameStreamer` encodes VP9 lazily — only when the credit window has room — because a stateful stream must never encode-then-drop (a lost delta frame corrupts decode until a keyframe).
- **Transport:** VP9 frames are sent `.reliable`; back-pressure is applied at encode time via a lock-boxed mirror of the credit window, so the reliable queue can never build up. Stills remain `.unreliable`.
- **Compatibility — version gate, no capability negotiation:** `VP9PreviewCompatibility.minimumPeerBundleVersion = 100` (this build, the first VP9-preview release). A monitor reporting an older `bundleVersion` (already exchanged on `PeerBecameMonitor`) is routed to the existing "App is out of date → Update" alert instead of being streamed to. The legacy `bundleVersion <= 0` handling is unchanged.
- **Recovery:** new `CommandAction.RequestKeyframe = 20`; the monitor requests a keyframe on decoder desync, gated on having already received a VP9 frame so old peers can never misread the command (same precedent as the `SelectCameraDevice` gate). Periodic keyframes (every 30) as passive backstop. Sequence numbers detect desync.
- **Decode:** `PeerVP9PreviewDecoder` on the receiver's serial queue, drop-but-recover, rendered through the existing `MonitorPresenter` seam. Monitor-side stills decoding is kept — an old camera streaming HEIC to a new monitor still renders.
- **Runtime fallback (dev-only):** `VP9Support` probes the Rust encoder at runtime; on configs without an arm64 slice the still-encode chain still works. On every shipping arm64 build VP9 is always available.

## Schema

`FlatBufferSchemas.fbs`: adds `CommandAction.RequestKeyframe = 20` only. Regenerated with flatc 25.2.10.

## Verification

- Full suite: 480 tests, 0 failures
- Loopback coverage: version gate (qualified monitor streams; out-of-date monitor gets the update alert and no frames; `<= 0` unchanged), keyframe request round trip + old-peer gate, VP9 surviving photo capture, legacy stills rendering on a new monitor
- iOS Simulator and Mac Catalyst builds succeed
- Known window: an out-of-date monitor may receive a sub-second burst of VP9 frames (renders nothing) before `PeerBecameMonitor` arrives and the update alert fires — matches the existing handshake ordering
- Not yet smoke-tested on two physical devices — recommended before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)