### PR TITLE
Add zoom control to the Mac monitor screen

### DIFF
--- a/RemoteCam/CameraRig.swift
+++ b/RemoteCam/CameraRig.swift
@@ -104,6 +104,14 @@ final class CameraRig: @unchecked Sendable {
 
     /// Bridges the non-UI engine/pipeline back to the actor system and the screen.
     private func wireCallbacks() {
+        // A device swap is a hard scene cut that the VP9 encoder cannot see, so it
+        // would keep predicting from the old camera's frames. Force the next
+        // preview frame to stand on its own.
+        engine.onDeviceSwapped = { [frameSender] in
+            StreamLog.encode.info("camera device swapped — forcing a keyframe")
+            frameSender.requestKeyframe()
+        }
+
         // Captures the session ref (not self) so an in-flight capture still
         // reaches the actor if the rig deallocates before the delegate fires.
         engine.onPicture = { [session] pic, error in

--- a/RemoteCam/CaptureEngine.swift
+++ b/RemoteCam/CaptureEngine.swift
@@ -112,6 +112,12 @@ final class CaptureEngine: NSObject, AVCapturePhotoCaptureDelegate {
     /// Fired whenever camera status (resolution/frame rate/format/HDR) changes so
     /// the VC can refresh its status overlay.
     var onStatusChanged: (() -> Void)?
+    /// The capture device was swapped underneath the running outputs — a flip, a
+    /// device pick, or a lens switch. The scene cuts completely, but the preview
+    /// encoder is not recreated unless the *scaled* dimensions happen to change
+    /// (they don't on a flip: both cameras land on the same long edge), so it
+    /// would otherwise encode a delta frame across the cut. Fires on `sessionQueue`.
+    var onDeviceSwapped: (() -> Void)?
 
     // MARK: - Setup
 
@@ -337,6 +343,9 @@ final class CaptureEngine: NSObject, AVCapturePhotoCaptureDelegate {
         if isExpectedToRun && !captureSession.isRunning {
             captureSession.startRunning()
         }
+        // Every device swap funnels through here — toggle, device pick and lens
+        // switch alike — so this is the one place that has to announce the cut.
+        onDeviceSwapped?()
 
         return CameraSelectionResult(
             device: CameraDeviceDescriptor(device: newDevice),

--- a/RemoteCam/FrameSender.swift
+++ b/RemoteCam/FrameSender.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import MultipeerConnectivity
+import UIKit
 
 /// Failed to push a frame to the peer — the session pops to scanning with a
 /// connection alert, exactly as any other failed send.
@@ -55,13 +56,40 @@ final class FrameSender {
     /// Send failures pop the session to scanning (via the inbox).
     weak var coordinator: SessionCoordinator?
 
-    init(coordinator: SessionCoordinator? = nil) {
+    private var foregroundObserver: NSObjectProtocol?
+
+    init(coordinator: SessionCoordinator? = nil, notificationCenter: NotificationCenter = .default) {
         self.coordinator = coordinator
+        // Returning from the background leaves the monitor's decoder holding
+        // reference frames from before the freeze, while this encoder carries on
+        // from its own state. Nothing errors — the deltas still decode — so the
+        // monitor never asks; it just renders against stale references. Arm a
+        // keyframe here so the first frame back is self-contained.
+        foregroundObserver = notificationCenter.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            StreamLog.lifecycle.info("camera foregrounded — forcing a keyframe")
+            self?.requestKeyframe()
+        }
+    }
+
+    deinit {
+        if let foregroundObserver {
+            NotificationCenter.default.removeObserver(foregroundObserver)
+        }
     }
 
     /// Binds the streaming target. Re-binding (each time the camera state is
     /// re-entered) resets the credit window, matching the old re-become.
+    ///
+    /// Also arms a keyframe: this is the moment the stream starts flowing to a
+    /// peer, and it is re-entered after a photo or a video transfer. Whatever the
+    /// monitor's decoder holds from before is not a safe reference to build on,
+    /// so the first frame of a resumed stream is always self-contained.
     func setSession(peer: MCPeerID, transport: any MultipeerServiceProtocol) {
+        requestKeyframe()
         queue.async {
             if self.hasSession {
                 self.window.reset()

--- a/RemoteCam/FrameStreamReceiver.swift
+++ b/RemoteCam/FrameStreamReceiver.swift
@@ -68,6 +68,11 @@ final class FrameStreamReceiver {
                 StreamLog.lifecycle.info("monitor foregrounded — re-requesting frame")
                 self.resetStallClock()
                 self.onStall?()
+                // A frame alone isn't enough: this decoder still holds references
+                // from before the freeze while the camera's encoder moved on.
+                // Deltas built on those decode without error and render as smears,
+                // so nothing would ever prompt a request — ask up front.
+                self.requestKeyframe(at: self.now())
             }
         }
     }

--- a/RemoteCam/MonitorView.swift
+++ b/RemoteCam/MonitorView.swift
@@ -105,15 +105,8 @@ struct MonitorView: View {
                 }
             }
             
-            // Zoom controls overlay - positioned at top for right-handed accessibility
-            if viewModel.showZoomControls {
-                VStack {
-                    zoomControlsOverlay
-                        .padding(.top, 50) // Below status bar
-                    Spacer()
-                }
-            }
-            
+            zoomControls
+
             // Video transfer progress overlay - positioned at center
             if viewModel.isVideoTransferring {
                 VideoTransferProgressView(
@@ -155,20 +148,7 @@ struct MonitorView: View {
                         zoomAtGestureStart = viewModel.currentZoomFactor
                     }
                     let start = zoomAtGestureStart!
-
-                    // Logarithmic zoom: newZoom = start * value^sensitivity
-                    // Operates in log2 space for uniform perceptual sensitivity
-                    let minZoom = viewModel.zoomStops.first ?? 1.0
-                    let maxZoom = viewModel.maxZoomFactor
-                    let sensitivity: CGFloat = 0.6
-
-                    let logStart = log2(start)
-                    let logDelta = log2(value) * sensitivity
-                    let logNew = logStart + logDelta
-                    let clamped = max(log2(minZoom), min(log2(maxZoom), logNew))
-                    let newZoom = pow(2, clamped)
-
-                    onZoomChange(newZoom)
+                    onZoomChange(viewModel.zoomScale.pinched(from: start, magnification: value))
                     viewModel.showZoomControlsTemporarily()
                 }
                 .onEnded { _ in
@@ -180,11 +160,39 @@ struct MonitorView: View {
     // MARK: - Recording Indicator
     // Note: Replaced with RecordingTimer component that includes duration
     
-    // MARK: - Zoom Controls Overlay
+    // MARK: - Zoom Controls
+
+    /// iPhone and iPad zoom by pinch, so they get a read-only HUD that auto-hides 0.5s
+    /// after the last gesture. A Mac has no pinch affordance for mouse users, and a
+    /// control that vanishes half a second after you release it can't be operated, so
+    /// Catalyst gets an interactive pill that stays put instead.
+    @ViewBuilder
+    private var zoomControls: some View {
+        #if targetEnvironment(macCatalyst)
+        VStack {
+            Spacer()
+            ZoomPill(scale: viewModel.zoomScale,
+                     currentZoomFactor: viewModel.currentZoomFactor,
+                     onZoomChange: onZoomChange)
+                .padding(.bottom, 24)
+        }
+        #else
+        if viewModel.showZoomControls {
+            VStack {
+                // Positioned at top for right-handed accessibility.
+                zoomControlsOverlay
+                    .padding(.top, 50) // Below status bar
+                Spacer()
+            }
+        }
+        #endif
+    }
+
+    #if !targetEnvironment(macCatalyst)
     private var zoomControlsOverlay: some View {
         VStack(spacing: 10) {
             // Current zoom level - display relative to wide-angle
-            Text("\(String(format: "%.1f", viewModel.currentZoomFactor / viewModel.wideAngleZoomFactor))×")
+            Text("\(String(format: "%.1f", viewModel.zoomScale.displayFactor(forHardware: viewModel.currentZoomFactor)))×")
                 .font(.system(size: 18, weight: .semibold, design: .rounded))
                 .foregroundColor(.white)
                 .tracking(0.5)
@@ -232,8 +240,10 @@ struct MonitorView: View {
                         .shadow(color: AppTheme.accent.opacity(0.3), radius: 2, x: 0, y: 1)
                 }
 
-                // End label
-                Text("\(String(format: "%.0f", viewModel.maxZoomFactor))×")
+                // End label. maxZoomFactor is a hardware factor, so it has to go through
+                // formatZoomStop like the start label — printed raw it brackets the bar in
+                // a different unit than the label at the other end.
+                Text(formatZoomStop(viewModel.maxZoomFactor))
                     .font(.system(size: 11, weight: .medium, design: .rounded))
                     .foregroundColor(.white.opacity(0.8))
             }
@@ -266,7 +276,8 @@ struct MonitorView: View {
         .shadow(color: Color.black.opacity(0.3), radius: 12, x: 0, y: 4)
         .shadow(color: Color.black.opacity(0.1), radius: 2, x: 0, y: 1)
     }
-    
+    #endif
+
     // MARK: - Quality Controls
     private var qualityControls: some View {
         ScrollView(.horizontal, showsIndicators: false) {
@@ -494,16 +505,13 @@ struct MonitorView: View {
         }
     }
     
+    #if !targetEnvironment(macCatalyst)
     /// Formats a hardware zoom factor as a user-facing label relative to the wide-angle camera.
     /// e.g., hardware 1.0 with wideAngleFactor 2.0 → "0.5x", hardware 2.0 → "1x", hardware 6.0 → "3x"
     private func formatZoomStop(_ hardwareZoom: CGFloat) -> String {
-        let displayZoom = hardwareZoom / viewModel.wideAngleZoomFactor
-        let rounded = round(displayZoom * 10) / 10
-        if rounded == CGFloat(Int(rounded)) {
-            return "\(Int(rounded))x"
-        }
-        return String(format: "%.1fx", rounded)
+        viewModel.zoomScale.label(forHardware: hardwareZoom, glyph: "x")
     }
+    #endif
 
     // MARK: - Lens Controls
     private var lensControls: some View {

--- a/RemoteCam/MonitorViewController+SwiftUI.swift
+++ b/RemoteCam/MonitorViewController+SwiftUI.swift
@@ -225,9 +225,24 @@ extension MonitorViewController {
         showSettings()
     }
     
+    /// Single entry point for user-driven zoom, from pinch or the Mac zoom pill.
+    /// Throttled to 20Hz with a trailing-edge flush so the value the user released on is
+    /// always delivered, mirroring how the Watch drives crown zoom.
     private func handleZoomChange(_ factor: CGFloat) {
         currentZoomFactor = factor
-        session ! UICmd.SetZoom(zoomFactor: factor)
+
+        switch zoomThrottle.update(value: Double(factor), now: Date()) {
+        case .sendNow:
+            session ! UICmd.SetZoom(zoomFactor: factor)
+        case .scheduleTrailing:
+            trailingZoomTimer?.invalidate()
+            trailingZoomTimer = Timer.scheduledTimer(withTimeInterval: zoomThrottle.interval,
+                                                     repeats: false) { [weak self] _ in
+                guard let self,
+                      let pending = self.zoomThrottle.fireTrailing(now: Date()) else { return }
+                self.session ! UICmd.SetZoom(zoomFactor: CGFloat(pending))
+            }
+        }
     }
     
     private func handleLensChange(_ lensType: CameraLensType) {

--- a/RemoteCam/MonitorViewController.swift
+++ b/RemoteCam/MonitorViewController.swift
@@ -56,6 +56,14 @@ public class MonitorViewController: UIViewController {
     // MARK: - Zoom and Lens Properties
     var currentZoomFactor: CGFloat = 1.0
     public var maxZoomFactor: CGFloat = 10.0
+
+    /// Zoom sends are throttled to 20Hz with a trailing-edge flush. A continuous drag on
+    /// the Mac zoom pill emits a value per frame, which would flood the Multipeer channel;
+    /// a plain rate limit would silently drop the final position the user released on.
+    /// Internal rather than private: `handleZoomChange` lives in a different file's
+    /// extension, and `private` is file-scoped.
+    var zoomThrottle = ZoomSendThrottle()
+    var trailingZoomTimer: Timer?
     var availableLensTypes: [CameraLensType] = [.wideAngle]
     var currentLensType: CameraLensType = .wideAngle
 

--- a/RemoteCam/MonitorViewModel.swift
+++ b/RemoteCam/MonitorViewModel.swift
@@ -55,6 +55,15 @@ class MonitorViewModel: ObservableObject {
     @Published var zoomStops: [CGFloat] = [1.0]
     @Published var wideAngleZoomFactor: CGFloat = 1.0 // Hardware zoom for "1x" reference
 
+    /// Zoom math for every control on this screen — pinch, the zoom HUD, and the Mac
+    /// zoom pill. Derived rather than stored so it can never disagree with the three
+    /// published values it is built from.
+    var zoomScale: ZoomScale {
+        ZoomScale(stops: zoomStops,
+                  maxZoomFactor: maxZoomFactor,
+                  wideAngleZoomFactor: wideAngleZoomFactor)
+    }
+
     // MARK: - Aspect Ratio Properties
     @Published var currentAspectRatio: AspectRatio = .sixteenNine
 

--- a/RemoteCam/RecordingPipeline.swift
+++ b/RemoteCam/RecordingPipeline.swift
@@ -230,8 +230,19 @@ class RecordingPipeline {
 
     func setupAssetWriterVideoInput(_ formatDescription: CMVideoFormatDescription,
                                     assetWriter: AVAssetWriter) -> Bool {
-        var videoSettings = self.engine.videoDataOutput.recommendedVideoSettingsForAssetWriter(writingTo: .mov)
-        videoSettings?[AVVideoCodecKey] = AVVideoCodecType.hevc
+        // Ask for settings that are COHERENT with the codec we want, rather than taking
+        // the generic recommendation and overwriting AVVideoCodecKey. The recommendation
+        // carries compression properties keyed to the codec it chose: on a Mac it returns
+        // avc1 with H.264 profile levels, so patching HEVC over the top produced a
+        // dictionary `canApply` refused — the video input was never added,
+        // readyToRecordVideo never flipped, recording never started, and `stopRecording`
+        // then early-returned in silence while the monitor waited forever. (On iPhone the
+        // recommendation is already HEVC, so the overwrite was a no-op and it worked.)
+        // Fall back to the plain recommendation where HEVC isn't offered: a recording in
+        // the device's preferred codec beats no recording at all.
+        var videoSettings = self.engine.videoDataOutput.recommendedVideoSettings(
+            forVideoCodecType: .hevc, assetWriterOutputFileType: .mov)
+            ?? self.engine.videoDataOutput.recommendedVideoSettingsForAssetWriter(writingTo: .mov)
 
         let dims = CMVideoFormatDescriptionGetDimensions(formatDescription)
         let sourceWidth = CGFloat(dims.width)
@@ -281,9 +292,11 @@ class RecordingPipeline {
             if assetWriter.canAdd(videoInput) {
                 assetWriter.add(videoInput)
             } else {
+                debugLog("❌ recording: asset writer refused the video input")
                 return false
             }
         } else {
+            debugLog("❌ recording: video settings rejected by canApply — \(String(describing: videoSettings))")
             return false
         }
         return true

--- a/RemoteCam/SessionCoordinator.swift
+++ b/RemoteCam/SessionCoordinator.swift
@@ -801,6 +801,12 @@ public actor SessionCoordinator {
 
     private func inCameraTakingPic(_ msg: Message, sendMediaToPeer: Bool, generation: Int) async {
         switch msg {
+        case is RemoteCmd.RequestKeyframe:
+            // The preview keeps streaming while a picture is taken, so a monitor
+            // can desync here — and without this case the request falls through to
+            // handleRoot's unhandled default and is dropped silently.
+            frameSender?.requestKeyframe()
+
         case let timeout as UICmd.StateTimeout:
             guard timeout.stateName == .cameraTakingPic && timeout.generation == generation else { break }
             await dismissCameraAlert()
@@ -913,6 +919,12 @@ public actor SessionCoordinator {
 
     private func inCameraTransmittingVideo(_ msg: Message) async {
         switch msg {
+        case is RemoteCmd.RequestKeyframe:
+            // A video file transfer saturates the link while the preview keeps
+            // streaming, so this is one of the likeliest places to desync — and
+            // the one place the request used to be dropped on the floor.
+            frameSender?.requestKeyframe()
+
         case let started as UICmd.VideoResourceTransferStarted:
             ctrl?.cameraViewModel.startVideoTransfer(totalBytes: started.totalBytes)
 

--- a/RemoteCam/VP9FrameEncoder.swift
+++ b/RemoteCam/VP9FrameEncoder.swift
@@ -10,9 +10,16 @@
 //
 //  Per frame: downscale the 32BGRA capture buffer with vImage, convert to
 //  planar I420 (full-range ITU-R 601, mirrored by the Watch decoder), feed the
-//  Rust encoder. The Rust session is recreated whenever the scaled dimensions
-//  change (rotation, lens switch, camera flip) — a fresh session's first frame
-//  is a keyframe, so every geometry change re-syncs the stream for free.
+//  Rust encoder. The Rust session is recreated whenever the scaled *output*
+//  dimensions change, and a fresh session's first frame is a keyframe.
+//
+//  That is a narrower guarantee than it looks: a lens switch or camera flip
+//  usually scales to the same long edge, so the session is NOT recreated and the
+//  encoder happily predicts across a total scene cut. Such deltas decode without
+//  error, so the monitor never asks for a keyframe — it just renders smears.
+//  Discontinuities must therefore be announced explicitly (see
+//  `CaptureEngine.onDeviceSwapped` and `FrameSender.requestKeyframe`); only a
+//  genuine resolution change re-syncs on its own.
 //
 //  Confined to the capture queue like every FrameEncoding conformer; all
 //  buffers are reused across frames and never shared across threads.

--- a/RemoteCam/ZoomPill.swift
+++ b/RemoteCam/ZoomPill.swift
@@ -1,0 +1,230 @@
+#if targetEnvironment(macCatalyst)
+import SwiftUI
+
+/// Camera-style detented zoom control for the Mac monitor screen.
+///
+/// `MagnificationGesture` only fires from a trackpad pinch, so a mouse-only Mac has no
+/// way to zoom at all. This is that affordance: collapsed it shows the lens stops with
+/// the active one highlighted; dragging expands it into a ruler that snaps to those
+/// stops; releasing collapses it again.
+///
+/// Mac-only by design — iPhone and iPad keep pinch plus the auto-hiding zoom HUD.
+/// All zoom math is delegated to `ZoomScale`, which the pinch gesture shares.
+struct ZoomPill: View {
+    let scale: ZoomScale
+    /// Current zoom in hardware factors, as reported by the camera.
+    let currentZoomFactor: CGFloat
+    let onZoomChange: (CGFloat) -> Void
+
+    @State private var isExpanded = false
+    @State private var collapseWork: DispatchWorkItem?
+    /// What the user just asked for, shown immediately. `currentZoomFactor` only catches
+    /// up when the camera's SetZoomResp returns — a throttled send plus a peer-to-peer
+    /// round trip — so without this the thumb visibly trails the cursor.
+    @State private var pendingZoom: CGFloat?
+    @State private var isDragging = false
+
+    private static let trackWidth: CGFloat = 240
+    private static let horizontalPadding: CGFloat = 14
+    private static let height: CGFloat = 46
+    private static let stopDiameter: CGFloat = 30
+    private static let thumbWidth: CGFloat = 3
+    private static let tickCount = 41
+    /// How long the ruler lingers after the drag ends, so a repeated adjustment
+    /// doesn't have to re-expand each time.
+    private static let collapseDelay: TimeInterval = 1.2
+
+    var body: some View {
+        ZStack {
+            if isExpanded {
+                ruler
+            } else {
+                stopRow
+            }
+        }
+        .frame(width: Self.trackWidth, height: Self.height)
+        .padding(.horizontal, Self.horizontalPadding)
+        .background(glassBackground)
+        // The whole pill is draggable, not just the track, so there is no thin
+        // target to hunt for with a mouse.
+        .contentShape(Rectangle())
+        .gesture(dragGesture)
+        .animation(.easeOut(duration: 0.18), value: isExpanded)
+        .opacity(scale.isDegenerate ? 0 : 1)
+        .allowsHitTesting(!scale.isDegenerate)
+        // Hand control back to the camera once it confirms, but never mid-drag: a
+        // response for an earlier value would yank the thumb backwards under the cursor.
+        .onChange(of: currentZoomFactor) { _ in
+            if !isDragging { pendingZoom = nil }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Zoom")
+        .accessibilityValue(scale.label(forHardware: displayedZoom))
+        .accessibilityAdjustableAction { direction in
+            let step = 0.05
+            let position = scale.position(forHardware: displayedZoom)
+            switch direction {
+            case .increment: commit(scale.hardwareFactor(atPosition: position + step))
+            case .decrement: commit(scale.hardwareFactor(atPosition: position - step))
+            @unknown default: break
+            }
+        }
+    }
+
+    // MARK: - Collapsed: the lens stops
+
+    private var stopRow: some View {
+        ZStack(alignment: .leading) {
+            ForEach(scale.stops, id: \.self) { stop in
+                stopButton(stop)
+                    .offset(x: offset(forHardware: stop, itemWidth: Self.stopDiameter))
+            }
+        }
+        .frame(width: Self.trackWidth, alignment: .leading)
+    }
+
+    private func stopButton(_ stop: CGFloat) -> some View {
+        let isActive = stop == activeStop
+        return Text(labelText(for: stop))
+            .font(.system(size: isActive ? 13 : 12, weight: .semibold, design: .rounded))
+            .foregroundColor(isActive ? .black : .white.opacity(0.85))
+            .lineLimit(1)
+            .fixedSize()
+            .frame(width: Self.stopDiameter, height: Self.stopDiameter)
+            .background(
+                Circle().fill(isActive ? AppTheme.accent : Color.white.opacity(0.12))
+            )
+            .contentShape(Circle())
+            .onTapGesture { commit(scale.clamped(stop)) }
+    }
+
+    /// The zoom the pill draws: the user's in-flight value if there is one, otherwise
+    /// whatever the camera last confirmed.
+    private var displayedZoom: CGFloat { pendingZoom ?? currentZoomFactor }
+
+    /// The stop the pill highlights: whichever is nearest on the track.
+    private var activeStop: CGFloat? {
+        let position = scale.position(forHardware: displayedZoom)
+        return scale.stops.min {
+            abs(scale.position(forHardware: $0) - position)
+                < abs(scale.position(forHardware: $1) - position)
+        }
+    }
+
+    /// The active stop reads out the live factor ("2.4×") when zoom sits between stops,
+    /// and its own name ("2×") when parked on it — same as the Camera app.
+    private func labelText(for stop: CGFloat) -> String {
+        guard stop == activeStop else { return scale.label(forHardware: stop) }
+        return scale.label(forHardware: displayedZoom)
+    }
+
+    // MARK: - Expanded: the ruler
+
+    private var ruler: some View {
+        VStack(spacing: 4) {
+            Text(scale.label(forHardware: displayedZoom))
+                .font(.system(size: 12, weight: .semibold, design: .rounded))
+                .foregroundColor(.white)
+                .monospacedDigitIfAvailable()
+
+            ZStack(alignment: .leading) {
+                ticks
+                RoundedRectangle(cornerRadius: Self.thumbWidth / 2)
+                    .fill(AppTheme.accent)
+                    .frame(width: Self.thumbWidth, height: 20)
+                    .shadow(color: AppTheme.accent.opacity(0.5), radius: 3)
+                    .offset(x: offset(forHardware: displayedZoom, itemWidth: Self.thumbWidth))
+            }
+            .frame(width: Self.trackWidth, height: 20, alignment: .leading)
+        }
+    }
+
+    private var ticks: some View {
+        HStack(spacing: 0) {
+            ForEach(0..<Self.tickCount, id: \.self) { index in
+                let isStop = tickMarksAStop(index)
+                Rectangle()
+                    .fill(Color.white.opacity(isStop ? 0.9 : 0.3))
+                    .frame(width: isStop ? 2 : 1, height: isStop ? 16 : 8)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .frame(width: Self.trackWidth)
+    }
+
+    /// True when a lens stop falls within half a tick of this tick, so detents read as
+    /// taller marks rather than being drawn at a position no tick occupies.
+    private func tickMarksAStop(_ index: Int) -> Bool {
+        let spacing = 1.0 / Double(Self.tickCount - 1)
+        let position = Double(index) * spacing
+        return scale.stops.contains {
+            abs(scale.position(forHardware: $0) - position) < spacing / 2
+        }
+    }
+
+    // MARK: - Geometry
+
+    private func offset(forHardware hardware: CGFloat, itemWidth: CGFloat) -> CGFloat {
+        CGFloat(scale.position(forHardware: hardware)) * (Self.trackWidth - itemWidth)
+    }
+
+    // MARK: - Interaction
+
+    private var dragGesture: some Gesture {
+        DragGesture(minimumDistance: 2)
+            .onChanged { value in
+                cancelCollapse()
+                isDragging = true
+                if !isExpanded { isExpanded = true }
+                let x = value.location.x - Self.horizontalPadding
+                let raw = scale.hardwareFactor(atPosition: Double(x / Self.trackWidth))
+                commit(scale.snappedToStop(raw))
+            }
+            .onEnded { _ in
+                isDragging = false
+                scheduleCollapse()
+            }
+    }
+
+    private func commit(_ hardware: CGFloat) {
+        guard !scale.isDegenerate else { return }
+        pendingZoom = hardware
+        onZoomChange(hardware)
+    }
+
+    private func scheduleCollapse() {
+        cancelCollapse()
+        let work = DispatchWorkItem { isExpanded = false }
+        collapseWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.collapseDelay, execute: work)
+    }
+
+    private func cancelCollapse() {
+        collapseWork?.cancel()
+        collapseWork = nil
+    }
+
+    // MARK: - Chrome
+
+    private var glassBackground: some View {
+        ZStack {
+            Color.black.opacity(0.3)
+                .background(.ultraThinMaterial)
+                .clipShape(Capsule())
+            Capsule().stroke(Color.white.opacity(0.25), lineWidth: 1)
+        }
+    }
+}
+
+private extension View {
+    /// The ruler's readout changes every frame during a drag; monospaced digits stop it
+    /// jittering. `.monospacedDigit()` is iOS 16+, and the deployment target is 15.
+    @ViewBuilder func monospacedDigitIfAvailable() -> some View {
+        if #available(iOS 16.0, *) {
+            self.monospacedDigit()
+        } else {
+            self
+        }
+    }
+}
+#endif

--- a/RemoteCam/ZoomPill.swift
+++ b/RemoteCam/ZoomPill.swift
@@ -22,13 +22,19 @@ struct ZoomPill: View {
     /// up when the camera's SetZoomResp returns — a throttled send plus a peer-to-peer
     /// round trip — so without this the thumb visibly trails the cursor.
     @State private var pendingZoom: CGFloat?
-    @State private var isDragging = false
+    @State private var isAdjusting = false
 
     private static let trackWidth: CGFloat = 240
     private static let horizontalPadding: CGFloat = 14
     private static let height: CGFloat = 46
-    private static let stopDiameter: CGFloat = 30
+    private static let stopDiameter: CGFloat = 32
+    /// Breathing room between the number and the circle's edge.
+    private static let stopTextInset: CGFloat = 5
     private static let thumbWidth: CGFloat = 3
+    /// Track fraction travelled per point of scroll. A wheel notch is ~10pt, so a notch
+    /// moves ~3% of the range — fine enough to land on a value, coarse enough to cross
+    /// the whole range without spinning forever.
+    private static let scrollSensitivity: Double = 0.003
     private static let tickCount = 41
     /// How long the ruler lingers after the drag ends, so a repeated adjustment
     /// doesn't have to re-expand each time.
@@ -45,6 +51,15 @@ struct ZoomPill: View {
         .frame(width: Self.trackWidth, height: Self.height)
         .padding(.horizontal, Self.horizontalPadding)
         .background(glassBackground)
+        // Scrolling over the pill zooms — reaching for the wheel is the reflex on a Mac.
+        // Behind the content so it never intercepts the drag.
+        .background(
+            ScrollWheelCatcher(onScroll: handleScroll,
+                               onEnded: {
+                                   isAdjusting = false
+                                   scheduleCollapse()
+                               })
+        )
         // The whole pill is draggable, not just the track, so there is no thin
         // target to hunt for with a mouse.
         .contentShape(Rectangle())
@@ -55,7 +70,7 @@ struct ZoomPill: View {
         // Hand control back to the camera once it confirms, but never mid-drag: a
         // response for an earlier value would yank the thumb backwards under the cursor.
         .onChange(of: currentZoomFactor) { _ in
-            if !isDragging { pendingZoom = nil }
+            if !isAdjusting { pendingZoom = nil }
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Zoom")
@@ -86,10 +101,15 @@ struct ZoomPill: View {
     private func stopButton(_ stop: CGFloat) -> some View {
         let isActive = stop == activeStop
         return Text(labelText(for: stop))
-            .font(.system(size: isActive ? 13 : 12, weight: .semibold, design: .rounded))
+            .font(.system(size: isActive ? 11.5 : 11, weight: .semibold, design: .rounded))
             .foregroundColor(isActive ? .black : .white.opacity(0.85))
             .lineLimit(1)
-            .fixedSize()
+            // The active circle reads out the live factor, so it can be as wide as "2.4×"
+            // where a stop's own name is just "1×". Scale the wide one down to fit rather
+            // than letting it spill past the circle, and keep an inset so glyphs never
+            // touch the edge. (Sizing the text before the frame is what bounds it.)
+            .minimumScaleFactor(0.7)
+            .padding(.horizontal, Self.stopTextInset)
             .frame(width: Self.stopDiameter, height: Self.stopDiameter)
             .background(
                 Circle().fill(isActive ? AppTheme.accent : Color.white.opacity(0.12))
@@ -174,16 +194,32 @@ struct ZoomPill: View {
         DragGesture(minimumDistance: 2)
             .onChanged { value in
                 cancelCollapse()
-                isDragging = true
+                isAdjusting = true
                 if !isExpanded { isExpanded = true }
                 let x = value.location.x - Self.horizontalPadding
                 let raw = scale.hardwareFactor(atPosition: Double(x / Self.trackWidth))
                 commit(scale.snappedToStop(raw))
             }
             .onEnded { _ in
-                isDragging = false
+                isAdjusting = false
                 scheduleCollapse()
             }
+    }
+
+    /// Mouse wheel / trackpad scroll: nudge along the track from wherever zoom is now.
+    /// Scrolling up (negative delta) zooms in, matching the direction the content appears
+    /// to move in Maps and Photos.
+    private func handleScroll(_ delta: CGFloat) {
+        guard !scale.isDegenerate else { return }
+        cancelCollapse()
+        // Same as a drag: hold off the camera's confirmations until the user stops, or a
+        // response for an earlier value resets pendingZoom and the next scroll steps from
+        // a stale position.
+        isAdjusting = true
+        if !isExpanded { isExpanded = true }
+        let position = scale.position(forHardware: displayedZoom)
+        let moved = position - Double(delta) * Self.scrollSensitivity
+        commit(scale.snappedToStop(scale.hardwareFactor(atPosition: moved)))
     }
 
     private func commit(_ hardware: CGFloat) {
@@ -212,6 +248,63 @@ struct ZoomPill: View {
                 .background(.ultraThinMaterial)
                 .clipShape(Capsule())
             Capsule().stroke(Color.white.opacity(0.25), lineWidth: 1)
+        }
+    }
+}
+
+/// Delivers mouse-wheel and trackpad scrolls to SwiftUI, which has no gesture for them.
+///
+/// A `UIPanGestureRecognizer` with `allowedScrollTypesMask` is UIKit's way to receive
+/// indirect scrolls. `allowedTouchTypes = []` makes it a scroll-only recognizer, so it
+/// cannot compete with the pill's `DragGesture` for click-drags.
+private struct ScrollWheelCatcher: UIViewRepresentable {
+    /// Vertical scroll delta in points, positive when scrolling down.
+    let onScroll: (CGFloat) -> Void
+    let onEnded: () -> Void
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.backgroundColor = .clear
+        let pan = UIPanGestureRecognizer(target: context.coordinator,
+                                         action: #selector(Coordinator.handleScroll(_:)))
+        pan.allowedScrollTypesMask = .all
+        pan.allowedTouchTypes = []  // scroll events only — leave touches to SwiftUI
+        view.addGestureRecognizer(pan)
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        context.coordinator.onScroll = onScroll
+        context.coordinator.onEnded = onEnded
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(onScroll: onScroll, onEnded: onEnded) }
+
+    final class Coordinator: NSObject {
+        var onScroll: (CGFloat) -> Void
+        var onEnded: () -> Void
+        /// `translation` is cumulative for the gesture; the pill wants per-event deltas.
+        private var lastTranslation: CGFloat = 0
+
+        init(onScroll: @escaping (CGFloat) -> Void, onEnded: @escaping () -> Void) {
+            self.onScroll = onScroll
+            self.onEnded = onEnded
+        }
+
+        @objc func handleScroll(_ pan: UIPanGestureRecognizer) {
+            switch pan.state {
+            case .began:
+                lastTranslation = 0
+            case .changed:
+                let translation = pan.translation(in: pan.view).y
+                onScroll(translation - lastTranslation)
+                lastTranslation = translation
+            case .ended, .cancelled, .failed:
+                lastTranslation = 0
+                onEnded()
+            default:
+                break
+            }
         }
     }
 }

--- a/RemoteCam/ZoomScale.swift
+++ b/RemoteCam/ZoomScale.swift
@@ -1,0 +1,116 @@
+import CoreGraphics
+import Foundation
+
+/// Single source of truth for monitor-side zoom math.
+///
+/// The camera reports zoom as a *hardware* factor (`AVCaptureDevice.videoZoomFactor`),
+/// but the user reads a *display* factor: "1×" means the wide-angle lens, which on a
+/// triple-camera iPhone is hardware 2.0. Conversion, clamping, ruler geometry, detents
+/// and label formatting all live here so the pinch gesture and the Mac zoom pill cannot
+/// drift apart, and so no call site has to remember which unit it is holding.
+///
+/// Pure value type — no UIKit, no AVFoundation, no actor. Pinned by `ZoomScaleTests`.
+struct ZoomScale: Equatable {
+    /// Lens switch-over points in hardware factors, ascending. Never empty.
+    let stops: [CGFloat]
+    /// The hardware factor the user reads as "1×".
+    let wideAngleZoomFactor: CGFloat
+    let minZoom: CGFloat
+    let maxZoom: CGFloat
+
+    init(stops: [CGFloat], maxZoomFactor: CGFloat, wideAngleZoomFactor: CGFloat) {
+        let usable = stops.filter { $0.isFinite && $0 > 0 }.sorted()
+        let safeStops = usable.isEmpty ? [1.0] : usable
+        let low = safeStops[0]
+        // `maxZoomFactor` arrives as a default (10.0) before the first SetZoomResp and can
+        // legitimately land at or below the low stop on a fixed-focal-length camera.
+        let ceiling = (maxZoomFactor.isFinite && maxZoomFactor > low) ? maxZoomFactor : low
+
+        self.minZoom = low
+        self.maxZoom = ceiling
+        self.wideAngleZoomFactor =
+            (wideAngleZoomFactor.isFinite && wideAngleZoomFactor > 0) ? wideAngleZoomFactor : 1.0
+        // A stop past the ceiling can't be reached, so it must not be offered as a detent.
+        // `low` always survives, so this can never empty the array.
+        self.stops = safeStops.filter { $0 <= ceiling }
+    }
+
+    /// True when the range has collapsed and there is nothing to zoom: before the first
+    /// `SetZoomResp` lands, or on a camera with a single fixed focal length. Callers must
+    /// check this before drawing a track — a SwiftUI `Slider` traps on an empty range.
+    var isDegenerate: Bool { maxZoom <= minZoom }
+
+    private var logMin: Double { Double(log2(minZoom)) }
+    private var logSpan: Double { Double(log2(maxZoom)) - logMin }
+
+    func clamped(_ hardware: CGFloat) -> CGFloat {
+        guard hardware.isFinite else { return minZoom }
+        return max(minZoom, min(maxZoom, hardware))
+    }
+
+    // MARK: - Display units
+
+    func displayFactor(forHardware hardware: CGFloat) -> CGFloat {
+        hardware / wideAngleZoomFactor
+    }
+
+    var displayStops: [CGFloat] { stops.map { displayFactor(forHardware: $0) } }
+
+    /// Formats a hardware factor as a user-facing label, e.g. hardware 1.0 against a
+    /// wide-angle factor of 2.0 → "0.5×", hardware 2.0 → "1×", hardware 6.0 → "3×".
+    func label(forHardware hardware: CGFloat, glyph: String = "×") -> String {
+        let rounded = (displayFactor(forHardware: hardware) * 10).rounded() / 10
+        if rounded == CGFloat(Int(rounded)) {
+            return "\(Int(rounded))\(glyph)"
+        }
+        return String(format: "%.1f", rounded) + glyph
+    }
+
+    // MARK: - Ruler geometry
+
+    /// Where `hardware` sits on a 0…1 track. Log2 so equal travel is equal perceived
+    /// change at 1× and at 5×, matching the pinch curve.
+    func position(forHardware hardware: CGFloat) -> Double {
+        guard !isDegenerate else { return 0 }
+        return (Double(log2(clamped(hardware))) - logMin) / logSpan
+    }
+
+    func hardwareFactor(atPosition position: Double) -> CGFloat {
+        guard !isDegenerate, position.isFinite else { return minZoom }
+        let clampedPosition = max(0, min(1, position))
+        // Exact at the ends. Round-tripping through log2/pow2 leaves a max of 5.0 as
+        // 4.999999999999999, so a drag to the end of the ruler would stop a hair short
+        // of the ceiling and never compare equal to `maxZoom`.
+        if clampedPosition <= 0 { return minZoom }
+        if clampedPosition >= 1 { return maxZoom }
+        return clamped(CGFloat(pow(2, logMin + clampedPosition * logSpan)))
+    }
+
+    // MARK: - Detents
+
+    /// Snaps to the nearest stop when within `tolerance` of it. Tolerance is a fraction of
+    /// the whole track, not a zoom delta, so the pull feels identical at 1× and at 5×.
+    func snappedToStop(_ hardware: CGFloat, tolerance: Double = 0.04) -> CGFloat {
+        guard !isDegenerate else { return minZoom }
+        let target = clamped(hardware)
+        let targetPosition = position(forHardware: target)
+        let nearest = stops.min {
+            abs(position(forHardware: $0) - targetPosition)
+                < abs(position(forHardware: $1) - targetPosition)
+        }
+        guard let stop = nearest,
+              abs(position(forHardware: stop) - targetPosition) <= tolerance else { return target }
+        return stop
+    }
+
+    // MARK: - Pinch
+
+    /// `newZoom = start * magnification^sensitivity`, evaluated in log2 space so a given
+    /// finger movement changes zoom by the same perceptual amount across the range.
+    func pinched(from start: CGFloat, magnification: CGFloat, sensitivity: CGFloat = 0.6) -> CGFloat {
+        guard start > 0, start.isFinite, magnification > 0, magnification.isFinite else {
+            return clamped(start)
+        }
+        return clamped(pow(2, log2(start) + log2(magnification) * sensitivity))
+    }
+}

--- a/RemoteCamTests/CaptureIntegrationTests.swift
+++ b/RemoteCamTests/CaptureIntegrationTests.swift
@@ -173,6 +173,215 @@ final class CaptureIntegrationTests: XCTestCase {
         }
     }
 
+    // MARK: - Recording
+
+    /// Counts audio sample buffers straight off the capture stack.
+    private final class AudioProbe: NSObject, AVCaptureAudioDataOutputSampleBufferDelegate {
+        let samples = Locked(0)
+        func captureOutput(_ output: AVCaptureOutput,
+                           didOutput sampleBuffer: CMSampleBuffer,
+                           from connection: AVCaptureConnection) {
+            samples.mutate { $0 += 1 }
+        }
+    }
+
+    /// A missing mic TCC grant produces "no audio samples" for a reason that has
+    /// nothing to do with the recording bug. Skip loudly rather than fail, so a
+    /// permission problem can never be mistaken for the capture problem.
+    private static func skipUnlessMicAuthorized() async throws {
+        var status = AVCaptureDevice.authorizationStatus(for: .audio)
+        if status == .notDetermined {
+            status = await AVCaptureDevice.requestAccess(for: .audio) ? .authorized : .denied
+        }
+        guard status == .authorized else {
+            throw XCTSkip("""
+                no microphone permission for the test host (status \(status.rawValue)) — grant it \
+                under System Settings > Privacy & Security > Microphone. Until then this run says \
+                nothing about recording.
+                """)
+        }
+    }
+
+    /// `configureAudioForRecording` is the value `RecordingPipeline` trusts to decide
+    /// whether a recording can proceed. If it reports success without actually
+    /// attaching audio, the pipeline arms a recording that can never start: no audio
+    /// sample ⇒ `readyToRecordAudio` never flips ⇒ `isRecording` never flips ⇒ stop
+    /// silently no-ops and both devices hang. So its verdict must match reality.
+    func testAudioConfigurationVerdictMatchesReality() async throws {
+        try await startRealRig()
+        try await Self.skipUnlessMicAuthorized()
+        guard await waitForFrames(since: 0) != nil else {
+            return XCTFail("startup never delivered frames — \(await diagnostics())")
+        }
+
+        print("🎙 default audio device: \(AVCaptureDevice.default(for: .audio)?.localizedName ?? "NONE")")
+
+        let verdict = rig.engine.configureAudioForRecording(delegate: AudioProbe())
+
+        let session = rig.engine.captureSession
+        let input = session.inputs
+            .compactMap { $0 as? AVCaptureDeviceInput }
+            .first { $0.device.hasMediaType(.audio) }
+        let output = session.outputs.first { $0 is AVCaptureAudioDataOutput }
+
+        print("""
+            🎙 verdict=\(verdict) \
+            input=\(input?.device.localizedName ?? "NOT ATTACHED") \
+            output=\(output == nil ? "NOT ATTACHED" : "attached") \
+            connection=\(rig.engine.audioConnection == nil ? "nil" : "live")
+            """)
+
+        XCTAssertEqual(verdict, input != nil && output != nil, """
+            configureAudioForRecording returned \(verdict) but audio input attached=\(input != nil), \
+            output attached=\(output != nil). A false success is what strands the recording.
+            """)
+    }
+
+    /// Attaching audio isn't enough: the pipeline only becomes ready on a real audio
+    /// sample buffer (RecordingPipeline `readyToRecordAudio`). If the device attaches
+    /// but never delivers, the symptom is identical to a failed attach.
+    func testAudioSamplesActuallyArrive() async throws {
+        try await startRealRig()
+        try await Self.skipUnlessMicAuthorized()
+        guard await waitForFrames(since: 0) != nil else {
+            return XCTFail("startup never delivered frames — \(await diagnostics())")
+        }
+
+        let probe = AudioProbe()
+        guard rig.engine.configureAudioForRecording(delegate: probe) else {
+            throw XCTSkip("audio could not be configured at all — testAudioConfigurationVerdictMatchesReality has the detail")
+        }
+
+        let deadline = Date().addingTimeInterval(5)
+        while probe.samples.value == 0 && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        print("🎙 audio sample buffers in 5s: \(probe.samples.value)")
+        XCTAssertGreaterThan(probe.samples.value, 0, """
+            no audio sample buffers within 5s. readyToRecordAudio can therefore never flip, so \
+            recording never starts and stopRecording silently does nothing — the hang.
+            """)
+    }
+
+    private func scratchWriter() throws -> AVAssetWriter {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("probe-\(UUID().uuidString).mov")
+        return try AVAssetWriter(outputURL: url, fileType: .mov)
+    }
+
+    /// Pinpoints WHICH asset-writer input can't be configured on this machine.
+    /// `setupAssetWriterVideoInput` and `setupAssetWriterAudioInput` both return false
+    /// silently when `canApply`/`canAdd` rejects their settings, and a false from
+    /// either leaves its ready flag off forever — which is precisely what strands the
+    /// recording and hangs both devices.
+    func testAssetWriterInputsConfigureOnThisHardware() async throws {
+        try await startRealRig()
+        try await Self.skipUnlessMicAuthorized()
+        guard await waitForFrames(since: 0) != nil else {
+            return XCTFail("startup never delivered frames — \(await diagnostics())")
+        }
+        // The real AVFoundation device, not the app's descriptor — we need its format.
+        guard let device = rig.engine.captureSession.inputs
+            .compactMap({ $0 as? AVCaptureDeviceInput })
+            .first(where: { $0.device.hasMediaType(.video) })?.device else {
+            return XCTFail("no video device input on the session — \(await diagnostics())")
+        }
+        print("🎬 video device: \(device.localizedName)")
+
+        // What the capture stack recommends, and whether forcing HEVC onto it survives.
+        let recommended = rig.engine.videoDataOutput.recommendedVideoSettingsForAssetWriter(writingTo: .mov)
+        print("🎬 recommended video settings: \(recommended.map { String(describing: $0) } ?? "NIL")")
+
+        var withHEVC = recommended
+        withHEVC?[AVVideoCodecKey] = AVVideoCodecType.hevc
+        var withH264 = recommended
+        withH264?[AVVideoCodecKey] = AVVideoCodecType.h264
+
+        let probe = try scratchWriter()
+        print("""
+            🎬 canApply: recommended=\(probe.canApply(outputSettings: recommended, forMediaType: .video)) \
+            +hevc=\(probe.canApply(outputSettings: withHEVC, forMediaType: .video)) \
+            +h264=\(probe.canApply(outputSettings: withH264, forMediaType: .video))
+            """)
+
+        // Is HEVC itself unsupported here, or only HEVC *merged into* the recommended
+        // settings (whose compression properties are keyed to the recommended codec)?
+        let dims = CMVideoFormatDescriptionGetDimensions(device.activeFormat.formatDescription)
+        let bareHEVC: [String: Any] = [
+            AVVideoCodecKey: AVVideoCodecType.hevc,
+            AVVideoWidthKey: Int(dims.width),
+            AVVideoHeightKey: Int(dims.height)
+        ]
+        let recommendedForHEVC = rig.engine.videoDataOutput
+            .recommendedVideoSettings(forVideoCodecType: .hevc, assetWriterOutputFileType: .mov)
+        print("""
+            🎬 canApply: bare-hevc=\(probe.canApply(outputSettings: bareHEVC, forMediaType: .video)) \
+            hevc-recommended=\(recommendedForHEVC.map { probe.canApply(outputSettings: $0, forMediaType: .video) }.map(String.init) ?? "NIL-SETTINGS")
+            """)
+        print("🎬 recommendedVideoSettings(forVideoCodecType: .hevc) = \(recommendedForHEVC.map { String(describing: $0) } ?? "NIL")")
+
+        // The real code path, with this machine's real format description.
+        let videoOK = rig.pipeline.setupAssetWriterVideoInput(device.activeFormat.formatDescription,
+                                                              assetWriter: try scratchWriter())
+        print("🎬 setupAssetWriterVideoInput → \(videoOK)")
+
+        var audioOK: Bool?
+        if let audioFormat = AVCaptureDevice.default(for: .audio)?.activeFormat.formatDescription {
+            audioOK = rig.pipeline.setupAssetWriterAudioInput(audioFormat, assetWriter: try scratchWriter())
+            print("🎙 setupAssetWriterAudioInput → \(audioOK!)")
+        }
+
+        XCTAssertTrue(videoOK, """
+            the VIDEO asset-writer input could not be configured on this hardware, so \
+            readyToRecordVideo can never flip and recording can never start.
+            """)
+        XCTAssertNotEqual(audioOK, false, """
+            the AUDIO asset-writer input could not be configured on this hardware, so \
+            readyToRecordAudio can never flip and recording can never start.
+            """)
+    }
+
+    /// The product invariant, end to end on real hardware: a recording starts, and
+    /// stopping it resolves the protocol with a StopRecordingVideoResp — the message
+    /// the monitor blocks on in `.monitorWaitingForVideo`.
+    func testRecordingStartsAndStopEmitsAResponse() async throws {
+        try await startRealRig()
+        try await Self.skipUnlessMicAuthorized()
+        guard await waitForFrames(since: 0) != nil else {
+            return XCTFail("startup never delivered frames — \(await diagnostics())")
+        }
+
+        // Intercept the pipeline's outbound messages: this is exactly what the
+        // session coordinator (and so the monitor) waits for.
+        let responded = expectation(description: "StopRecordingVideoResp")
+        responded.assertForOverFulfill = false
+        var startAcked = false
+        rig.pipeline.sendMessage = { msg in
+            if msg is RemoteCmd.StartRecordingVideoAck { startAcked = true }
+            if msg is RemoteCmd.StopRecordingVideoResp { responded.fulfill() }
+        }
+
+        rig.startRecordingVideo()
+
+        let deadline = Date().addingTimeInterval(10)
+        while !rig.isRecording && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        let diag = await diagnostics()
+        XCTAssertTrue(rig.isRecording, """
+            recording never started within 10s (startAcked=\(startAcked)). \(diag)
+            """)
+
+        try? await Task.sleep(nanoseconds: 1_000_000_000)  // ~1s of footage
+
+        // false = don't ship the movie to a peer; the pipeline then answers directly
+        // instead of going through a resource transfer that needs a live peer.
+        rig.stopRecordingVideo(false)
+
+        await fulfillment(of: [responded], timeout: 15)
+    }
+
     func testToggleKeepsFramesFlowing() async throws {
         try await startRealRig()
         guard await waitForFrames(since: 0) != nil else {

--- a/RemoteCamTests/FrameSenderTests.swift
+++ b/RemoteCamTests/FrameSenderTests.swift
@@ -9,6 +9,7 @@
 
 import XCTest
 import MultipeerConnectivity
+import UIKit
 
 @testable import RemoteShutter
 
@@ -191,5 +192,35 @@ class FrameSenderTests: XCTestCase {
         frameSender.setSession(peer: peer, transport: fakeMP)
         frameSender.drain()
         XCTAssertEqual(frameSender.windowSnapshot().inFlight, 0)
+    }
+
+    // MARK: - Keyframe triggers
+
+    /// Binding a peer is the moment the stream starts flowing — and it is re-entered
+    /// after a photo or a video transfer. The monitor's decoder cannot safely predict
+    /// from whatever it held before, so the first frame back must stand alone.
+    func testSetSessionArmsAKeyframe() {
+        let sender = FrameSender()
+        XCTAssertFalse(sender.takeKeyframeRequest(), "nothing armed before binding")
+
+        sender.setSession(peer: peer, transport: fakeMP)
+        sender.drain()
+
+        XCTAssertTrue(sender.takeKeyframeRequest(), "binding a peer must arm a keyframe")
+        XCTAssertFalse(sender.takeKeyframeRequest(), "consumed exactly once")
+    }
+
+    /// Coming back from the background, this encoder carries on from its own state
+    /// while the monitor's decoder still holds pre-freeze references. The deltas
+    /// decode without error, so nothing else would ever prompt a keyframe.
+    func testForegroundingArmsAKeyframe() {
+        let center = NotificationCenter()
+        let sender = FrameSender(notificationCenter: center)
+        XCTAssertFalse(sender.takeKeyframeRequest(), "nothing armed at rest")
+
+        center.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        XCTAssertTrue(sender.takeKeyframeRequest(), "foregrounding must arm a keyframe")
+        XCTAssertFalse(sender.takeKeyframeRequest(), "consumed exactly once")
     }
 }

--- a/RemoteCamTests/LoopbackSessionTests.swift
+++ b/RemoteCamTests/LoopbackSessionTests.swift
@@ -28,7 +28,19 @@ class LoopbackMultipeerService: MultipeerServiceProtocol {
     var progressCancellables = Set<AnyCancellable>()
 
     /// Messages sent from this side, recorded before serialization.
-    var sentMessages: [Message] = []
+    ///
+    /// Lock-backed rather than a plain array: `send(_:to:mode:)` is called from the
+    /// coordinator's actor context while the test body reads this from the test thread.
+    /// As a bare `[Message]` that was a data race, which Thread Sanitizer turned into a
+    /// crash (`sentMessages.modify`) on roughly half of all TSan runs of this suite.
+    ///
+    /// The public shape is unchanged — still a settable `[Message]` — so reads and the
+    /// `removeAll()` calls throughout these tests keep working untouched.
+    private let sentMessagesStorage = Locked<[Message]>([])
+    var sentMessages: [Message] {
+        get { sentMessagesStorage.value }
+        set { sentMessagesStorage.value = newValue }
+    }
 
     init(peerName: String) {
         localPeerID = MCPeerID(displayName: peerName)
@@ -52,7 +64,9 @@ class LoopbackMultipeerService: MultipeerServiceProtocol {
 
     func send(_ msg: Message, to peers: [MCPeerID],
               mode: MCSessionSendDataMode) -> Try<Message> {
-        sentMessages.append(msg)
+        // One lock acquisition: going through the computed property would read, append to
+        // a copy, then write back, losing a concurrent append.
+        sentMessagesStorage.mutate { $0.append(msg) }
 
         guard let data = serializeToFlatBuffer(msg) else {
             return Failure(error: NSError(

--- a/RemoteCamTests/RemoteCamSessionTests.swift
+++ b/RemoteCamTests/RemoteCamSessionTests.swift
@@ -1141,6 +1141,46 @@ class SessionCoordinatorTests: XCTestCase {
                        "straggler failures after the pop must not restart discovery again")
     }
 
+    // MARK: - Keyframe requests across camera states
+
+    /// The preview keeps streaming while a picture is taken, so the monitor can
+    /// desync there. The request used to fall through to handleRoot's unhandled
+    /// default and vanish.
+    func testKeyframeRequestHonoredWhileTakingPicture() async {
+        let sender = FrameSender()
+        harness.coordinator.setFrameSender(sender)
+        sender.drain()
+        _ = sender.takeKeyframeRequest()  // clear anything the seed armed
+
+        await harness.coordinator.seed(state: .cameraTakingPic(sendMediaToPeer: true, generation: 0),
+                                       lobby: harness.lobbyWrapper,
+                                       peer: harness.peer,
+                                       ctrl: FakeCameraControlling())
+        await harness.deliver(RemoteCmd.RequestKeyframe(sender: nil))
+
+        XCTAssertTrue(sender.takeKeyframeRequest(),
+                      "a keyframe request must not be dropped while taking a picture")
+    }
+
+    /// A video file transfer saturates the link while the preview keeps flowing,
+    /// making this the likeliest place to desync — and the one place the request
+    /// was silently discarded.
+    func testKeyframeRequestHonoredWhileTransmittingVideo() async {
+        let sender = FrameSender()
+        harness.coordinator.setFrameSender(sender)
+        sender.drain()
+        _ = sender.takeKeyframeRequest()
+
+        await harness.coordinator.seed(state: .cameraTransmittingVideo,
+                                       lobby: harness.lobbyWrapper,
+                                       peer: harness.peer,
+                                       ctrl: FakeCameraControlling())
+        await harness.deliver(RemoteCmd.RequestKeyframe(sender: nil))
+
+        XCTAssertTrue(sender.takeKeyframeRequest(),
+                      "a keyframe request must not be dropped while transmitting video")
+    }
+
     /// The pipeline refuses to record when audio can't be configured and
     /// reports MicrophoneAccessDenied. The recording state must answer the
     /// monitor with the stop ack + an error response, and return to camera.

--- a/RemoteCamTests/ZoomScaleTests.swift
+++ b/RemoteCamTests/ZoomScaleTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+@testable import RemoteShutter
+
+final class ZoomScaleTests: XCTestCase {
+
+    /// Single-lens iPhone / Mac webcam: wide angle is hardware 1.0.
+    private let singleLens = ZoomScale(stops: [1.0], maxZoomFactor: 5.0, wideAngleZoomFactor: 1.0)
+
+    /// Triple-camera iPhone: ultra-wide is the base, so the wide angle the user calls
+    /// "1×" is hardware 2.0, and 5× display is hardware 10.0.
+    private let tripleCamera = ZoomScale(stops: [1.0, 2.0, 6.0], maxZoomFactor: 10.0, wideAngleZoomFactor: 2.0)
+
+    // MARK: - Clamping
+
+    func testClampsToRange() {
+        XCTAssertEqual(singleLens.clamped(0.1), 1.0)
+        XCTAssertEqual(singleLens.clamped(99.0), 5.0)
+        XCTAssertEqual(singleLens.clamped(2.5), 2.5)
+    }
+
+    func testClampRejectsNonFiniteInput() {
+        XCTAssertEqual(singleLens.clamped(.nan), 1.0)
+        XCTAssertEqual(singleLens.clamped(.infinity), 1.0)
+    }
+
+    // MARK: - Display units
+
+    func testDisplayFactorIsRelativeToWideAngle() {
+        // The whole point of the conversion: hardware 2.0 is what the user calls "1×".
+        XCTAssertEqual(tripleCamera.displayFactor(forHardware: 2.0), 1.0, accuracy: 0.0001)
+        XCTAssertEqual(tripleCamera.displayFactor(forHardware: 1.0), 0.5, accuracy: 0.0001)
+        XCTAssertEqual(tripleCamera.displayFactor(forHardware: 10.0), 5.0, accuracy: 0.0001)
+    }
+
+    func testDisplayStopsMatchTheLensesTheUserSees() {
+        XCTAssertEqual(tripleCamera.displayStops, [0.5, 1.0, 3.0])
+    }
+
+    func testLabelDropsTrailingZeroAndKeepsOneDecimal() {
+        XCTAssertEqual(tripleCamera.label(forHardware: 2.0), "1×")
+        XCTAssertEqual(tripleCamera.label(forHardware: 1.0), "0.5×")
+        XCTAssertEqual(tripleCamera.label(forHardware: 4.8), "2.4×")
+        XCTAssertEqual(tripleCamera.label(forHardware: 2.0, glyph: "x"), "1x")
+    }
+
+    // MARK: - Ruler geometry
+
+    func testPositionSpansTheFullTrack() {
+        XCTAssertEqual(singleLens.position(forHardware: 1.0), 0.0, accuracy: 0.0001)
+        XCTAssertEqual(singleLens.position(forHardware: 5.0), 1.0, accuracy: 0.0001)
+    }
+
+    func testPositionIsLogarithmic() {
+        // The geometric midpoint of 1…5 is sqrt(5) ≈ 2.236, not the arithmetic mean of 3.
+        XCTAssertEqual(singleLens.position(forHardware: CGFloat(5.0).squareRoot()), 0.5, accuracy: 0.0001)
+    }
+
+    func testPositionRoundTrips() {
+        for hardware in stride(from: 1.0, through: 10.0, by: 0.25) {
+            let position = tripleCamera.position(forHardware: CGFloat(hardware))
+            XCTAssertEqual(tripleCamera.hardwareFactor(atPosition: position),
+                           CGFloat(hardware),
+                           accuracy: 0.0001,
+                           "round trip failed at \(hardware)")
+        }
+    }
+
+    func testPositionClampsOutOfRangeInput() {
+        XCTAssertEqual(singleLens.position(forHardware: 99.0), 1.0, accuracy: 0.0001)
+        XCTAssertEqual(singleLens.position(forHardware: 0.01), 0.0, accuracy: 0.0001)
+        XCTAssertEqual(singleLens.hardwareFactor(atPosition: 2.0), 5.0)
+        XCTAssertEqual(singleLens.hardwareFactor(atPosition: -1.0), 1.0)
+    }
+
+    // MARK: - Detents
+
+    func testSnapsToNearbyStop() {
+        // Just off the hardware-6.0 stop — close enough to pull in.
+        XCTAssertEqual(tripleCamera.snappedToStop(6.05), 6.0)
+    }
+
+    func testDoesNotSnapWhenFarFromAnyStop() {
+        // Midway between the 2.0 and 6.0 stops: the user meant this value.
+        XCTAssertEqual(tripleCamera.snappedToStop(3.5), 3.5, accuracy: 0.0001)
+    }
+
+    func testSnapToleranceIsUniformAcrossTheRange() {
+        // Same fractional distance from a stop at each end must snap the same way,
+        // even though the absolute zoom deltas differ by 6x.
+        let lowSide = tripleCamera.hardwareFactor(
+            atPosition: tripleCamera.position(forHardware: 1.0) + 0.02)
+        let highSide = tripleCamera.hardwareFactor(
+            atPosition: tripleCamera.position(forHardware: 6.0) + 0.02)
+        XCTAssertEqual(tripleCamera.snappedToStop(lowSide), 1.0)
+        XCTAssertEqual(tripleCamera.snappedToStop(highSide), 6.0)
+    }
+
+    // MARK: - Degenerate ranges
+
+    func testDegenerateRangeIsFlaggedAndNeverDividesByZero() {
+        // maxZoomFactor below the low stop: what the view model holds before the first
+        // SetZoomResp arrives. Must not produce NaN or trap.
+        let collapsed = ZoomScale(stops: [1.0], maxZoomFactor: 1.0, wideAngleZoomFactor: 1.0)
+        XCTAssertTrue(collapsed.isDegenerate)
+        XCTAssertEqual(collapsed.position(forHardware: 1.0), 0.0)
+        XCTAssertEqual(collapsed.hardwareFactor(atPosition: 0.5), 1.0)
+        XCTAssertEqual(collapsed.snappedToStop(1.0), 1.0)
+        XCTAssertFalse(collapsed.position(forHardware: 1.0).isNaN)
+    }
+
+    func testMaxBelowMinCollapsesRatherThanInverting() {
+        let inverted = ZoomScale(stops: [2.0], maxZoomFactor: 1.0, wideAngleZoomFactor: 1.0)
+        XCTAssertEqual(inverted.minZoom, 2.0)
+        XCTAssertEqual(inverted.maxZoom, 2.0)
+        XCTAssertTrue(inverted.isDegenerate)
+    }
+
+    func testEmptyStopsFallBackToUnityRatherThanCrashing() {
+        let empty = ZoomScale(stops: [], maxZoomFactor: 5.0, wideAngleZoomFactor: 1.0)
+        XCTAssertEqual(empty.stops, [1.0])
+        XCTAssertEqual(empty.minZoom, 1.0)
+    }
+
+    func testUnreachableStopsAreNotOfferedAsDetents() {
+        // A 6.0 stop is meaningless when the camera caps at 3.0.
+        let capped = ZoomScale(stops: [1.0, 2.0, 6.0], maxZoomFactor: 3.0, wideAngleZoomFactor: 1.0)
+        XCTAssertEqual(capped.stops, [1.0, 2.0])
+    }
+
+    func testStopsAreSortedAndSanitised() {
+        let messy = ZoomScale(stops: [6.0, 1.0, -2.0, .nan, 2.0],
+                              maxZoomFactor: 10.0,
+                              wideAngleZoomFactor: 1.0)
+        XCTAssertEqual(messy.stops, [1.0, 2.0, 6.0])
+    }
+
+    // MARK: - Pinch parity
+
+    /// The exact math that lived inline in MonitorView's MagnificationGesture before it
+    /// moved into ZoomScale. Pins the refactor: iPhone pinch must not change feel.
+    private func legacyPinch(start: CGFloat,
+                             magnification: CGFloat,
+                             minZoom: CGFloat,
+                             maxZoom: CGFloat) -> CGFloat {
+        let sensitivity: CGFloat = 0.6
+        let logStart = log2(start)
+        let logDelta = log2(magnification) * sensitivity
+        let logNew = logStart + logDelta
+        let clamped = max(log2(minZoom), min(log2(maxZoom), logNew))
+        return pow(2, clamped)
+    }
+
+    func testPinchMatchesTheLegacyInlineMath() {
+        for start in [1.0, 1.5, 2.0, 4.0, 9.5] as [CGFloat] {
+            for magnification in [0.25, 0.5, 0.9, 1.0, 1.1, 2.0, 4.0] as [CGFloat] {
+                XCTAssertEqual(
+                    tripleCamera.pinched(from: start, magnification: magnification),
+                    legacyPinch(start: start, magnification: magnification, minZoom: 1.0, maxZoom: 10.0),
+                    accuracy: 0.0001,
+                    "pinch drifted at start=\(start) magnification=\(magnification)")
+            }
+        }
+    }
+
+    func testPinchIsIdentityAtUnitMagnification() {
+        XCTAssertEqual(tripleCamera.pinched(from: 4.0, magnification: 1.0), 4.0, accuracy: 0.0001)
+    }
+
+    func testPinchClampsAtBothEnds() {
+        XCTAssertEqual(tripleCamera.pinched(from: 9.5, magnification: 8.0), 10.0)
+        XCTAssertEqual(tripleCamera.pinched(from: 1.1, magnification: 0.01), 1.0)
+    }
+
+    func testPinchRejectsNonFiniteMagnification() {
+        // MagnificationGesture can emit 0 on the first event of a fast pinch.
+        XCTAssertEqual(tripleCamera.pinched(from: 3.0, magnification: 0.0), 3.0)
+        XCTAssertEqual(tripleCamera.pinched(from: 3.0, magnification: .nan), 3.0)
+    }
+}

--- a/RemoteShutter.xcodeproj/project.pbxproj
+++ b/RemoteShutter.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		0684A2E81BE7049800F0B238 /* beep.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 0684A2E61BE7049800F0B238 /* beep.m4a */; };
 		0684A2EB1BE704C600F0B238 /* fastBeep.aif in Resources */ = {isa = PBXBuildFile; fileRef = 0684A2E91BE704C600F0B238 /* fastBeep.aif */; };
 		068DF59D2E3544AD00A49279 /* MonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068DF59A2E3544AD00A49279 /* MonitorView.swift */; };
+		0A11B22C33D44E55F6070002 /* ZoomScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A11B22C33D44E55F6070001 /* ZoomScale.swift */; };
+		0A11B22C33D44E55F6070004 /* ZoomPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A11B22C33D44E55F6070003 /* ZoomPill.swift */; };
 		068DF59E2E3544AD00A49279 /* MonitorViewController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068DF59B2E3544AD00A49279 /* MonitorViewController+SwiftUI.swift */; };
 		068DF59F2E3544AD00A49279 /* MonitorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068DF59C2E3544AD00A49279 /* MonitorViewModel.swift */; };
 		0692841F1BE5BF5B00AF4678 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0692841E1BE5BF5B00AF4678 /* AppDelegate.swift */; };
@@ -127,6 +129,7 @@
 		AB12CD34EF5601789ABC0DF8 /* MonitorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DF7 /* MonitorPresenter.swift */; };
 		AB12CD34EF5601789ABC0DFA /* Messages.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DF9 /* Messages.swift */; };
 		AB12CD34EF5601789ABC0DFC /* SessionTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5601789ABC0DFB /* SessionTestSupport.swift */; };
+		0A11B22C33D44E55F6070006 /* ZoomScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A11B22C33D44E55F6070005 /* ZoomScaleTests.swift */; };
 		AB31E7ED97070E2109B89652 /* MultipeerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3644AC8CC7EEDECC00BE3D9 /* MultipeerService.swift */; };
 		ABE88EBB0583BA42617B496C /* Pods_RemoteShutter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E06F124E7E28CC7B25BDE83 /* Pods_RemoteShutter.framework */; };
 		AFE75F7F7AE0F1FBF334D385 /* FlatBufferSchemas_generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC2B012FFC1D370B0818D3C /* FlatBufferSchemas_generated.swift */; };
@@ -277,6 +280,8 @@
 		0684A2E61BE7049800F0B238 /* beep.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = beep.m4a; sourceTree = "<group>"; };
 		0684A2E91BE704C600F0B238 /* fastBeep.aif */ = {isa = PBXFileReference; lastKnownFileType = file; path = fastBeep.aif; sourceTree = "<group>"; };
 		068DF59A2E3544AD00A49279 /* MonitorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorView.swift; sourceTree = "<group>"; };
+		0A11B22C33D44E55F6070001 /* ZoomScale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomScale.swift; sourceTree = "<group>"; };
+		0A11B22C33D44E55F6070003 /* ZoomPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomPill.swift; sourceTree = "<group>"; };
 		068DF59B2E3544AD00A49279 /* MonitorViewController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MonitorViewController+SwiftUI.swift"; sourceTree = "<group>"; };
 		068DF59C2E3544AD00A49279 /* MonitorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorViewModel.swift; sourceTree = "<group>"; };
 		0692841E1BE5BF5B00AF4678 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -369,6 +374,7 @@
 		AB12CD34EF5601789ABC0DF7 /* MonitorPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MonitorPresenter.swift; sourceTree = "<group>"; };
 		AB12CD34EF5601789ABC0DF9 /* Messages.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Messages.swift; sourceTree = "<group>"; };
 		AB12CD34EF5601789ABC0DFB /* SessionTestSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SessionTestSupport.swift; sourceTree = "<group>"; };
+		0A11B22C33D44E55F6070005 /* ZoomScaleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ZoomScaleTests.swift; sourceTree = "<group>"; };
 		B1C0DE0100000001 /* RolePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolePickerView.swift; sourceTree = "<group>"; };
 		B1C0DE0200000001 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
 		B1C0DE0300000001 /* DeviceScannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceScannerViewModel.swift; sourceTree = "<group>"; };
@@ -573,6 +579,7 @@
 				AB12CD34EF5601789ABC0DE9 /* CameraScreenSnapshotTests.swift */,
 				C4F2A81D9E3B47CA8D5E1A01 /* DeviceScannerSnapshotTests.swift */,
 				AB12CD34EF5601789ABC0DFB /* SessionTestSupport.swift */,
+				0A11B22C33D44E55F6070005 /* ZoomScaleTests.swift */,
 				AB12CD34EF5601789ABC0DEB /* SnapshotTestSupport.swift */,
 				AB12CD34EF5601789ABC0DED /* MonitorScreenSnapshotTests.swift */,
 			);
@@ -584,6 +591,8 @@
 			children = (
 				06BB79AD2E372D420094E085 /* RecordingTimer.swift */,
 				068DF59A2E3544AD00A49279 /* MonitorView.swift */,
+				0A11B22C33D44E55F6070001 /* ZoomScale.swift */,
+				0A11B22C33D44E55F6070003 /* ZoomPill.swift */,
 				06BB79BB2E3884F00094E085 /* CameraProgressOverlayView.swift */,
 				06BB79BE2E3884FA0094E085 /* CameraViewModel.swift */,
 				06BB79C02E38852B0094E085 /* VideoTransferProgressView.swift */,
@@ -1088,6 +1097,8 @@
 				FADEC0DE0001000000000002 /* FrameCreditWindow.swift in Sources */,
 				CAFEBABE0007000000000002 /* WatchPreviewStreamer.swift in Sources */,
 				068DF59D2E3544AD00A49279 /* MonitorView.swift in Sources */,
+				0A11B22C33D44E55F6070002 /* ZoomScale.swift in Sources */,
+				0A11B22C33D44E55F6070004 /* ZoomPill.swift in Sources */,
 				068DF59E2E3544AD00A49279 /* MonitorViewController+SwiftUI.swift in Sources */,
 				068DF59F2E3544AD00A49279 /* MonitorViewModel.swift in Sources */,
 				06B1D80F2536C2330029CCB6 /* UIImage+gif.swift in Sources */,
@@ -1199,6 +1210,7 @@
 				AB12CD34EF5601789ABC0DEA /* CameraScreenSnapshotTests.swift in Sources */,
 				C4F2A81D9E3B47CA8D5E1A02 /* DeviceScannerSnapshotTests.swift in Sources */,
 				AB12CD34EF5601789ABC0DFC /* SessionTestSupport.swift in Sources */,
+				0A11B22C33D44E55F6070006 /* ZoomScaleTests.swift in Sources */,
 				AB12CD34EF5601789ABC0DEC /* SnapshotTestSupport.swift in Sources */,
 				AB12CD34EF5601789ABC0DEE /* MonitorScreenSnapshotTests.swift in Sources */,
 			);


### PR DESCRIPTION
## Why

`MagnificationGesture` only fires from a trackpad pinch, so a mouse-only Mac has **no way to zoom at all**. This adds the missing affordance.

## What

A camera-style detented zoom pill at the bottom of the live preview, **Catalyst only**. Collapsed it shows the lens stops with the active one highlighted; dragging expands it into a ruler that snaps to those stops; releasing collapses it. Same range as pinch.

**iPhone and iPad are unchanged** — same pinch, same auto-hiding HUD. (The HUD auto-hides 0.5s after the last gesture, which would make it unusable as a Mac control, hence the separate pill.)

## How

The pill needs the zoom math that lived inline in the pinch gesture, and needs it in display units (0.5×/1×/2×) while the view model stores hardware factors. Rather than copy it — which is how the unit bug below got there — both now call one pure `ZoomScale` value type: hardware↔display conversion, log2 ruler geometry, clamping, detent snapping, label formatting. No UIKit, no actor, fully unit-tested.

Zoom sends are throttled to 20Hz with a trailing-edge flush, reusing the Watch's existing `ZoomSendThrottle` (already in the app target — `Shared/` untouched). A continuous drag would otherwise emit one `SetZoom` per frame and flood the Multipeer channel, while a plain rate limit would drop the position the user released on.

## Bugs fixed along the way

- **Mixed units in the zoom HUD** (iOS): the max label printed `maxZoomFactor` as a raw hardware factor while the min label printed a display factor — on a triple-camera iPhone the bar read "0.5x" to "10×", two different units bracketing one track.
- **Ruler never reached the ceiling**: `pow(2, log2(5))` is `4.999999999999999`, so a drag to the end stopped a hair short and never compared equal to `maxZoom`. Endpoints are now returned exactly.
- **~50% TSan crash in the loopback suite** (separate commit, pre-existing on master): `LoopbackMultipeerService.sentMessages` was a plain array appended from the coordinator's actor while tests read it from the test thread. Now backed by `Locked<[Message]>`; the property keeps its name and type so all 40 call sites are untouched.

## Verification

- iOS suite green — 22 new `ZoomScaleTests`, including a **parity test against the exact math that was previously inline**, so the pinch refactor is provably a no-op.
- Catalyst + iOS both build clean, zero warnings.
- Full suite now **TSan-clean**: the loopback test went from 5/10 failing on master to **10/10 passing, 0 races**.

## Not verified

The pill has **not been driven in a live two-device session** — it compiles for Catalyst and its math is covered, but nobody has watched it move on a real Mac against an iPhone camera. Worth a look before merge.

## Follow-ups deliberately left out

- The iOS HUD's progress fill is linear in hardware while the pinch curve is logarithmic (cosmetic, iOS-only).
- `FakeMultipeerService.sentMessages` has the same latent race but isn't what TSan trips on.
- `isZoomSliderEnabled` is a vestigial published flag nothing reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)