### PR TITLE
Gear store follow-ups: fix live-site 404s, honest copy, working rate prompt

### DIFF
--- a/RemoteCam/RolePickerView.swift
+++ b/RemoteCam/RolePickerView.swift
@@ -59,7 +59,7 @@ struct RolePickerView: View {
                 Button(action: openGearPage) {
                     glassPanel(
                         icon: "bag.fill",
-                        title: NSLocalizedString("Recommended Gear", comment: ""),
+                        title: NSLocalizedString("Works best on a tripod", comment: ""),
                         subtitle: NSLocalizedString("Tripods, mounts & lenses", comment: ""),
                         tint: AppTheme.accentLight
                     )

--- a/RemoteCam/RolePickerView.swift
+++ b/RemoteCam/RolePickerView.swift
@@ -10,6 +10,7 @@ struct RolePickerView: View {
     @ObservedObject private var watchManager = WatchSessionManager.shared
 
     @State private var appeared = false
+    @State private var hasEarnedAsk = false
 
     var body: some View {
         ZStack {
@@ -69,10 +70,26 @@ struct RolePickerView: View {
                 .offset(y: appeared ? 0 : 20)
 
                 Spacer()
+
+                if hasEarnedAsk {
+                    Button(action: openAppStoreReview) {
+                        HStack(spacing: 6) {
+                            Image(systemName: "heart.fill")
+                                .font(.caption)
+                            Text(NSLocalizedString("Rate on App Store", comment: ""))
+                                .font(.subheadline)
+                        }
+                        .foregroundColor(AppTheme.accent)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.bottom, 8)
+                    .opacity(appeared ? 1 : 0)
+                }
             }
             .padding(.horizontal, 16)
         }
         .onAppear {
+            hasEarnedAsk = hasEarnedReviewAsk()
             withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
                 appeared = true
             }

--- a/RemoteCam/SettingsView.swift
+++ b/RemoteCam/SettingsView.swift
@@ -109,6 +109,13 @@ struct SettingsView: View {
                 }
             }
 
+            // Ungated: someone who navigated here to rate has already asked.
+            linkRow(
+                icon: "heart.fill",
+                title: NSLocalizedString("Rate on App Store", comment: ""),
+                urlString: AppStoreReviewURL.absoluteString
+            )
+
             linkRow(
                 icon: "envelope.fill",
                 title: NSLocalizedString("Contact Support", comment: ""),

--- a/RemoteCam/SwiftConstants.swift
+++ b/RemoteCam/SwiftConstants.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import SafariServices
 import StoreKit
 import UIKit
 
@@ -90,23 +89,14 @@ public func showReviewPromptIfAppropriate() {
 }
 
 // MARK: - Recommended Gear Web Page
+
+// Deliberately the system browser rather than SFSafariViewController. The gear
+// page sends people on to Amazon, and since iOS 11 an SFSafariViewController
+// keeps its own cookie store, isolated from Safari — so an affiliate cookie set
+// inside one is stranded there the moment the shopper continues in the Amazon
+// app, and the referral goes uncredited. Handing off to Safari also lets
+// Amazon's universal links open its app directly, which is what Amazon asks
+// Associates to do.
 func openGearPage() {
-    #if targetEnvironment(macCatalyst)
-    // SFSafariViewController is unavailable on Mac Catalyst; open in the default browser.
     UIApplication.shared.open(GearURL)
-    #else
-    guard let windowScene = UIApplication.shared.connectedScenes
-        .compactMap({ $0 as? UIWindowScene })
-        .first(where: { $0.activationState == .foregroundActive }),
-        let rootViewController = windowScene.windows.first(where: { $0.isKeyWindow })?.rootViewController
-        else { return }
-
-    var topViewController = rootViewController
-    while let presented = topViewController.presentedViewController {
-        topViewController = presented
-    }
-
-    let safari = SFSafariViewController(url: GearURL)
-    topViewController.present(safari, animated: true)
-    #endif
 }

--- a/RemoteCam/SwiftConstants.swift
+++ b/RemoteCam/SwiftConstants.swift
@@ -14,7 +14,7 @@ import UIKit
 public let tempFile = "remoteshutter_video.mov"
 
 let AppStoreURL = URL(string: "https://apps.apple.com/us/app/remote-shutter/id633274861")!
-let GearURL = URL(string: "https://security-union.github.io/remote-shutter/gear?src=app")!
+let GearURL = URL(string: "https://remoteshutter.app/gear?src=app")!
 public let disableAdsPID = "05"
 public let enableVideoPID = "06"
 public let enableTorchPID = "07"

--- a/RemoteCam/SwiftConstants.swift
+++ b/RemoteCam/SwiftConstants.swift
@@ -14,6 +14,10 @@ import UIKit
 public let tempFile = "remoteshutter_video.mov"
 
 let AppStoreURL = URL(string: "https://apps.apple.com/us/app/remote-shutter/id633274861")!
+// SKStoreReviewController is rate-limited by the system (~3/year) and can show
+// nothing at all, so it is only fit for the unsolicited prompt. A deliberate tap
+// goes here instead: the write-review deep link is never throttled.
+let AppStoreReviewURL = URL(string: "https://apps.apple.com/us/app/remote-shutter/id633274861?action=write-review")!
 let GearURL = URL(string: "https://remoteshutter.app/gear?src=app")!
 public let disableAdsPID = "05"
 public let enableVideoPID = "06"
@@ -22,7 +26,7 @@ public let enableVideoOnlyPID = "08"
 public let reviewCounterKey = "reviewCounter"
 public let lastVersionPromptedForReviewKey = "lastVersionPromptedForReview"
 public let mediaCaptureCounterKey = "mediaCaptureCounter"
-public let mediaCapturedBeforeRequestingReview = 10
+public let mediaCapturedBeforeRequestingReview = 5
 
 // MARK: - Shared Review Prompt Utility
 func privateShowReviewPromptIfAppropriate() {
@@ -54,12 +58,30 @@ func privateShowReviewPromptIfAppropriate() {
     }
 }
 
+// MARK: - Rate on App Store
+
+/// The single gate for every surface that offers the "Rate on App Store" heart,
+/// so they can't drift apart. Someone earns the ask by having actually captured
+/// something — purchasing isn't a proxy for it, and asking before the app has
+/// worked for them samples the wrong people. Surfaces the user navigates to
+/// deliberately (Settings) skip this: they already asked.
+func hasEarnedReviewAsk(captureCount: Int) -> Bool {
+    captureCount >= mediaCapturedBeforeRequestingReview
+}
+
+func hasEarnedReviewAsk() -> Bool {
+    hasEarnedReviewAsk(captureCount: UserDefaults.standard.integer(forKey: mediaCaptureCounterKey))
+}
+
+func openAppStoreReview() {
+    UIApplication.shared.open(AppStoreReviewURL)
+}
+
 public func showReviewPromptIfAppropriate() {
     var count = UserDefaults.standard.integer(forKey: mediaCaptureCounterKey)
     count += 1
     UserDefaults.standard.set(count, forKey: mediaCaptureCounterKey)
     
-    // Show review prompt after 10 captures
     if count >= mediaCapturedBeforeRequestingReview {
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
             privateShowReviewPromptIfAppropriate()

--- a/RemoteCam/WelcomeView.swift
+++ b/RemoteCam/WelcomeView.swift
@@ -26,6 +26,10 @@ struct WelcomeView: View {
                     if viewModel.hasAnyPurchase {
                         thankYouSection
                     }
+
+                    if viewModel.canShowReview {
+                        rateSection
+                    }
                 }
                 .padding(.horizontal, 20)
                 .padding(.bottom, 40)
@@ -205,24 +209,24 @@ struct WelcomeView: View {
     // MARK: - Thank You
 
     private var thankYouSection: some View {
-        VStack(spacing: 12) {
-            Text(NSLocalizedString("Thank you for your support!", comment: ""))
-                .font(.subheadline)
-                .foregroundColor(.secondary)
+        Text(NSLocalizedString("Thank you for your support!", comment: ""))
+            .font(.subheadline)
+            .foregroundColor(.secondary)
+    }
 
-            if viewModel.canShowReview {
-                Button {
-                    onReviewApp()
-                } label: {
-                    HStack(spacing: 6) {
-                        Image(systemName: "heart.fill")
-                            .font(.caption)
-                        Text(NSLocalizedString("Rate on App Store", comment: ""))
-                            .font(.subheadline)
-                    }
-                    .foregroundColor(AppTheme.accent)
-                }
+    // MARK: - Rate
+
+    private var rateSection: some View {
+        Button {
+            onReviewApp()
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "heart.fill")
+                    .font(.caption)
+                Text(NSLocalizedString("Rate on App Store", comment: ""))
+                    .font(.subheadline)
             }
+            .foregroundColor(AppTheme.accent)
         }
     }
 }

--- a/RemoteCam/WelcomeViewController.swift
+++ b/RemoteCam/WelcomeViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import StoreKit
 import SwiftUI
 
 class WelcomeViewController: UIViewController {
@@ -70,23 +69,7 @@ class WelcomeViewController: UIViewController {
     // MARK: - Review
 
     private func reviewApp() {
-        var count = UserDefaults.standard.integer(forKey: reviewCounterKey)
-        count += 1
-        UserDefaults.standard.set(count, forKey: reviewCounterKey)
-
-        let infoDictionaryKey = kCFBundleVersionKey as String
-        guard let currentVersion = Bundle.main.object(forInfoDictionaryKey: infoDictionaryKey) as? String else { return }
-        let lastVersionPrompted = UserDefaults.standard.string(forKey: lastVersionPromptedForReviewKey)
-
-        if count <= 4 && currentVersion != lastVersionPrompted {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
-                guard self?.navigationController?.topViewController is WelcomeViewController else { return }
-                if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
-                    SKStoreReviewController.requestReview(in: windowScene)
-                }
-                UserDefaults.standard.set(currentVersion, forKey: lastVersionPromptedForReviewKey)
-            }
-        }
+        openAppStoreReview()
     }
 
 }

--- a/RemoteCam/WelcomeViewModel.swift
+++ b/RemoteCam/WelcomeViewModel.swift
@@ -76,17 +76,7 @@ final class WelcomeViewModel: ObservableObject, PurchaseManaging {
     // MARK: - Review
 
     var canShowReview: Bool {
-        let store = StoreManager.shared
-        guard store.hasAdRemovalFeature() || store.hasTorchFeature()
-                || store.hasVideoRecordingFeature() || store.hasProMode() else {
-            return false
-        }
-        let count = UserDefaults.standard.integer(forKey: reviewCounterKey)
-        guard let currentVersion = Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as? String else {
-            return false
-        }
-        let lastVersion = UserDefaults.standard.string(forKey: lastVersionPromptedForReviewKey)
-        return count <= 4 && currentVersion != lastVersion
+        hasEarnedReviewAsk()
     }
 
     // MARK: - Private Helpers

--- a/RemoteCam/da.lproj/Localizable.strings
+++ b/RemoteCam/da.lproj/Localizable.strings
@@ -183,6 +183,7 @@
 "Source Code" = "Kildekode";
 "Recommended Gear" = "Anbefalet udstyr";
 "Tripods, mounts & lenses" = "Stativer, holdere og objektiver";
+"Works best on a tripod" = "Virker bedst på stativ";
 "Version" = "Version";
 
 /* Camera/Monitor Status */

--- a/RemoteCam/de-DE.lproj/Localizable.strings
+++ b/RemoteCam/de-DE.lproj/Localizable.strings
@@ -303,6 +303,7 @@
 "Source Code" = "Quellcode";
 "Recommended Gear" = "Empfohlenes Zubehör";
 "Tripods, mounts & lenses" = "Stative, Halterungen & Objektive";
+"Works best on a tripod" = "Am besten mit Stativ";
 "Version" = "Version";
 
 /* Camera/Monitor Status */

--- a/RemoteCam/en.lproj/Localizable.strings
+++ b/RemoteCam/en.lproj/Localizable.strings
@@ -303,6 +303,7 @@
 "Source Code" = "Source Code";
 "Recommended Gear" = "Recommended Gear";
 "Tripods, mounts & lenses" = "Tripods, mounts & lenses";
+"Works best on a tripod" = "Works best on a tripod";
 "Version" = "Version";
 
 /* Camera/Monitor Status */

--- a/RemoteCam/es-MX.lproj/Localizable.strings
+++ b/RemoteCam/es-MX.lproj/Localizable.strings
@@ -199,6 +199,7 @@
 "Source Code" = "Código Fuente";
 "Recommended Gear" = "Equipo Recomendado";
 "Tripods, mounts & lenses" = "Trípodes, soportes y lentes";
+"Works best on a tripod" = "Funciona mejor con trípode";
 "Version" = "Versión";
 
 /* Camera/Monitor Status */

--- a/RemoteCam/fr-FR.lproj/Localizable.strings
+++ b/RemoteCam/fr-FR.lproj/Localizable.strings
@@ -199,6 +199,7 @@
 "Source Code" = "Code Source";
 "Recommended Gear" = "Équipement Recommandé";
 "Tripods, mounts & lenses" = "Trépieds, supports et objectifs";
+"Works best on a tripod" = "Idéal sur trépied";
 "Version" = "Version";
 
 /* Camera/Monitor Status */

--- a/RemoteCam/hi.lproj/Localizable.strings
+++ b/RemoteCam/hi.lproj/Localizable.strings
@@ -303,6 +303,7 @@
 "Source Code" = "सोर्स कोड";
 "Recommended Gear" = "अनुशंसित गियर";
 "Tripods, mounts & lenses" = "तिपाई, माउंट और लेंस";
+"Works best on a tripod" = "तिपाई पर सबसे अच्छा";
 "Version" = "वर्शन";
 
 /* Camera/Monitor Status */

--- a/RemoteCam/it.lproj/Localizable.strings
+++ b/RemoteCam/it.lproj/Localizable.strings
@@ -183,6 +183,7 @@
 "Source Code" = "Codice Sorgente";
 "Recommended Gear" = "Attrezzatura Consigliata";
 "Tripods, mounts & lenses" = "Treppiedi, supporti e obiettivi";
+"Works best on a tripod" = "Ideale su treppiede";
 "Version" = "Versione";
 
 /* Camera/Monitor Status */

--- a/RemoteCam/ja.lproj/Localizable.strings
+++ b/RemoteCam/ja.lproj/Localizable.strings
@@ -303,6 +303,7 @@
 "Source Code" = "ソースコード";
 "Recommended Gear" = "おすすめの機材";
 "Tripods, mounts & lenses" = "三脚・マウント・レンズ";
+"Works best on a tripod" = "三脚での使用がおすすめ";
 "Version" = "バージョン";
 
 /* Camera/Monitor Status */

--- a/RemoteCam/ko.lproj/Localizable.strings
+++ b/RemoteCam/ko.lproj/Localizable.strings
@@ -303,6 +303,7 @@
 "Source Code" = "소스 코드";
 "Recommended Gear" = "추천 장비";
 "Tripods, mounts & lenses" = "삼각대, 마운트, 렌즈";
+"Works best on a tripod" = "삼각대 거치 권장";
 "Version" = "버전";
 
 /* Camera/Monitor Status */

--- a/RemoteCam/ms.lproj/Localizable.strings
+++ b/RemoteCam/ms.lproj/Localizable.strings
@@ -303,6 +303,7 @@
 "Source Code" = "Kod Sumber";
 "Recommended Gear" = "Peralatan Disyorkan";
 "Tripods, mounts & lenses" = "Tripod, pelekap & kanta";
+"Works best on a tripod" = "Terbaik dengan tripod";
 "Version" = "Versi";
 
 /* Camera/Monitor Status */

--- a/RemoteCam/pt-BR.lproj/Localizable.strings
+++ b/RemoteCam/pt-BR.lproj/Localizable.strings
@@ -303,6 +303,7 @@
 "Source Code" = "Código Fonte";
 "Recommended Gear" = "Equipamento Recomendado";
 "Tripods, mounts & lenses" = "Tripés, suportes e lentes";
+"Works best on a tripod" = "Funciona melhor com tripé";
 "Version" = "Versão";
 
 /* Camera/Monitor Status */

--- a/RemoteCam/ru.lproj/Localizable.strings
+++ b/RemoteCam/ru.lproj/Localizable.strings
@@ -303,6 +303,7 @@
 "Source Code" = "Исходный код";
 "Recommended Gear" = "Рекомендуемое оборудование";
 "Tripods, mounts & lenses" = "Штативы, крепления и объективы";
+"Works best on a tripod" = "Лучше всего на штативе";
 "Version" = "Версия";
 
 /* Camera/Monitor Status */

--- a/RemoteCam/tr.lproj/Localizable.strings
+++ b/RemoteCam/tr.lproj/Localizable.strings
@@ -303,6 +303,7 @@
 "Source Code" = "Kaynak Kodu";
 "Recommended Gear" = "Önerilen Ekipman";
 "Tripods, mounts & lenses" = "Tripodlar, tutucular ve lensler";
+"Works best on a tripod" = "En iyi tripodla çalışır";
 "Version" = "Sürüm";
 
 /* Camera/Monitor Status */

--- a/RemoteCam/vi.lproj/Localizable.strings
+++ b/RemoteCam/vi.lproj/Localizable.strings
@@ -303,6 +303,7 @@
 "Source Code" = "Mã nguồn";
 "Recommended Gear" = "Thiết bị đề xuất";
 "Tripods, mounts & lenses" = "Chân máy, giá đỡ và ống kính";
+"Works best on a tripod" = "Tốt nhất với chân máy";
 "Version" = "Phiên bản";
 
 /* Camera/Monitor Status */

--- a/RemoteCam/zh-Hans.lproj/Localizable.strings
+++ b/RemoteCam/zh-Hans.lproj/Localizable.strings
@@ -303,6 +303,7 @@
 "Source Code" = "源代码";
 "Recommended Gear" = "推荐配件";
 "Tripods, mounts & lenses" = "三脚架、支架和镜头";
+"Works best on a tripod" = "建议搭配三脚架使用";
 "Version" = "版本";
 
 /* Camera/Monitor Status */

--- a/fastlane/metadata/en-US/marketing_url.txt
+++ b/fastlane/metadata/en-US/marketing_url.txt
@@ -1,1 +1,1 @@
-https://security-union.github.io/remote-shutter
+https://remoteshutter.app

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
-  basePath: '/remote-shutter',
   images: {
     unoptimized: true,
   },

--- a/website/public/CNAME
+++ b/website/public/CNAME
@@ -1,0 +1,1 @@
+remoteshutter.app

--- a/website/src/app/blog/[slug]/page.tsx
+++ b/website/src/app/blog/[slug]/page.tsx
@@ -102,7 +102,7 @@ export default async function BlogPost({ params }: Props) {
       <Header />
       <main className={styles.main}>
         <nav className={styles.breadcrumb} aria-label="Breadcrumb">
-          <a href={BASE_PATH}>Home</a>
+          <a href={BASE_PATH || '/'}>Home</a>
           <span aria-hidden="true">/</span>
           <a href={`${BASE_PATH}/blog`}>Blog</a>
           <span aria-hidden="true">/</span>

--- a/website/src/app/gear/page.module.css
+++ b/website/src/app/gear/page.module.css
@@ -175,10 +175,9 @@
   line-height: 1.3;
 }
 
-.price {
+.tier {
   color: var(--accent);
   font-weight: 600;
-  font-variant-numeric: tabular-nums;
   font-size: 0.95rem;
 }
 

--- a/website/src/app/gear/page.tsx
+++ b/website/src/app/gear/page.tsx
@@ -97,6 +97,10 @@ export default function Gear() {
             >
               <h2 id={section.id}>{section.title}</h2>
               <p className={styles.sectionSub}>{section.sub}</p>
+              {/* Repeated per section, not just in the hero: the FTC asks that a
+                  reader see the disclosure and the buy link at the same time, and
+                  the hero scrolls away long before the last card. */}
+              <p className={styles.disclosure}>{DISCLOSURE}</p>
               <div className={styles.cards}>
                 {section.items.map((item) => (
                   <article key={item.name} className={styles.card}>

--- a/website/src/app/gear/page.tsx
+++ b/website/src/app/gear/page.tsx
@@ -14,8 +14,10 @@ export const metadata: Metadata = {
   alternates: { canonical: `${SITE_URL}/gear` },
 };
 
-const DISCLOSURE =
-  'As an Amazon Associate, Remote Shutter earns from qualifying purchases. Prices are typical street prices and may vary.';
+// Verbatim per the Associates Operating Agreement §5 — the only permitted
+// variants are ones previously allowed under that agreement, and §6 makes a §5
+// violation a material breach. Reword nothing here.
+const DISCLOSURE = 'As an Amazon Associate I earn from qualifying purchases.';
 
 function RigDiagram() {
   return (
@@ -108,7 +110,7 @@ export default function Gear() {
                       />
                     </div>
                     <h3>{item.name}</h3>
-                    <p className={styles.price}>{item.price}</p>
+                    <p className={styles.tier}>{item.tier}</p>
                     <p className={styles.why}>{item.why}</p>
                     <AmazonLink query={item.query} className={styles.buy}>
                       View on Amazon ↗

--- a/website/src/lib/constants.ts
+++ b/website/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const SITE_URL = 'https://security-union.github.io/remote-shutter';
-export const BASE_PATH = '/remote-shutter';
+export const SITE_URL = 'https://remoteshutter.app';
+export const BASE_PATH = '';
 export const APP_STORE_URL = 'https://apps.apple.com/us/app/remote-shutter/id633274861';
 export const GITHUB_URL = 'https://github.com/security-union/remote-shutter';

--- a/website/src/lib/gear.ts
+++ b/website/src/lib/gear.ts
@@ -1,6 +1,8 @@
-// Amazon Associates tracking IDs. These are the intended IDs — they MUST be
-// updated to the real ones once the Associates account is approved, or the
-// clicks earn nothing (links still work for shoppers either way).
+// Live Amazon Associates tracking IDs, registered under the securityunion-20
+// account. The split lets app-driven clicks report separately from organic web
+// in Amazon's Tracking ID Summary Report; AmazonLink picks between them on
+// ?src=app. Both must exist in Associates Central — an unregistered tag still
+// links fine for shoppers but attributes nothing.
 export const AMAZON_TAG_WEB = 'remoteshutter-web-20';
 export const AMAZON_TAG_APP = 'remoteshutter-app-20';
 

--- a/website/src/lib/gear.ts
+++ b/website/src/lib/gear.ts
@@ -8,7 +8,9 @@ export const AMAZON_TAG_APP = 'remoteshutter-app-20';
 
 export interface GearItem {
   name: string;
-  price: string;
+  /** editorial price band — deliberately not a number: we have no
+   *  licensed live price source, and a stale one is worse than none */
+  tier: string;
   why: string;
   /** Amazon search query the buy button points at */
   query: string;
@@ -33,7 +35,7 @@ export const GEAR_SECTIONS: GearSection[] = [
     items: [
       {
         name: 'UBeesize TR50 50″ tripod',
-        price: '$23–30',
+        tier: 'Budget',
         why: 'The value workhorse: chest-height group shots anywhere, light enough to live in a backpack.',
         query: 'ubeesize tr50 phone tripod',
         image: 'tripod-full.jpg',
@@ -42,7 +44,7 @@ export const GEAR_SECTIONS: GearSection[] = [
       },
       {
         name: 'Joby GorillaPod Mobile',
-        price: '$25–35',
+        tier: 'Budget',
         why: "Wraps around railings, branches, and door frames — camera angles a straight tripod can't reach.",
         query: 'joby gorillapod mobile phone',
         image: 'tripod-flex.jpg',
@@ -50,7 +52,7 @@ export const GEAR_SECTIONS: GearSection[] = [
       },
       {
         name: 'Manfrotto PIXI + phone clamp',
-        price: '$30–40',
+        tier: 'Mid-range',
         why: 'The tabletop workhorse: dead-stable for video, product shots, and long exposures on any flat surface.',
         query: 'manfrotto pixi mini tripod phone clamp',
         image: 'tripod-mini.jpg',
@@ -58,7 +60,7 @@ export const GEAR_SECTIONS: GearSection[] = [
       },
       {
         name: 'Manfrotto Element MII Mobile',
-        price: '$120–160',
+        tier: 'Premium',
         why: 'The buy-once tripod: 63″ tall, 8 kg payload, Arca ball head — and Manfrotto’s smartphone clamp in the box.',
         query: 'manfrotto element mii mobile tripod',
         image: 'tripod-manfrotto.jpg',
@@ -73,8 +75,8 @@ export const GEAR_SECTIONS: GearSection[] = [
     items: [
       {
         name: 'Universal tripod phone clamp',
-        price: '$10–14',
-        why: 'Turns any standard tripod you already own into a Remote Shutter rig. The highest-value $12 in this list.',
+        tier: 'Budget',
+        why: 'Turns any standard tripod you already own into a Remote Shutter rig. The best value on this page.',
         query: 'phone tripod mount clamp cold shoe',
         image: 'mount-clamp.jpg',
         alt: 'Universal tripod phone clamp',
@@ -82,7 +84,7 @@ export const GEAR_SECTIONS: GearSection[] = [
       },
       {
         name: 'MagSafe tripod mount',
-        price: '$15–25',
+        tier: 'Budget',
         why: 'Snap the camera phone on and off between shots — no clamping, no fiddling while the group waits.',
         query: 'magsafe tripod mount',
         image: 'mount-magsafe.jpg',
@@ -90,7 +92,7 @@ export const GEAR_SECTIONS: GearSection[] = [
       },
       {
         name: 'Belkin MagSafe desk stand',
-        price: '$28–35',
+        tier: 'Mid-range',
         why: 'The desk-studio option: holds the phone at monitor height for recording setups driven from the Mac app.',
         query: 'belkin magsafe phone stand',
         image: 'stand-desk.jpg',
@@ -98,7 +100,7 @@ export const GEAR_SECTIONS: GearSection[] = [
       },
       {
         name: 'Suction cup phone mount',
-        price: '$12–20',
+        tier: 'Budget',
         why: 'Sticks to windows, mirrors, and tile — overhead and behind-glass angles no tripod will give you.',
         query: 'suction cup phone mount camera',
         image: 'mount-suction.jpg',
@@ -113,7 +115,7 @@ export const GEAR_SECTIONS: GearSection[] = [
     items: [
       {
         name: 'Xenvo Pro lens kit',
-        price: '$35–45',
+        tier: 'Budget',
         why: 'The proven first lens: wide + macro on a padded clip that works with any phone, no case required.',
         query: 'xenvo pro lens kit',
         image: 'lens-xenvo.jpg',
@@ -121,7 +123,7 @@ export const GEAR_SECTIONS: GearSection[] = [
       },
       {
         name: 'Sirui 1.33× anamorphic',
-        price: '$70–90',
+        tier: 'Mid-range',
         why: 'Cinematic widescreen on a budget — the affordable way into anamorphic before committing to Moment glass.',
         query: 'sirui anamorphic lens smartphone',
         image: 'lens-sirui.jpg',
@@ -129,7 +131,7 @@ export const GEAR_SECTIONS: GearSection[] = [
       },
       {
         name: 'Sandmarc Wide',
-        price: '$110–130',
+        tier: 'Premium',
         why: 'Magnesium-built wide that gets every face in the group shot without stepping back. Clip or case mount.',
         query: 'sandmarc wide lens iphone',
         image: 'lens-sandmarc.jpg',
@@ -138,7 +140,7 @@ export const GEAR_SECTIONS: GearSection[] = [
       },
       {
         name: 'Moment T-Series',
-        price: '$130–150',
+        tier: 'Premium',
         why: 'The benchmark: aircraft-aluminum glass that snaps onto a Moment case. For shooters going all-in.',
         query: 'moment t-series lens',
         image: 'lens-moment.jpg',


### PR DESCRIPTION
Follow-ups to #151. The gear store shipped, but the site is currently serving broken — every asset 404s — and a few things in the original PR turned out wrong. This fixes them.

## Unbreak the live site (the urgent one)
`#151` kept `basePath: '/remote-shutter'`, which is correct for the github.io subpath but wrong for the `remoteshutter.app` custom domain — the domain serves from the root, so the HTML asks for `/remote-shutter/_next/...` and every stylesheet, script, and image 404s. Right now the deployed page loads as an unstyled shell.

- Drop `basePath`, empty `BASE_PATH`, point `SITE_URL` (canonicals, sitemap, robots, JSON-LD) at the real domain.
- Ship `website/public/CNAME` so the workflow deploy keeps the custom domain instead of dropping it, and re-triggers the cert check.
- Fix a latent bug: the blog breadcrumb interpolated `BASE_PATH` directly, which became `href=""` (link to the current page) once it was empty.

Verified: rebuilt export has no `/remote-shutter/` paths, assets are root-relative, `CNAME` is in the artifact.

## Amazon compliance / honesty
- **Tags are live.** `securityunion-20`'s `remoteshutter-web-20` / `remoteshutter-app-20` are both registered now; the comment no longer tells the next reader to swap them.
- **Prices → editorial tiers.** Hardcoded prices go stale silently and a live one needs Product Advertising data we can't get (Creators API is gated behind a sales threshold a new storefront won't clear). Budget/Mid-range/Premium keeps the ladder without asserting a number.
- **Disclosure verbatim.** Was reworded to name the app; Operating Agreement §5 wants the exact sentence, and §6 makes a §5 breach material. Now repeated per section so a reader sees it and the buy link together (FTC).

## App
- **Gear button copy.** "Recommended Gear" → "Works best on a tripod" — the honest reason to tap (the setup, not image quality), translated across all 15 locales with that distinction held.
- **Open the gear page in Safari, not SFSafariViewController.** SFVC has kept a per-app cookie store since iOS 11, so the Associates cookie is stranded when a shopper continues into the Amazon app — the referral goes uncredited. Net deletion; Catalyst already did this. *(Attribution reasoning is unmeasured — worth confirming clicks land in the Tracking ID report once deployed.)*
- **Fix the Rate on App Store heart.** It was gated on having bought an IAP (~4% reach), its tap called the throttled `SKStoreReviewController` (usually showed nothing, then hid itself), and it fought the capture prompt over shared state. Deliberate taps now use the `?action=write-review` deep link; the after-5-captures prompt keeps `SKStoreReviewController` (its correct use). Now appears on Welcome + role picker gated at 5 captures, and ungated in Settings.

Verified: iOS + Mac Catalyst build, full suite passes (521 tests), jest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)