### PR TITLE
Tap to focus (iOS + Catalyst) + Pro subscription

### DIFF
--- a/Configuration.storekit
+++ b/Configuration.storekit
@@ -30,18 +30,18 @@
       "type" : "NonConsumable"
     },
     {
-      "displayPrice" : "9.99",
+      "displayPrice" : "39.99",
       "familyShareable" : false,
       "internalID" : "2D9566A3",
       "localizations" : [
         {
-          "description" : "",
-          "displayName" : "Pro: All features",
+          "description" : "Every feature forever — one-time.",
+          "displayName" : "Pro (Lifetime)",
           "locale" : "en_US"
         }
       ],
       "productID" : "06",
-      "referenceName" : "Pro: All features",
+      "referenceName" : "Pro (Lifetime)",
       "type" : "NonConsumable"
     },
     {

--- a/Configuration.storekit
+++ b/Configuration.storekit
@@ -73,6 +73,21 @@
       "productID" : "08",
       "referenceName" : "Enable Video Only",
       "type" : "NonConsumable"
+    },
+    {
+      "displayPrice" : "1.99",
+      "familyShareable" : false,
+      "internalID" : "F0C05000",
+      "localizations" : [
+        {
+          "description" : "Tap the preview to set focus and exposure",
+          "displayName" : "Tap to Focus",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "09",
+      "referenceName" : "Tap to Focus",
+      "type" : "NonConsumable"
     }
   ],
   "settings" : {
@@ -128,7 +143,65 @@
     ]
   },
   "subscriptionGroups" : [
+    {
+      "id" : "F0C05010",
+      "localizations" : [
 
+      ],
+      "name" : "Pro",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "1.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "F0C05001",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "All features, billed monthly",
+              "displayName" : "Pro Monthly",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "pro_monthly",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Pro Monthly",
+          "subscriptionGroupID" : "F0C05010",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "14.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "F0C05002",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "All features, billed yearly",
+              "displayName" : "Pro Yearly",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "pro_yearly",
+          "recurringSubscriptionPeriod" : "P1Y",
+          "referenceName" : "Pro Yearly",
+          "subscriptionGroupID" : "F0C05010",
+          "type" : "RecurringSubscription"
+        }
+      ]
+    }
   ],
   "version" : {
     "major" : 4,

--- a/Configuration.storekit
+++ b/Configuration.storekit
@@ -75,7 +75,7 @@
       "type" : "NonConsumable"
     },
     {
-      "displayPrice" : "1.99",
+      "displayPrice" : "0.99",
       "familyShareable" : false,
       "internalID" : "F0C05000",
       "localizations" : [

--- a/Configuration.storekit
+++ b/Configuration.storekit
@@ -30,18 +30,18 @@
       "type" : "NonConsumable"
     },
     {
-      "displayPrice" : "39.99",
+      "displayPrice" : "9.99",
       "familyShareable" : false,
       "internalID" : "2D9566A3",
       "localizations" : [
         {
-          "description" : "Every feature forever — one-time.",
-          "displayName" : "Pro (Lifetime)",
+          "description" : "",
+          "displayName" : "Pro: All features",
           "locale" : "en_US"
         }
       ],
       "productID" : "06",
-      "referenceName" : "Pro (Lifetime)",
+      "referenceName" : "Pro: All features",
       "type" : "NonConsumable"
     },
     {

--- a/RemoteCam/CameraControlling.swift
+++ b/RemoteCam/CameraControlling.swift
@@ -34,6 +34,10 @@ protocol CameraControlling: AnyObject, Sendable {
     func stopRecordingVideo(_ shouldSendVideo: Bool)
 
     func setZoom(zoomFactor: CGFloat) async throws -> (CGFloat, CameraLensType, RemoteCmd.ZoomRange)
+    /// Sets the focus/exposure point of interest from a monitor tap. `x`/`y` are
+    /// normalized (0..1) in the upright display image, origin top-left.
+    /// Fire-and-forget: a no-op if the active device has no point of interest.
+    func focusAtPoint(x: Float, y: Float) async throws
     func switchLens(to lensType: CameraLensType) async throws -> (CameraLensType, [CameraLensType], CGFloat, RemoteCmd.ZoomRange)
     func toggleFlash() async throws -> AVCaptureDevice.FlashMode
     func toggleTorch() async throws -> AVCaptureDevice.TorchMode

--- a/RemoteCam/CameraRig.swift
+++ b/RemoteCam/CameraRig.swift
@@ -460,6 +460,10 @@ extension CameraRig: CameraControlling {
     }
 
     func focusAtPoint(x: Float, y: Float) async throws {
+        // Show the same reticle the monitor draws, so the person holding the
+        // camera sees the tap land — on every command, even where the device
+        // can't focus (the box is the confirmation).
+        cameraViewModel.showRemoteFocus(x: x, y: y)
         try await engine.setFocusExposurePoint(displayNormalized: CGPoint(x: CGFloat(x), y: CGFloat(y)))
     }
 

--- a/RemoteCam/CameraRig.swift
+++ b/RemoteCam/CameraRig.swift
@@ -459,6 +459,10 @@ extension CameraRig: CameraControlling {
         try await engine.setZoom(zoomFactor: zoomFactor)
     }
 
+    func focusAtPoint(x: Float, y: Float) async throws {
+        try await engine.setFocusExposurePoint(displayNormalized: CGPoint(x: CGFloat(x), y: CGFloat(y)))
+    }
+
     func switchLens(to lensType: CameraLensType) async throws -> (CameraLensType, [CameraLensType], CGFloat, RemoteCmd.ZoomRange) {
         try await engine.switchLens(to: lensType)
     }

--- a/RemoteCam/CameraScreenView.swift
+++ b/RemoteCam/CameraScreenView.swift
@@ -84,21 +84,43 @@ struct CameraScreenView: View {
         }
     }
 
-    /// The remote focus reticle — the same box/animation the monitor draws,
-    /// positioned within the fitted video rect at the tapped point. x is flipped
-    /// when the preview is mirrored (front camera) so the box lands on the same
-    /// subject the monitor operator tapped. Drawn as a preview overlay so it
-    /// shares the preview layer's coordinate space (no safe-area offset).
+    /// The remote focus reticle — the same box/animation the monitor draws. The
+    /// tapped point is normalized in the displayed image; we recompute the fitted
+    /// (letterboxed) video rect inside a GeometryReader measuring THIS overlay's
+    /// own space, using only the video's aspect ratio (which is coordinate-space
+    /// invariant). That avoids any safe-area/coordinate offset between the preview
+    /// layer and SwiftUI. x is flipped when the preview is mirrored (front camera).
     @ViewBuilder
     private var focusReticleOverlay: some View {
-        if let indicator = viewModel.focusIndicator, videoRect.width > 0 {
-            let nx = previewMirrored ? (1 - indicator.normalized.x) : indicator.normalized.x
-            FocusReticleView()
-                .id(indicator.id)
-                .position(x: videoRect.minX + nx * videoRect.width,
-                          y: videoRect.minY + indicator.normalized.y * videoRect.height)
-                .allowsHitTesting(false)
+        if let indicator = viewModel.focusIndicator, videoRect.width > 0, videoRect.height > 0 {
+            let aspect = videoRect.width / videoRect.height
+            GeometryReader { geo in
+                let fitted = Self.fittedRect(aspect: aspect, in: geo.size)
+                let nx = previewMirrored ? (1 - indicator.normalized.x) : indicator.normalized.x
+                FocusReticleView()
+                    .id(indicator.id)
+                    .position(x: fitted.minX + nx * fitted.width,
+                              y: fitted.minY + indicator.normalized.y * fitted.height)
+            }
+            .allowsHitTesting(false)
         }
+    }
+
+    /// The rect an `aspect` (width/height) image occupies when aspect-fit into
+    /// `size` — matches the preview layer's `.resizeAspect` letterboxing.
+    static func fittedRect(aspect: CGFloat, in size: CGSize) -> CGRect {
+        guard size.width > 0, size.height > 0, aspect > 0 else { return .zero }
+        let viewAspect = size.width / size.height
+        let w: CGFloat
+        let h: CGFloat
+        if aspect > viewAspect {
+            w = size.width
+            h = size.width / aspect
+        } else {
+            h = size.height
+            w = size.height * aspect
+        }
+        return CGRect(x: (size.width - w) / 2, y: (size.height - h) / 2, width: w, height: h)
     }
 
     private var cameraDevicePicker: some View {

--- a/RemoteCam/CameraScreenView.swift
+++ b/RemoteCam/CameraScreenView.swift
@@ -18,6 +18,9 @@ struct CameraScreenView: View {
     @ObservedObject var viewModel: CameraViewModel
     /// Local device selection from the picker chrome (nil in previews/tests).
     var onSelectCameraDevice: ((String) -> Void)?
+    /// The letterbox-fitted video rect (view coords), reported by the preview so
+    /// the focus reticle lands on the image, not the black bars.
+    @State private var videoRect: CGRect = .zero
 
     var body: some View {
         ZStack {
@@ -25,8 +28,19 @@ struct CameraScreenView: View {
 
             if let session = viewModel.previewSession {
                 CameraPreviewView(session: session,
-                                  videoOrientation: viewModel.previewVideoOrientation)
+                                  videoOrientation: viewModel.previewVideoOrientation,
+                                  onVideoRectChange: { videoRect = $0 })
                     .ignoresSafeArea()
+            }
+
+            // Remote focus reticle — the same box/animation the monitor draws,
+            // positioned within the fitted video rect at the tapped point.
+            if let indicator = viewModel.focusIndicator, videoRect.width > 0 {
+                FocusReticleView()
+                    .id(indicator.id)
+                    .position(x: videoRect.minX + indicator.normalized.x * videoRect.width,
+                              y: videoRect.minY + indicator.normalized.y * videoRect.height)
+                    .allowsHitTesting(false)
             }
 
             // Animated "recording" badge, top center — visible only in video mode.
@@ -97,6 +111,9 @@ struct CameraScreenView: View {
 struct CameraPreviewView: UIViewRepresentable {
     let session: AVCaptureSession
     let videoOrientation: AVCaptureVideoOrientation
+    /// Reports the letterbox-fitted video rect (view coords) whenever it changes,
+    /// so overlays can position against the image rather than the black bars.
+    var onVideoRectChange: ((CGRect) -> Void)?
 
     final class PreviewHostView: UIView {
         override static var layerClass: AnyClass { AVCaptureVideoPreviewLayer.self }
@@ -104,16 +121,32 @@ struct CameraPreviewView: UIViewRepresentable {
             // swiftlint:disable:next force_cast
             layer as! AVCaptureVideoPreviewLayer
         }
+        var onVideoRectChange: ((CGRect) -> Void)?
+        private var lastRect: CGRect = .zero
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            // The rect the video image actually occupies under .resizeAspect,
+            // in view coordinates. Deferred off the layout pass to avoid
+            // mutating SwiftUI state mid-update.
+            let rect = previewLayer.layerRectConverted(fromMetadataOutputRect: CGRect(x: 0, y: 0, width: 1, height: 1))
+            guard rect.width > 0, rect.height > 0, rect != lastRect else { return }
+            lastRect = rect
+            let callback = onVideoRectChange
+            DispatchQueue.main.async { callback?(rect) }
+        }
     }
 
     func makeUIView(context: Context) -> PreviewHostView {
         let view = PreviewHostView()
         view.previewLayer.videoGravity = .resizeAspect
         view.previewLayer.session = session
+        view.onVideoRectChange = onVideoRectChange
         return view
     }
 
     func updateUIView(_ uiView: PreviewHostView, context: Context) {
+        uiView.onVideoRectChange = onVideoRectChange
         if uiView.previewLayer.session !== session {
             uiView.previewLayer.session = session
         }

--- a/RemoteCam/CameraScreenView.swift
+++ b/RemoteCam/CameraScreenView.swift
@@ -21,6 +21,10 @@ struct CameraScreenView: View {
     /// The letterbox-fitted video rect (view coords), reported by the preview so
     /// the focus reticle lands on the image, not the black bars.
     @State private var videoRect: CGRect = .zero
+    /// Whether the preview is horizontally mirrored (front camera, by default).
+    /// The monitor's frame is never mirrored (the data output isn't), so the
+    /// reticle's x is flipped to match what the camera operator actually sees.
+    @State private var previewMirrored: Bool = false
 
     var body: some View {
         ZStack {
@@ -29,16 +33,22 @@ struct CameraScreenView: View {
             if let session = viewModel.previewSession {
                 CameraPreviewView(session: session,
                                   videoOrientation: viewModel.previewVideoOrientation,
-                                  onVideoRectChange: { videoRect = $0 })
+                                  onGeometryChange: { rect, mirrored in
+                                      videoRect = rect
+                                      previewMirrored = mirrored
+                                  })
                     .ignoresSafeArea()
             }
 
             // Remote focus reticle — the same box/animation the monitor draws,
-            // positioned within the fitted video rect at the tapped point.
+            // positioned within the fitted video rect at the tapped point. x is
+            // flipped when the preview is mirrored (front camera) so the box
+            // lands on the same subject the monitor operator tapped.
             if let indicator = viewModel.focusIndicator, videoRect.width > 0 {
+                let nx = previewMirrored ? (1 - indicator.normalized.x) : indicator.normalized.x
                 FocusReticleView()
                     .id(indicator.id)
-                    .position(x: videoRect.minX + indicator.normalized.x * videoRect.width,
+                    .position(x: videoRect.minX + nx * videoRect.width,
                               y: videoRect.minY + indicator.normalized.y * videoRect.height)
                     .allowsHitTesting(false)
             }
@@ -111,9 +121,10 @@ struct CameraScreenView: View {
 struct CameraPreviewView: UIViewRepresentable {
     let session: AVCaptureSession
     let videoOrientation: AVCaptureVideoOrientation
-    /// Reports the letterbox-fitted video rect (view coords) whenever it changes,
-    /// so overlays can position against the image rather than the black bars.
-    var onVideoRectChange: ((CGRect) -> Void)?
+    /// Reports the letterbox-fitted video rect (view coords) and whether the
+    /// preview is mirrored, whenever either changes, so overlays can position
+    /// against the image (not the black bars) and account for front-camera mirror.
+    var onGeometryChange: ((CGRect, Bool) -> Void)?
 
     final class PreviewHostView: UIView {
         override static var layerClass: AnyClass { AVCaptureVideoPreviewLayer.self }
@@ -121,19 +132,25 @@ struct CameraPreviewView: UIViewRepresentable {
             // swiftlint:disable:next force_cast
             layer as! AVCaptureVideoPreviewLayer
         }
-        var onVideoRectChange: ((CGRect) -> Void)?
-        private var lastRect: CGRect = .zero
+        var onGeometryChange: ((CGRect, Bool) -> Void)?
+        private var last: (rect: CGRect, mirrored: Bool) = (.zero, false)
+
+        /// The rect the video image occupies under .resizeAspect (view coords)
+        /// plus the connection's mirror state. Deferred off the layout pass to
+        /// avoid mutating SwiftUI state mid-update. Called on layout and on
+        /// updateUIView (a camera swap can flip mirroring without a resize).
+        func reportGeometry() {
+            let rect = previewLayer.layerRectConverted(fromMetadataOutputRect: CGRect(x: 0, y: 0, width: 1, height: 1))
+            let mirrored = previewLayer.connection?.isVideoMirrored ?? false
+            guard rect.width > 0, rect.height > 0, (rect, mirrored) != last else { return }
+            last = (rect, mirrored)
+            let callback = onGeometryChange
+            DispatchQueue.main.async { callback?(rect, mirrored) }
+        }
 
         override func layoutSubviews() {
             super.layoutSubviews()
-            // The rect the video image actually occupies under .resizeAspect,
-            // in view coordinates. Deferred off the layout pass to avoid
-            // mutating SwiftUI state mid-update.
-            let rect = previewLayer.layerRectConverted(fromMetadataOutputRect: CGRect(x: 0, y: 0, width: 1, height: 1))
-            guard rect.width > 0, rect.height > 0, rect != lastRect else { return }
-            lastRect = rect
-            let callback = onVideoRectChange
-            DispatchQueue.main.async { callback?(rect) }
+            reportGeometry()
         }
     }
 
@@ -141,15 +158,16 @@ struct CameraPreviewView: UIViewRepresentable {
         let view = PreviewHostView()
         view.previewLayer.videoGravity = .resizeAspect
         view.previewLayer.session = session
-        view.onVideoRectChange = onVideoRectChange
+        view.onGeometryChange = onGeometryChange
         return view
     }
 
     func updateUIView(_ uiView: PreviewHostView, context: Context) {
-        uiView.onVideoRectChange = onVideoRectChange
+        uiView.onGeometryChange = onGeometryChange
         if uiView.previewLayer.session !== session {
             uiView.previewLayer.session = session
         }
+        defer { uiView.reportGeometry() }
         // Same policy as the capture connections (OrientationUtils): iOS
         // rotates the preview to the interface; Mac cameras render native.
         guard OrientationUtils.appliesInterfaceRotation,

--- a/RemoteCam/CameraScreenView.swift
+++ b/RemoteCam/CameraScreenView.swift
@@ -38,19 +38,10 @@ struct CameraScreenView: View {
                                       previewMirrored = mirrored
                                   })
                     .ignoresSafeArea()
-            }
-
-            // Remote focus reticle — the same box/animation the monitor draws,
-            // positioned within the fitted video rect at the tapped point. x is
-            // flipped when the preview is mirrored (front camera) so the box
-            // lands on the same subject the monitor operator tapped.
-            if let indicator = viewModel.focusIndicator, videoRect.width > 0 {
-                let nx = previewMirrored ? (1 - indicator.normalized.x) : indicator.normalized.x
-                FocusReticleView()
-                    .id(indicator.id)
-                    .position(x: videoRect.minX + nx * videoRect.width,
-                              y: videoRect.minY + indicator.normalized.y * videoRect.height)
-                    .allowsHitTesting(false)
+                    // The reticle overlays the preview so it shares the preview
+                    // layer's full-screen coordinate space — `videoRect` is in
+                    // those coords, so positioning here has no safe-area offset.
+                    .overlay(focusReticleOverlay)
             }
 
             // Animated "recording" badge, top center — visible only in video mode.
@@ -90,6 +81,23 @@ struct CameraScreenView: View {
                 isRecording: viewModel.isRecordingTimerActive)
 
             CameraProgressOverlayView(viewModel: viewModel)
+        }
+    }
+
+    /// The remote focus reticle — the same box/animation the monitor draws,
+    /// positioned within the fitted video rect at the tapped point. x is flipped
+    /// when the preview is mirrored (front camera) so the box lands on the same
+    /// subject the monitor operator tapped. Drawn as a preview overlay so it
+    /// shares the preview layer's coordinate space (no safe-area offset).
+    @ViewBuilder
+    private var focusReticleOverlay: some View {
+        if let indicator = viewModel.focusIndicator, videoRect.width > 0 {
+            let nx = previewMirrored ? (1 - indicator.normalized.x) : indicator.normalized.x
+            FocusReticleView()
+                .id(indicator.id)
+                .position(x: videoRect.minX + nx * videoRect.width,
+                          y: videoRect.minY + indicator.normalized.y * videoRect.height)
+                .allowsHitTesting(false)
         }
     }
 

--- a/RemoteCam/CameraViewModel.swift
+++ b/RemoteCam/CameraViewModel.swift
@@ -145,6 +145,29 @@ class CameraViewModel: ObservableObject {
         }
     }
 
+    // MARK: - Remote Focus Indicator
+    /// Shown when a remote focus command arrives, so the person holding the
+    /// camera sees the tap register — the same reticle the monitor draws.
+    /// `normalized` is 0..1 in the upright display image (origin top-left).
+    @Published var focusIndicator: RemoteFocusIndicator?
+
+    struct RemoteFocusIndicator: Equatable {
+        let id = UUID()
+        let normalized: CGPoint
+    }
+
+    func showRemoteFocus(x: Float, y: Float) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            let indicator = RemoteFocusIndicator(normalized: CGPoint(x: CGFloat(x), y: CGFloat(y)))
+            self.focusIndicator = indicator
+            // Match the monitor reticle's lifetime.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
+                if self?.focusIndicator?.id == indicator.id { self?.focusIndicator = nil }
+            }
+        }
+    }
+
     // MARK: - Toast
     @Published var showRemoteHint: Bool = false
     private var remoteHintWorkItem: DispatchWorkItem?

--- a/RemoteCam/CaptureEngine.swift
+++ b/RemoteCam/CaptureEngine.swift
@@ -338,6 +338,7 @@ final class CaptureEngine: NSObject, AVCapturePhotoCaptureDelegate {
         let newFlashMode: AVCaptureDevice.FlashMode? = newDevice.hasFlash ? cameraSettings.flashMode : nil
         captureSession.commitConfiguration()
         applyDesiredTorchLocked()   // restore torch onto the new camera (no-op if it has none)
+        resetFocusExposureToAutoLocked()   // a stale focus point must not carry across a device change
         // Swapping away from a dead device must also revive a session that a
         // runtime error stopped — otherwise the new camera never delivers.
         if isExpectedToRun && !captureSession.isRunning {
@@ -930,6 +931,8 @@ final class CaptureEngine: NSObject, AVCapturePhotoCaptureDelegate {
             currentHDRMode: currentHDRMode,
             cameraDevices: deviceEntries,
             activeDeviceID: activeDeviceID,
+            supportsFocusPoint: currentDevice.isFocusPointOfInterestSupported
+                || currentDevice.isExposurePointOfInterestSupported,
             error: nil
         )
 
@@ -972,6 +975,77 @@ final class CaptureEngine: NSObject, AVCapturePhotoCaptureDelegate {
         default: return nil
         }
         #endif
+    }
+
+    // MARK: - Focus / Exposure Point
+
+    /// Sets the focus and exposure point of interest from a monitor tap. `point`
+    /// is normalized (0..1) in the upright display image (origin top-left). No-op
+    /// if the active device supports neither point of interest.
+    func setFocusExposurePoint(displayNormalized point: CGPoint) async throws {
+        try await onSessionQueueThrowing { try self.setFocusExposurePointLocked(displayNormalized: point) }
+    }
+
+    private func setFocusExposurePointLocked(displayNormalized point: CGPoint) throws {
+        dispatchPrecondition(condition: .onQueue(sessionQueue))
+        guard let device = self.videoDeviceInput?.device else {
+            throw NSError(domain: "No camera device available", code: 0, userInfo: nil)
+        }
+
+        guard device.isFocusPointOfInterestSupported || device.isExposurePointOfInterestSupported else {
+            debugLog("🎯 DEBUG: focus/exposure POI unsupported on \(device.localizedName) — ignoring tap")
+            return
+        }
+
+        // The buffer the monitor tapped was rotated into this orientation before
+        // it left the camera; front preview is shown mirrored. Invert both.
+        let videoOrientation: AVCaptureVideoOrientation =
+            OrientationUtils.appliesInterfaceRotation
+            ? OrientationUtils.transform(o: self.orientation)
+            : .landscapeRight
+        let poi = FocusPointMapping.devicePoint(displayNormalized: point,
+                                                videoOrientation: videoOrientation,
+                                                mirrored: device.position == .front)
+
+        try device.lockForConfiguration()
+        defer { device.unlockForConfiguration() }
+
+        if device.isFocusPointOfInterestSupported {
+            device.focusPointOfInterest = poi
+            if device.isFocusModeSupported(.continuousAutoFocus) {
+                device.focusMode = .continuousAutoFocus
+            } else if device.isFocusModeSupported(.autoFocus) {
+                device.focusMode = .autoFocus
+            }
+        }
+        if device.isExposurePointOfInterestSupported {
+            device.exposurePointOfInterest = poi
+            if device.isExposureModeSupported(.continuousAutoExposure) {
+                device.exposureMode = .continuousAutoExposure
+            } else if device.isExposureModeSupported(.autoExpose) {
+                device.exposureMode = .autoExpose
+            }
+        }
+        debugLog("🎯 DEBUG: focus/exposure POI set to \(poi) (orientation \(videoOrientation.rawValue))")
+    }
+
+    /// Restores continuous auto focus/exposure at the center. Called when the
+    /// active camera changes so a stale point of interest does not persist.
+    func resetFocusExposureToAutoLocked() {
+        dispatchPrecondition(condition: .onQueue(sessionQueue))
+        guard let device = self.videoDeviceInput?.device,
+              device.isFocusPointOfInterestSupported || device.isExposurePointOfInterestSupported,
+              (try? device.lockForConfiguration()) != nil else { return }
+        defer { device.unlockForConfiguration() }
+        let center = CGPoint(x: 0.5, y: 0.5)
+        if device.isFocusPointOfInterestSupported {
+            device.focusPointOfInterest = center
+            if device.isFocusModeSupported(.continuousAutoFocus) { device.focusMode = .continuousAutoFocus }
+        }
+        if device.isExposurePointOfInterestSupported {
+            device.exposurePointOfInterest = center
+            if device.isExposureModeSupported(.continuousAutoExposure) { device.exposureMode = .continuousAutoExposure }
+        }
     }
 
     // MARK: - Enhanced Zoom Control Methods

--- a/RemoteCam/CaptureEngine.swift
+++ b/RemoteCam/CaptureEngine.swift
@@ -931,6 +931,8 @@ final class CaptureEngine: NSObject, AVCapturePhotoCaptureDelegate {
             currentHDRMode: currentHDRMode,
             cameraDevices: deviceEntries,
             activeDeviceID: activeDeviceID,
+            // Matches setFocusExposurePointLocked's apply predicate: a device that
+            // supports only exposure POI still benefits from a tap.
             supportsFocusPoint: currentDevice.isFocusPointOfInterestSupported
                 || currentDevice.isExposurePointOfInterestSupported,
             error: nil

--- a/RemoteCam/FeatureFlags.swift
+++ b/RemoteCam/FeatureFlags.swift
@@ -25,6 +25,12 @@ struct FeatureFlags {
     /// Enable Apple Watch companion app as standalone remote control
     static let ENABLE_WATCH_APP = true
 
+    /// Show the auto-renewable Pro subscription (Monthly/Yearly) in the paywall.
+    /// Off until the subscription is a validated experiment: the products exist
+    /// on App Store Connect but are not submitted for review, Pro stays a $9.99
+    /// one-time buy, and the entitlement code stays in place for when it flips on.
+    static let ENABLE_PRO_SUBSCRIPTION = false
+
     /// Show the local camera-device picker on the camera screen. On for Mac
     /// Catalyst only (a Mac has N cameras — built-in, Continuity, USB);
     /// iPhone keeps its flip button.

--- a/RemoteCam/FlatBufferSchemas.fbs
+++ b/RemoteCam/FlatBufferSchemas.fbs
@@ -31,10 +31,14 @@ enum CommandAction : byte {
     SelectCameraDevice = 19,   // never sent to peers that did not advertise
                                // camera_devices — old decoders read unknown
                                // actions as TakePicture (the field default)
-    RequestKeyframe = 20       // monitor -> camera: force the next VP9 preview
+    RequestKeyframe = 20,      // monitor -> camera: force the next VP9 preview
                                // frame to be a keyframe (decoder desync
                                // recovery). Only sent to a peer that has
                                // already delivered a VP9 frame — old decoders
+                               // read unknown actions as TakePicture.
+    FocusAtPoint = 21          // monitor -> camera: set focus/exposure point of
+                               // interest (normalized). Only sent to a peer that
+                               // advertised supports_focus_point — old decoders
                                // read unknown actions as TakePicture.
 }
 
@@ -141,6 +145,8 @@ table CommandParameters {
     aspect_ratio: AspectRatioEnum;
     // Appended fields only below this line (FlatBuffers schema evolution).
     device_unique_id: string;        // payload for SelectCameraDevice
+    focus_point_x: float;            // payload for FocusAtPoint (normalized 0..1,
+    focus_point_y: float;            // upright-display space; origin top-left)
 }
 
 // MARK: - Command Structure
@@ -229,6 +235,9 @@ table CameraCapabilities {
     // not send SelectCameraDevice to such a peer.
     camera_devices: [CameraDeviceInfo];
     active_device_id: string;
+    // False/absent = peer predates tap-to-focus; a monitor must not send
+    // FocusAtPoint to such a peer (old decoders read it as TakePicture).
+    supports_focus_point: bool;
 }
 
 // MARK: - Response Structure

--- a/RemoteCam/FlatBufferSchemas_generated.swift
+++ b/RemoteCam/FlatBufferSchemas_generated.swift
@@ -29,8 +29,9 @@ public enum RemoteShutter_CommandAction: Int8, Enum, Verifiable {
   case setaspectratio = 18
   case selectcameradevice = 19
   case requestkeyframe = 20
+  case focusatpoint = 21
 
-  public static var max: RemoteShutter_CommandAction { return .requestkeyframe }
+  public static var max: RemoteShutter_CommandAction { return .focusatpoint }
   public static var min: RemoteShutter_CommandAction { return .takepicture }
 }
 
@@ -311,6 +312,8 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
     case recordingMode = 30
     case aspectRatio = 32
     case deviceUniqueId = 34
+    case focusPointX = 36
+    case focusPointY = 38
     var v: Int32 { Int32(self.rawValue) }
     var p: VOffset { self.rawValue }
   }
@@ -334,7 +337,9 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
   public var aspectRatio: RemoteShutter_AspectRatioEnum { let o = _accessor.offset(VTOFFSET.aspectRatio.v); return o == 0 ? .unknown : RemoteShutter_AspectRatioEnum(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .unknown }
   public var deviceUniqueId: String? { let o = _accessor.offset(VTOFFSET.deviceUniqueId.v); return o == 0 ? nil : _accessor.string(at: o) }
   public var deviceUniqueIdSegmentArray: [UInt8]? { return _accessor.getVector(at: VTOFFSET.deviceUniqueId.v) }
-  public static func startCommandParameters(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 16) }
+  public var focusPointX: Float32 { let o = _accessor.offset(VTOFFSET.focusPointX.v); return o == 0 ? 0.0 : _accessor.readBuffer(of: Float32.self, at: o) }
+  public var focusPointY: Float32 { let o = _accessor.offset(VTOFFSET.focusPointY.v); return o == 0 ? 0.0 : _accessor.readBuffer(of: Float32.self, at: o) }
+  public static func startCommandParameters(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 18) }
   public static func add(sendToRemote: Bool, _ fbb: inout FlatBufferBuilder) { fbb.add(element: sendToRemote, def: false,
    at: VTOFFSET.sendToRemote.p) }
   public static func add(zoomFactor: Double, _ fbb: inout FlatBufferBuilder) { fbb.add(element: zoomFactor, def: 0.0, at: VTOFFSET.zoomFactor.p) }
@@ -352,6 +357,8 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
   public static func add(recordingMode: RemoteShutter_RecordingModeEnum, _ fbb: inout FlatBufferBuilder) { fbb.add(element: recordingMode.rawValue, def: 0, at: VTOFFSET.recordingMode.p) }
   public static func add(aspectRatio: RemoteShutter_AspectRatioEnum, _ fbb: inout FlatBufferBuilder) { fbb.add(element: aspectRatio.rawValue, def: 0, at: VTOFFSET.aspectRatio.p) }
   public static func add(deviceUniqueId: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: deviceUniqueId, at: VTOFFSET.deviceUniqueId.p) }
+  public static func add(focusPointX: Float32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: focusPointX, def: 0.0, at: VTOFFSET.focusPointX.p) }
+  public static func add(focusPointY: Float32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: focusPointY, def: 0.0, at: VTOFFSET.focusPointY.p) }
   public static func endCommandParameters(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createCommandParameters(
     _ fbb: inout FlatBufferBuilder,
@@ -370,7 +377,9 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
     countdownValue: Int32 = 0,
     recordingMode: RemoteShutter_RecordingModeEnum = .unknown,
     aspectRatio: RemoteShutter_AspectRatioEnum = .unknown,
-    deviceUniqueIdOffset deviceUniqueId: Offset = Offset()
+    deviceUniqueIdOffset deviceUniqueId: Offset = Offset(),
+    focusPointX: Float32 = 0.0,
+    focusPointY: Float32 = 0.0
   ) -> Offset {
     let __start = RemoteShutter_CommandParameters.startCommandParameters(&fbb)
     RemoteShutter_CommandParameters.add(sendToRemote: sendToRemote, &fbb)
@@ -389,6 +398,8 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
     RemoteShutter_CommandParameters.add(recordingMode: recordingMode, &fbb)
     RemoteShutter_CommandParameters.add(aspectRatio: aspectRatio, &fbb)
     RemoteShutter_CommandParameters.add(deviceUniqueId: deviceUniqueId, &fbb)
+    RemoteShutter_CommandParameters.add(focusPointX: focusPointX, &fbb)
+    RemoteShutter_CommandParameters.add(focusPointY: focusPointY, &fbb)
     return RemoteShutter_CommandParameters.endCommandParameters(&fbb, start: __start)
   }
 
@@ -410,6 +421,8 @@ public struct RemoteShutter_CommandParameters: FlatBufferObject, Verifiable {
     try _v.visit(field: VTOFFSET.recordingMode.p, fieldName: "recordingMode", required: false, type: RemoteShutter_RecordingModeEnum.self)
     try _v.visit(field: VTOFFSET.aspectRatio.p, fieldName: "aspectRatio", required: false, type: RemoteShutter_AspectRatioEnum.self)
     try _v.visit(field: VTOFFSET.deviceUniqueId.p, fieldName: "deviceUniqueId", required: false, type: ForwardOffset<String>.self)
+    try _v.visit(field: VTOFFSET.focusPointX.p, fieldName: "focusPointX", required: false, type: Float32.self)
+    try _v.visit(field: VTOFFSET.focusPointY.p, fieldName: "focusPointY", required: false, type: Float32.self)
     _v.finish()
   }
 }
@@ -968,6 +981,7 @@ public struct RemoteShutter_CameraCapabilities: FlatBufferObject, Verifiable {
     case backCamera = 6
     case cameraDevices = 8
     case activeDeviceId = 10
+    case supportsFocusPoint = 12
     var v: Int32 { Int32(self.rawValue) }
     var p: VOffset { self.rawValue }
   }
@@ -979,24 +993,29 @@ public struct RemoteShutter_CameraCapabilities: FlatBufferObject, Verifiable {
   public func cameraDevices(at index: Int32) -> RemoteShutter_CameraDeviceInfo? { let o = _accessor.offset(VTOFFSET.cameraDevices.v); return o == 0 ? nil : RemoteShutter_CameraDeviceInfo(_accessor.bb, o: _accessor.indirect(_accessor.vector(at: o) + index * 4)) }
   public var activeDeviceId: String? { let o = _accessor.offset(VTOFFSET.activeDeviceId.v); return o == 0 ? nil : _accessor.string(at: o) }
   public var activeDeviceIdSegmentArray: [UInt8]? { return _accessor.getVector(at: VTOFFSET.activeDeviceId.v) }
-  public static func startCameraCapabilities(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 4) }
+  public var supportsFocusPoint: Bool { let o = _accessor.offset(VTOFFSET.supportsFocusPoint.v); return o == 0 ? false : _accessor.readBuffer(of: Bool.self, at: o) }
+  public static func startCameraCapabilities(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 5) }
   public static func add(frontCamera: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: frontCamera, at: VTOFFSET.frontCamera.p) }
   public static func add(backCamera: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: backCamera, at: VTOFFSET.backCamera.p) }
   public static func addVectorOf(cameraDevices: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: cameraDevices, at: VTOFFSET.cameraDevices.p) }
   public static func add(activeDeviceId: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: activeDeviceId, at: VTOFFSET.activeDeviceId.p) }
+  public static func add(supportsFocusPoint: Bool, _ fbb: inout FlatBufferBuilder) { fbb.add(element: supportsFocusPoint, def: false,
+   at: VTOFFSET.supportsFocusPoint.p) }
   public static func endCameraCapabilities(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createCameraCapabilities(
     _ fbb: inout FlatBufferBuilder,
     frontCameraOffset frontCamera: Offset = Offset(),
     backCameraOffset backCamera: Offset = Offset(),
     cameraDevicesVectorOffset cameraDevices: Offset = Offset(),
-    activeDeviceIdOffset activeDeviceId: Offset = Offset()
+    activeDeviceIdOffset activeDeviceId: Offset = Offset(),
+    supportsFocusPoint: Bool = false
   ) -> Offset {
     let __start = RemoteShutter_CameraCapabilities.startCameraCapabilities(&fbb)
     RemoteShutter_CameraCapabilities.add(frontCamera: frontCamera, &fbb)
     RemoteShutter_CameraCapabilities.add(backCamera: backCamera, &fbb)
     RemoteShutter_CameraCapabilities.addVectorOf(cameraDevices: cameraDevices, &fbb)
     RemoteShutter_CameraCapabilities.add(activeDeviceId: activeDeviceId, &fbb)
+    RemoteShutter_CameraCapabilities.add(supportsFocusPoint: supportsFocusPoint, &fbb)
     return RemoteShutter_CameraCapabilities.endCameraCapabilities(&fbb, start: __start)
   }
 
@@ -1006,6 +1025,7 @@ public struct RemoteShutter_CameraCapabilities: FlatBufferObject, Verifiable {
     try _v.visit(field: VTOFFSET.backCamera.p, fieldName: "backCamera", required: false, type: ForwardOffset<RemoteShutter_CameraInfo>.self)
     try _v.visit(field: VTOFFSET.cameraDevices.p, fieldName: "cameraDevices", required: false, type: ForwardOffset<Vector<ForwardOffset<RemoteShutter_CameraDeviceInfo>, RemoteShutter_CameraDeviceInfo>>.self)
     try _v.visit(field: VTOFFSET.activeDeviceId.p, fieldName: "activeDeviceId", required: false, type: ForwardOffset<String>.self)
+    try _v.visit(field: VTOFFSET.supportsFocusPoint.p, fieldName: "supportsFocusPoint", required: false, type: Bool.self)
     _v.finish()
   }
 }

--- a/RemoteCam/FocusPointMapping.swift
+++ b/RemoteCam/FocusPointMapping.swift
@@ -1,0 +1,97 @@
+//
+//  FocusPointMapping.swift
+//  RemoteShutter
+//
+//  Pure geometry for tap-to-focus. The monitor taps a point on the live
+//  preview and sends it normalized (0..1) in the *upright display image*
+//  space (origin top-left, x → right, y → down). The camera must convert that
+//  into `AVCaptureDevice.focusPointOfInterest` space before applying it.
+//
+//  `focusPointOfInterest` is defined relative to the sensor's native readout,
+//  which corresponds to `AVCaptureVideoOrientation.landscapeRight` (AVFoundation's
+//  default connection orientation) being the identity. The preview frame was
+//  rotated from that reference into the connection's current `videoOrientation`
+//  before it left the camera, so mapping a display point back to device space
+//  is the inverse of that rotation, plus an un-mirror for the front camera
+//  (whose preview is shown horizontally mirrored).
+//
+//  This is deliberately isolated and pure so it can be unit-tested and,
+//  crucially, validated/tuned against real hardware in CaptureIntegrationTests
+//  (Catalyst) — the sensor/orientation conventions are the kind of thing a
+//  code-read gets subtly wrong.
+//
+
+import CoreGraphics
+import AVFoundation
+
+enum FocusPointMapping {
+
+    /// Converts a normalized preview-tap point into `focusPointOfInterest`
+    /// device space.
+    ///
+    /// - Parameters:
+    ///   - point: normalized (0..1) point in the upright display image, origin
+    ///     top-left. Values outside [0,1] are clamped.
+    ///   - videoOrientation: the orientation the preview buffer was rotated into
+    ///     (i.e. the capture connection's `videoOrientation`). On landscape-native
+    ///     Mac cameras this is `.landscapeRight` (identity).
+    ///   - mirrored: true when the displayed image is horizontally mirrored
+    ///     relative to the sensor (the front camera).
+    /// - Returns: a point in `focusPointOfInterest` space, clamped to [0,1].
+    static func devicePoint(displayNormalized point: CGPoint,
+                            videoOrientation: AVCaptureVideoOrientation,
+                            mirrored: Bool) -> CGPoint {
+        // Work in clamped, mirror-corrected display coordinates first.
+        var px = clamp01(point.x)
+        let py = clamp01(point.y)
+        if mirrored { px = 1 - px }
+
+        // Invert the display rotation back to the landscapeRight-identity
+        // reference used by focusPointOfInterest.
+        let device: CGPoint
+        switch videoOrientation {
+        case .landscapeRight:
+            device = CGPoint(x: px, y: py)
+        case .landscapeLeft:
+            device = CGPoint(x: 1 - px, y: 1 - py)
+        case .portrait:
+            device = CGPoint(x: py, y: 1 - px)
+        case .portraitUpsideDown:
+            device = CGPoint(x: 1 - py, y: px)
+        @unknown default:
+            device = CGPoint(x: px, y: py)
+        }
+        return CGPoint(x: clamp01(device.x), y: clamp01(device.y))
+    }
+
+    private static func clamp01(_ v: CGFloat) -> CGFloat {
+        min(1, max(0, v))
+    }
+
+    /// Maps a tap point in an aspect-fit (`.fit`, letterboxed) preview into a
+    /// normalized image point (0..1, origin top-left). Returns nil when the tap
+    /// lands in the letterbox/pillarbox bars, i.e. off the image — those taps
+    /// must not focus.
+    ///
+    /// - Parameters:
+    ///   - tap: tap location in the preview view's coordinate space.
+    ///   - viewSize: the preview view's size.
+    ///   - imageSize: the displayed image's pixel size.
+    static func normalizedImagePoint(tap: CGPoint,
+                                     viewSize: CGSize,
+                                     imageSize: CGSize) -> CGPoint? {
+        guard viewSize.width > 0, viewSize.height > 0,
+              imageSize.width > 0, imageSize.height > 0 else { return nil }
+        let imageRatio = imageSize.width / imageSize.height
+        let viewRatio = viewSize.width / viewSize.height
+        let fitted: CGSize = imageRatio > viewRatio
+            ? CGSize(width: viewSize.width, height: viewSize.width / imageRatio)
+            : CGSize(width: viewSize.height * imageRatio, height: viewSize.height)
+        let xOffset = (viewSize.width - fitted.width) / 2
+        let yOffset = (viewSize.height - fitted.height) / 2
+        let nx = (tap.x - xOffset) / fitted.width
+        let ny = (tap.y - yOffset) / fitted.height
+        guard (0...1).contains(nx), (0...1).contains(ny) else { return nil }
+        return CGPoint(x: nx, y: ny)
+    }
+}

--- a/RemoteCam/MonitorView.swift
+++ b/RemoteCam/MonitorView.swift
@@ -116,7 +116,40 @@ struct MonitorView: View {
                     Spacer()
                 }
             }
-            
+
+            // Preview gestures live on this layer, which sits BELOW the
+            // interactive zoom pill (added next) so a tap on the pill is never
+            // stolen as a focus tap. Double tap toggles the camera; a single tap
+            // focuses (runs simultaneously so the reticle is instant — an
+            // exclusive gesture would stall it for the double-tap window); pinch
+            // zooms. The translation guard keeps drags/pinches from focusing.
+            Color.clear
+                .contentShape(Rectangle())
+                .onTapGesture(count: 2) {
+                    onToggleCamera()
+                }
+                .simultaneousGesture(
+                    DragGesture(minimumDistance: 0)
+                        .onEnded { value in
+                            if abs(value.translation.width) < 10, abs(value.translation.height) < 10 {
+                                handleFocusTap(at: value.location)
+                            }
+                        }
+                )
+                .simultaneousGesture(
+                    MagnificationGesture()
+                        .onChanged { value in
+                            if zoomAtGestureStart == nil {
+                                zoomAtGestureStart = viewModel.currentZoomFactor
+                            }
+                            let start = zoomAtGestureStart!
+                            onZoomChange(viewModel.zoomScale.pinched(from: start, magnification: value))
+                        }
+                        .onEnded { _ in
+                            zoomAtGestureStart = nil
+                        }
+                )
+
             zoomControls
 
             // Video transfer progress overlay - positioned at center
@@ -155,36 +188,6 @@ struct MonitorView: View {
         )
         .onPreferenceChange(PreviewSizePreferenceKey.self) { previewSize = $0 }
         .overlay(focusReticleOverlay)
-        // Double tap toggles the camera. Tap-to-focus runs SIMULTANEOUSLY (not
-        // exclusively) so the reticle is instant — an exclusive gesture would
-        // stall every focus tap for the double-tap disambiguation window. A
-        // double tap harmlessly focuses on the first tap, then toggles.
-        .onTapGesture(count: 2) {
-            onToggleCamera()
-        }
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onEnded { value in
-                    // Only a tap (near-zero travel) focuses — not a drag or pinch.
-                    if abs(value.translation.width) < 10, abs(value.translation.height) < 10 {
-                        handleFocusTap(at: value.location)
-                    }
-                }
-        )
-        .simultaneousGesture(
-            MagnificationGesture()
-                .onChanged { value in
-                    // Capture zoom at gesture start (first onChanged)
-                    if zoomAtGestureStart == nil {
-                        zoomAtGestureStart = viewModel.currentZoomFactor
-                    }
-                    let start = zoomAtGestureStart!
-                    onZoomChange(viewModel.zoomScale.pinched(from: start, magnification: value))
-                }
-                .onEnded { _ in
-                    zoomAtGestureStart = nil
-                }
-        )
     }
 
     /// The focus reticle, drawn in the preview's coordinate space. Non-interactive

--- a/RemoteCam/MonitorView.swift
+++ b/RemoteCam/MonitorView.swift
@@ -155,16 +155,21 @@ struct MonitorView: View {
         )
         .onPreferenceChange(PreviewSizePreferenceKey.self) { previewSize = $0 }
         .overlay(focusReticleOverlay)
-        // Double tap toggles the camera and takes precedence; a genuine single
-        // tap falls through to tap-to-focus (with its location). Pinch-to-zoom
-        // runs simultaneously (two fingers vs one).
-        .gesture(
-            ExclusiveGesture(
-                TapGesture(count: 2).onEnded { onToggleCamera() },
-                DragGesture(minimumDistance: 0).onEnded { value in
-                    handleFocusTap(at: value.location)
+        // Double tap toggles the camera. Tap-to-focus runs SIMULTANEOUSLY (not
+        // exclusively) so the reticle is instant — an exclusive gesture would
+        // stall every focus tap for the double-tap disambiguation window. A
+        // double tap harmlessly focuses on the first tap, then toggles.
+        .onTapGesture(count: 2) {
+            onToggleCamera()
+        }
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onEnded { value in
+                    // Only a tap (near-zero travel) focuses — not a drag or pinch.
+                    if abs(value.translation.width) < 10, abs(value.translation.height) < 10 {
+                        handleFocusTap(at: value.location)
+                    }
                 }
-            )
         )
         .simultaneousGesture(
             MagnificationGesture()
@@ -208,7 +213,7 @@ struct MonitorView: View {
     private func showFocusReticle(at point: CGPoint) {
         let reticle = FocusReticle(point: point)
         focusReticle = reticle
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.9) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
             if focusReticle?.id == reticle.id { focusReticle = nil }
         }
     }
@@ -686,7 +691,7 @@ private struct PreviewSizePreferenceKey: PreferenceKey {
 /// The animated focus square: a yellow reticle that pulses in and fades. Purely
 /// local tap feedback — the focus command travels separately.
 struct FocusReticleView: View {
-    @State private var scale: CGFloat = 1.3
+    @State private var scale: CGFloat = 1.25
     @State private var opacity: Double = 0
 
     var body: some View {
@@ -696,11 +701,11 @@ struct FocusReticleView: View {
             .scaleEffect(scale)
             .opacity(opacity)
             .onAppear {
-                withAnimation(.easeOut(duration: 0.25)) {
+                withAnimation(.easeOut(duration: 0.12)) {
                     scale = 1.0
                     opacity = 1
                 }
-                withAnimation(.easeIn(duration: 0.35).delay(0.5)) {
+                withAnimation(.easeIn(duration: 0.2).delay(0.35)) {
                     opacity = 0
                 }
             }

--- a/RemoteCam/MonitorView.swift
+++ b/RemoteCam/MonitorView.swift
@@ -22,7 +22,16 @@ struct MonitorView: View {
     let onVideoQualityChange: (VideoResolution, VideoFrameRate) -> Void
     let onPhotoQualityChange: (PhotoFormat, HDRMode) -> Void
     let onAspectRatioChange: (AspectRatio) -> Void
-    
+    /// Tap-to-focus: the tap point normalized (0..1) in the displayed image,
+    /// origin top-left. Not called for taps that land in the letterbox bars.
+    let onFocusTap: (CGPoint) -> Void
+
+    /// The live focus reticle (view-space position + identity to re-trigger the
+    /// animation on each tap). Local UI only — no round-trip to the camera.
+    @State private var focusReticle: FocusReticle?
+    /// The preview area's measured size, for tap → normalized-image mapping.
+    @State private var previewSize: CGSize = .zero
+
     var body: some View {
         GeometryReader { geometry in
             ZStack {
@@ -139,11 +148,25 @@ struct MonitorView: View {
             }
 
         }
-        .onTapGesture(count: 2) {
-            // Double tap to toggle camera
-            onToggleCamera()
-        }
+        .background(
+            GeometryReader { geo in
+                Color.clear.preference(key: PreviewSizePreferenceKey.self, value: geo.size)
+            }
+        )
+        .onPreferenceChange(PreviewSizePreferenceKey.self) { previewSize = $0 }
+        .overlay(focusReticleOverlay)
+        // Double tap toggles the camera and takes precedence; a genuine single
+        // tap falls through to tap-to-focus (with its location). Pinch-to-zoom
+        // runs simultaneously (two fingers vs one).
         .gesture(
+            ExclusiveGesture(
+                TapGesture(count: 2).onEnded { onToggleCamera() },
+                DragGesture(minimumDistance: 0).onEnded { value in
+                    handleFocusTap(at: value.location)
+                }
+            )
+        )
+        .simultaneousGesture(
             MagnificationGesture()
                 .onChanged { value in
                     // Capture zoom at gesture start (first onChanged)
@@ -157,6 +180,37 @@ struct MonitorView: View {
                     zoomAtGestureStart = nil
                 }
         )
+    }
+
+    /// The focus reticle, drawn in the preview's coordinate space. Non-interactive
+    /// so it never eats a subsequent tap.
+    @ViewBuilder
+    private var focusReticleOverlay: some View {
+        if let reticle = focusReticle {
+            FocusReticleView()
+                .id(reticle.id)
+                .position(reticle.point)
+                .allowsHitTesting(false)
+        }
+    }
+
+    /// Maps a preview tap into a normalized image point and, if it landed on the
+    /// image (not the letterbox), shows the reticle and forwards it to the camera.
+    private func handleFocusTap(at location: CGPoint) {
+        guard let image = viewModel.frames.cameraImage,
+              let normalized = FocusPointMapping.normalizedImagePoint(
+                tap: location, viewSize: previewSize, imageSize: image.size)
+        else { return }
+        showFocusReticle(at: location)
+        onFocusTap(normalized)
+    }
+
+    private func showFocusReticle(at point: CGPoint) {
+        let reticle = FocusReticle(point: point)
+        focusReticle = reticle
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.9) {
+            if focusReticle?.id == reticle.id { focusReticle = nil }
+        }
     }
     
     // MARK: - Recording Indicator
@@ -569,7 +623,8 @@ struct MonitorView_Previews: PreviewProvider {
             onZoomChange: { _ in },
             onVideoQualityChange: { _, _ in },
             onPhotoQualityChange: { _, _ in },
-            onAspectRatioChange: { _ in }
+            onAspectRatioChange: { _ in },
+            onFocusTap: { _ in }
         )
         .preferredColorScheme(.dark)
     }
@@ -606,6 +661,49 @@ struct LiveFrameView: View {
                         .foregroundColor(.white.opacity(0.5))
                 )
         }
+    }
+}
+
+// MARK: - Tap to Focus
+
+/// One tap-to-focus reticle: its view-space position plus an identity so a new
+/// tap re-instantiates `FocusReticleView` and replays its animation.
+struct FocusReticle: Equatable {
+    let id = UUID()
+    let point: CGPoint
+}
+
+/// Measures the preview area's size so a tap can be mapped to a normalized image
+/// point. A preference key avoids mutating `@State` during layout.
+private struct PreviewSizePreferenceKey: PreferenceKey {
+    static var defaultValue: CGSize = .zero
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+        let next = nextValue()
+        if next != .zero { value = next }
+    }
+}
+
+/// The animated focus square: a yellow reticle that pulses in and fades. Purely
+/// local tap feedback — the focus command travels separately.
+struct FocusReticleView: View {
+    @State private var scale: CGFloat = 1.3
+    @State private var opacity: Double = 0
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 6)
+            .stroke(Color.yellow, lineWidth: 1.5)
+            .frame(width: 78, height: 78)
+            .scaleEffect(scale)
+            .opacity(opacity)
+            .onAppear {
+                withAnimation(.easeOut(duration: 0.25)) {
+                    scale = 1.0
+                    opacity = 1
+                }
+                withAnimation(.easeIn(duration: 0.35).delay(0.5)) {
+                    opacity = 0
+                }
+            }
     }
 }
 

--- a/RemoteCam/MonitorViewController+SwiftUI.swift
+++ b/RemoteCam/MonitorViewController+SwiftUI.swift
@@ -49,6 +49,9 @@ extension MonitorViewController {
             },
             onAspectRatioChange: { [weak self] ratio in
                 self?.handleAspectRatioChange(ratio)
+            },
+            onFocusTap: { [weak self] point in
+                self?.handleFocusTap(point)
             }
         )
         
@@ -179,7 +182,18 @@ extension MonitorViewController {
             handleSettingsTapped()
         }
     }
-    
+
+    /// Tap-to-focus. Gated behind its own entitlement; a locked user is routed to
+    /// the paywall (mirrors torch). The coordinator additionally drops the command
+    /// if the camera peer never advertised focus support.
+    private func handleFocusTap(_ point: CGPoint) {
+        guard StoreManager.shared.hasTapToFocusFeature() else {
+            handleSettingsTapped()
+            return
+        }
+        session ! UICmd.FocusAtPoint(x: Float(point.x), y: Float(point.y))
+    }
+
     private func handleTimerChange(_ value: Int) {
         viewModel.timerSliderValue = Double(value)
         // UserDefaults persistence is now handled in the view model

--- a/RemoteCam/PurchaseManaging.swift
+++ b/RemoteCam/PurchaseManaging.swift
@@ -11,7 +11,8 @@ extension PurchaseManaging {
 
     func observePurchaseNotifications() {
         let names: [Notification.Name] = [
-            .removeAds, .proModeAcquired, .enableTorch, .enableVideoOnly
+            .removeAds, .proModeAcquired, .enableTorch, .enableVideoOnly,
+            .tapToFocusAcquired, .proSubscriptionAcquired
         ]
         for name in names {
             let observer = NotificationCenter.default.addObserver(

--- a/RemoteCam/RemoteCmdFlatBuffers.swift
+++ b/RemoteCam/RemoteCmdFlatBuffers.swift
@@ -31,6 +31,7 @@ func serializeToFlatBuffer(_ msg: Message) -> Data? {
     case let m as RemoteCmd.RequestKeyframe: return m.toFlatBuffer()
     case let m as RemoteCmd.SetZoom: return m.toFlatBuffer()
     case let m as RemoteCmd.SetZoomResp: return m.toFlatBuffer()
+    case let m as RemoteCmd.FocusAtPoint: return m.toFlatBuffer()
     case let m as RemoteCmd.CameraCapabilitiesResp: return m.toFlatBuffer()
     case let m as RemoteCmd.SwitchLens: return m.toFlatBuffer()
     case let m as RemoteCmd.SwitchLensResp: return m.toFlatBuffer()
@@ -412,7 +413,8 @@ private func encodeCapabilitiesEnvelope(
         frontCameraOffset: frontOffset,
         backCameraOffset: backOffset,
         cameraDevicesVectorOffset: devicesVector,
-        activeDeviceIdOffset: activeIDOffset)
+        activeDeviceIdOffset: activeIDOffset,
+        supportsFocusPoint: c.supportsFocusPoint)
 
     let stateOffset = RemoteShutter_CameraState.createCameraState(
         &fbb,
@@ -572,6 +574,14 @@ extension RemoteCmd.SetZoom {
         var fbb = FlatBufferBuilder()
         let params = RemoteShutter_CommandParameters.createCommandParameters(&fbb, zoomFactor: Double(zoomFactor))
         return buildCommand(&fbb, action: .setzoom, parameters: params)
+    }
+}
+
+extension RemoteCmd.FocusAtPoint {
+    func toFlatBuffer() -> Data {
+        var fbb = FlatBufferBuilder()
+        let params = RemoteShutter_CommandParameters.createCommandParameters(&fbb, focusPointX: x, focusPointY: y)
+        return buildCommand(&fbb, action: .focusatpoint, parameters: params)
     }
 }
 
@@ -1072,6 +1082,9 @@ extension RemoteCmd {
 
         case .selectcameradevice:
             return SelectCameraDevice(uniqueID: params?.deviceUniqueId ?? "")
+
+        case .focusatpoint:
+            return FocusAtPoint(x: params?.focusPointX ?? 0.5, y: params?.focusPointY ?? 0.5)
         }
     }
 
@@ -1219,6 +1232,7 @@ extension RemoteCmd {
             currentHDRMode: state.map { fromFBHDRMode($0.hdrMode) } ?? .off,
             cameraDevices: cameraDevices,
             activeDeviceID: activeDeviceID,
+            supportsFocusPoint: caps?.supportsFocusPoint ?? false,
             error: error
         )
     }

--- a/RemoteCam/RemoteCmds.swift
+++ b/RemoteCam/RemoteCmds.swift
@@ -232,6 +232,25 @@ public class RemoteCmd: Message, @unchecked Sendable {
         }
     }
 
+    // MARK: - Focus Remote Commands
+
+    /// Monitor -> camera: set the focus/exposure point of interest. `x`/`y` are
+    /// normalized (0..1) in the monitor's upright-display image space, origin
+    /// top-left. Fire-and-forget: the camera no-ops if the active device does
+    /// not support a focus point. Only sent to peers that advertised
+    /// `CameraCapabilitiesResp.supportsFocusPoint` (old decoders read the
+    /// unknown action as `TakePicture`).
+    public class FocusAtPoint: Message, @unchecked Sendable {
+        public let x: Float
+        public let y: Float
+
+        public init(x: Float, y: Float) {
+            self.x = x
+            self.y = y
+            super.init(sender: nil)
+        }
+    }
+
     // MARK: - Camera Capabilities Structure
 
     public struct CameraInfo: Codable, Equatable {
@@ -342,6 +361,10 @@ public class RemoteCmd: Message, @unchecked Sendable {
         public let currentHDRMode: HDRMode
         public let cameraDevices: [CameraDeviceEntry]
         public let activeDeviceID: String?
+        /// True when this peer's build understands `RemoteCmd.FocusAtPoint`. The
+        /// monitor's tap-to-focus gate reads this so it never sends the command
+        /// to a peer that would decode it as `TakePicture`.
+        public let supportsFocusPoint: Bool
         public let error: Error?
 
         public init(frontCamera: CameraInfo?, backCamera: CameraInfo?,
@@ -353,6 +376,7 @@ public class RemoteCmd: Message, @unchecked Sendable {
                    currentHDRMode: HDRMode = .off,
                    cameraDevices: [CameraDeviceEntry] = [],
                    activeDeviceID: String? = nil,
+                   supportsFocusPoint: Bool = false,
                    error: Error?) {
             self.frontCamera = frontCamera
             self.backCamera = backCamera
@@ -365,6 +389,7 @@ public class RemoteCmd: Message, @unchecked Sendable {
             self.currentHDRMode = currentHDRMode
             self.cameraDevices = cameraDevices
             self.activeDeviceID = activeDeviceID
+            self.supportsFocusPoint = supportsFocusPoint
             self.error = error
             super.init(sender: nil)
         }

--- a/RemoteCam/SceneDelegate.swift
+++ b/RemoteCam/SceneDelegate.swift
@@ -7,6 +7,19 @@
 
 import UIKit
 
+/// A navigation bar that lets taps on its empty (non-button) area fall through to
+/// the content below. The monitor's live preview bleeds full-screen under this
+/// transparent bar; without pass-through, the bar would swallow tap-to-focus
+/// taps aimed at the top of the frame. Taps on the back/help bar-button items
+/// still hit the buttons.
+final class PassThroughNavigationBar: UINavigationBar {
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let hit = super.hitTest(point, with: event)
+        // `self` == the bar background/empty area → pass the touch through.
+        return hit === self ? nil : hit
+    }
+}
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
 
@@ -16,7 +29,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = scene as? UIWindowScene else { return }
 
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = UINavigationController(rootViewController: WelcomeViewController())
+        let navigationController = UINavigationController(
+            navigationBarClass: PassThroughNavigationBar.self, toolbarClass: nil)
+        navigationController.setViewControllers([WelcomeViewController()], animated: false)
+        window.rootViewController = navigationController
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/RemoteCam/SceneDelegate.swift
+++ b/RemoteCam/SceneDelegate.swift
@@ -14,9 +14,17 @@ import UIKit
 /// still hit the buttons.
 final class PassThroughNavigationBar: UINavigationBar {
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        let hit = super.hitTest(point, with: event)
-        // `self` == the bar background/empty area → pass the touch through.
-        return hit === self ? nil : hit
+        guard let hit = super.hitTest(point, with: event) else { return nil }
+        // Keep touches that land on an actual interactive control (the back /
+        // help bar-button items render as UIControls); pass everything else —
+        // the transparent background and empty area — through to the preview so
+        // tap-to-focus can reach the top of the frame.
+        var view: UIView? = hit
+        while let current = view, current !== self {
+            if current is UIControl { return hit }
+            view = current.superview
+        }
+        return nil
     }
 }
 

--- a/RemoteCam/SessionCoordinator.swift
+++ b/RemoteCam/SessionCoordinator.swift
@@ -177,6 +177,15 @@ public actor SessionCoordinator {
     /// actions as TakePicture (the FlatBuffers field default).
     private var peerAdvertisedCameraDevices = false
 
+    /// Whether the connected camera peer advertised focus-point support in its
+    /// capabilities — the feature gate for `RemoteCmd.FocusAtPoint`. Never send
+    /// that command otherwise: old decoders read unknown command actions as
+    /// TakePicture (same precedent as SelectCameraDevice).
+    private var peerSupportsFocusPoint = false
+
+    /// Test support.
+    func peerSupportsFocusPointForTesting() -> Bool { peerSupportsFocusPoint }
+
     /// Monitor side: at least one VP9 preview frame has arrived. Proves the
     /// camera peer speaks VP9, which gates sending `RemoteCmd.RequestKeyframe`
     /// (old decoders read that unknown action as TakePicture — same precedent as
@@ -386,6 +395,7 @@ public actor SessionCoordinator {
     /// restart discovery via `.scanning`'s entry behavior.
     func popToScanning() async {
         peerAdvertisedCameraDevices = false
+        peerSupportsFocusPoint = false
         monitorReceivedVP9Frame = false
         switch state {
         case .scanning:
@@ -670,6 +680,11 @@ public actor SessionCoordinator {
                     zoomFactor: nil, currentLens: nil, zoomRange: nil, error: error as NSError))
             }
 
+        case let focus as RemoteCmd.FocusAtPoint:
+            // Fire-and-forget: the monitor already showed its reticle. A device
+            // without a focus point simply ignores it.
+            try? await ctrl.focusAtPoint(x: focus.x, y: focus.y)
+
         case let lens as RemoteCmd.SwitchLens:
             do {
                 let (lensType, available, zoom, range) = try await ctrl.switchLens(to: lens.lensType)
@@ -866,6 +881,10 @@ public actor SessionCoordinator {
                 await sendOrGoToScanning(RemoteCmd.SetZoomResp(
                     zoomFactor: nil, currentLens: nil, zoomRange: nil, error: error as NSError))
             }
+
+        case let focus as RemoteCmd.FocusAtPoint:
+            // Fire-and-forget; focusing is allowed while recording too.
+            try? await ctrl.focusAtPoint(x: focus.x, y: focus.y)
 
         case let lens as RemoteCmd.SwitchLens:
             do {
@@ -1241,10 +1260,20 @@ public actor SessionCoordinator {
 
         case let capabilities as RemoteCmd.CameraCapabilitiesResp:
             peerAdvertisedCameraDevices = !capabilities.cameraDevices.isEmpty
+            peerSupportsFocusPoint = capabilities.supportsFocusPoint
             monitor?.updateCapabilities(capabilities)
 
         case let zoom as UICmd.SetZoom:
             sendMessage(RemoteCmd.SetZoom(zoomFactor: zoom.zoomFactor))
+
+        case let focus as UICmd.FocusAtPoint:
+            // Wire-safety gate: never send to a peer that would decode action 21
+            // as TakePicture. Silently dropped otherwise (reticle already shown).
+            guard peerSupportsFocusPoint else {
+                debugLog("FocusAtPoint dropped: peer did not advertise focus-point support")
+                break
+            }
+            sendMessage(RemoteCmd.FocusAtPoint(x: focus.x, y: focus.y))
 
         case let zoomResp as RemoteCmd.SetZoomResp:
             monitor?.updateZoom(zoomResp.zoomFactor, zoomRange: zoomResp.zoomRange, currentLens: zoomResp.currentLens)
@@ -1391,6 +1420,7 @@ public actor SessionCoordinator {
             // new camera (lens list, zoom range, quality).
             if let capabilities = toggleResp.cameraCapabilities {
                 peerAdvertisedCameraDevices = !capabilities.cameraDevices.isEmpty
+                peerSupportsFocusPoint = capabilities.supportsFocusPoint
                 monitor?.updateCapabilities(capabilities)
                 await dismissCameraAlert()
             } else if let error = toggleResp.error {
@@ -1497,6 +1527,13 @@ public actor SessionCoordinator {
 
         case let zoom as UICmd.SetZoom:
             sendMessage(RemoteCmd.SetZoom(zoomFactor: zoom.zoomFactor))
+
+        case let focus as UICmd.FocusAtPoint:
+            guard peerSupportsFocusPoint else {
+                debugLog("FocusAtPoint dropped: peer did not advertise focus-point support")
+                break
+            }
+            sendMessage(RemoteCmd.FocusAtPoint(x: focus.x, y: focus.y))
 
         case let zoomResp as RemoteCmd.SetZoomResp:
             monitor?.updateZoom(zoomResp.zoomFactor, zoomRange: zoomResp.zoomRange, currentLens: zoomResp.currentLens)

--- a/RemoteCam/SettingsView.swift
+++ b/RemoteCam/SettingsView.swift
@@ -46,10 +46,13 @@ struct SettingsView: View {
 
     private var upgradesSection: some View {
         Section {
+            purchaseRow(item: viewModel.proSubscriptionYearly, icon: "crown.fill")
+            purchaseRow(item: viewModel.proSubscriptionMonthly, icon: "crown")
             purchaseRow(item: viewModel.proMode, icon: "star.fill")
             purchaseRow(item: viewModel.removeAds, icon: "eye.slash.fill")
             purchaseRow(item: viewModel.enableTorch, icon: "flashlight.on.fill")
             purchaseRow(item: viewModel.enableVideo, icon: "video.fill")
+            purchaseRow(item: viewModel.tapToFocus, icon: "camera.metering.spot")
 
             Button {
                 viewModel.restorePurchases()

--- a/RemoteCam/SettingsView.swift
+++ b/RemoteCam/SettingsView.swift
@@ -44,11 +44,22 @@ struct SettingsView: View {
 
     // MARK: - Upgrades Section
 
+    @ViewBuilder
     private var upgradesSection: some View {
+        // "Everything" tier: the three Pro plans (Monthly, Yearly, Lifetime),
+        // each of which unlocks every feature including future ones.
         Section {
             purchaseRow(item: viewModel.proSubscriptionYearly, icon: "crown.fill")
             purchaseRow(item: viewModel.proSubscriptionMonthly, icon: "crown")
             purchaseRow(item: viewModel.proMode, icon: "star.fill")
+        } header: {
+            Text(NSLocalizedString("Pro — Unlock Everything", comment: ""))
+        } footer: {
+            Text(NSLocalizedString("Any Pro plan unlocks every feature, including future ones.", comment: ""))
+        }
+
+        // À la carte: individual features for a one-time purchase.
+        Section {
             purchaseRow(item: viewModel.removeAds, icon: "eye.slash.fill")
             purchaseRow(item: viewModel.enableTorch, icon: "flashlight.on.fill")
             purchaseRow(item: viewModel.enableVideo, icon: "video.fill")
@@ -70,7 +81,7 @@ struct SettingsView: View {
             }
             .disabled(viewModel.isRestoringPurchases)
         } header: {
-            Text(NSLocalizedString("Upgrades", comment: ""))
+            Text(NSLocalizedString("À la carte", comment: ""))
         }
     }
 
@@ -166,37 +177,45 @@ struct SettingsView: View {
 
     // MARK: - Reusable Rows
 
+    @ViewBuilder
     private func purchaseRow(
         item: SettingsViewModel.PurchaseItem,
         icon: String
     ) -> some View {
-        Button {
-            viewModel.purchase(item)
-        } label: {
-            HStack {
-                Image(systemName: item.isPurchased ? "checkmark.seal.fill" : icon)
-                    .foregroundColor(item.isPurchased ? AppTheme.success : AppTheme.accent)
-                    .frame(width: 28)
+        // Loaded but nameless = the product isn't on the store (e.g. not yet
+        // approved). Hide it rather than show an empty row.
+        if viewModel.productsLoaded && item.title.isEmpty {
+            EmptyView()
+        } else {
+            let ready = viewModel.productsLoaded
+            Button {
+                viewModel.purchase(item)
+            } label: {
+                HStack {
+                    Image(systemName: item.isPurchased ? "checkmark.seal.fill" : icon)
+                        .foregroundColor(item.isPurchased ? AppTheme.success : AppTheme.accent)
+                        .frame(width: 28)
 
-                Text(item.title)
-                    .foregroundColor(item.isPurchased ? .secondary : .primary)
+                    // Name comes from StoreKit; a placeholder sizes the skeleton.
+                    Text(ready ? item.title : "Placeholder name")
+                        .foregroundColor(item.isPurchased ? .secondary : .primary)
 
-                Spacer()
+                    Spacer()
 
-                if item.isPurchased {
-                    Text(NSLocalizedString("Purchased", comment: ""))
-                        .font(.subheadline)
-                        .foregroundColor(AppTheme.success)
-                } else if item.price.isEmpty {
-                    ProgressView()
-                } else {
-                    Text(item.price)
-                        .font(.subheadline)
-                        .foregroundColor(AppTheme.accent)
+                    if item.isPurchased {
+                        Text(NSLocalizedString("Purchased", comment: ""))
+                            .font(.subheadline)
+                            .foregroundColor(AppTheme.success)
+                    } else {
+                        Text(ready ? item.price : "$0.00")
+                            .font(.subheadline)
+                            .foregroundColor(AppTheme.accent)
+                    }
                 }
+                .redacted(reason: ready ? [] : .placeholder)
             }
+            .disabled(item.isPurchased || viewModel.isPurchasing || !ready)
         }
-        .disabled(item.isPurchased || viewModel.isPurchasing)
     }
 
     private func linkRow(icon: String, title: String, urlString: String) -> some View {

--- a/RemoteCam/SettingsView.swift
+++ b/RemoteCam/SettingsView.swift
@@ -49,13 +49,15 @@ struct SettingsView: View {
         // "Everything" tier: the three Pro plans (Monthly, Yearly, Lifetime),
         // each of which unlocks every feature including future ones.
         Section {
-            purchaseRow(item: viewModel.proSubscriptionYearly, icon: "crown.fill")
-            purchaseRow(item: viewModel.proSubscriptionMonthly, icon: "crown")
+            if FeatureFlags.ENABLE_PRO_SUBSCRIPTION {
+                purchaseRow(item: viewModel.proSubscriptionYearly, icon: "crown.fill")
+                purchaseRow(item: viewModel.proSubscriptionMonthly, icon: "crown")
+            }
             purchaseRow(item: viewModel.proMode, icon: "star.fill")
         } header: {
             Text(NSLocalizedString("Pro — Unlock Everything", comment: ""))
         } footer: {
-            Text(NSLocalizedString("Any Pro plan unlocks every feature, including future ones.", comment: ""))
+            Text(NSLocalizedString("Pro unlocks every feature, including future ones.", comment: ""))
         }
 
         // À la carte: individual features for a one-time purchase.

--- a/RemoteCam/SettingsViewModel.swift
+++ b/RemoteCam/SettingsViewModel.swift
@@ -109,7 +109,9 @@ final class SettingsViewModel: ObservableObject, PurchaseManaging {
             case enableVideoPID:
                 proMode.title = product.displayName
                 proMode.price = product.displayPrice
-                proMode.isPurchased = store.hasProMode()
+                // Full access (one-time OR subscription) marks the one-time Pro
+                // as owned so a subscriber can't redundantly buy it on top.
+                proMode.isPurchased = store.hasFullAccess()
             case disableAdsPID:
                 removeAds.title = product.displayName
                 removeAds.price = product.displayPrice
@@ -129,11 +131,13 @@ final class SettingsViewModel: ObservableObject, PurchaseManaging {
             case proMonthlyPID:
                 proSubscriptionMonthly.title = product.displayName
                 proSubscriptionMonthly.price = product.displayPrice
-                proSubscriptionMonthly.isPurchased = store.hasProSubscription()
+                // Full access blocks re-subscribing (e.g. a one-time 06 owner);
+                // plan switches happen via the system Manage Subscriptions sheet.
+                proSubscriptionMonthly.isPurchased = store.hasFullAccess()
             case proYearlyPID:
                 proSubscriptionYearly.title = product.displayName
                 proSubscriptionYearly.price = product.displayPrice
-                proSubscriptionYearly.isPurchased = store.hasProSubscription()
+                proSubscriptionYearly.isPurchased = store.hasFullAccess()
             default:
                 break
             }
@@ -142,9 +146,9 @@ final class SettingsViewModel: ObservableObject, PurchaseManaging {
 
     func refreshPurchaseStates() {
         let store = StoreManager.shared
-        proSubscriptionMonthly.isPurchased = store.hasProSubscription()
-        proSubscriptionYearly.isPurchased = store.hasProSubscription()
-        proMode.isPurchased = store.hasProMode()
+        proSubscriptionMonthly.isPurchased = store.hasFullAccess()
+        proSubscriptionYearly.isPurchased = store.hasFullAccess()
+        proMode.isPurchased = store.hasFullAccess()
         removeAds.isPurchased = store.hasAdRemovalFeature()
         enableTorch.isPurchased = store.hasTorchFeature()
         enableVideo.isPurchased = store.hasVideoRecordingFeature()

--- a/RemoteCam/SettingsViewModel.swift
+++ b/RemoteCam/SettingsViewModel.swift
@@ -15,13 +15,19 @@ final class SettingsViewModel: ObservableObject, PurchaseManaging {
         var isPurchased: Bool
     }
 
-    @Published var proSubscriptionMonthly = PurchaseItem(id: proMonthlyPID, title: NSLocalizedString("Pro (Monthly)", comment: ""), price: "", isPurchased: false)
-    @Published var proSubscriptionYearly = PurchaseItem(id: proYearlyPID, title: NSLocalizedString("Pro (Yearly)", comment: ""), price: "", isPurchased: false)
-    @Published var proMode = PurchaseItem(id: enableVideoPID, title: NSLocalizedString("Pro: All Features", comment: ""), price: "", isPurchased: false)
-    @Published var removeAds = PurchaseItem(id: disableAdsPID, title: NSLocalizedString("Remove Ads", comment: ""), price: "", isPurchased: false)
-    @Published var enableTorch = PurchaseItem(id: enableTorchPID, title: NSLocalizedString("Enable Torch", comment: ""), price: "", isPurchased: false)
-    @Published var enableVideo = PurchaseItem(id: enableVideoOnlyPID, title: NSLocalizedString("Enable Video", comment: ""), price: "", isPurchased: false)
-    @Published var tapToFocus = PurchaseItem(id: tapToFocusPID, title: NSLocalizedString("Tap to Focus", comment: ""), price: "", isPurchased: false)
+    // Titles/prices are intentionally empty — they come from StoreKit
+    // (product.displayName/displayPrice, localized by App Store Connect). The UI
+    // shows a skeleton until `productsLoaded`, so there are no app-side name strings.
+    @Published var proSubscriptionMonthly = PurchaseItem(id: proMonthlyPID, title: "", price: "", isPurchased: false)
+    @Published var proSubscriptionYearly = PurchaseItem(id: proYearlyPID, title: "", price: "", isPurchased: false)
+    @Published var proMode = PurchaseItem(id: enableVideoPID, title: "", price: "", isPurchased: false)
+    @Published var removeAds = PurchaseItem(id: disableAdsPID, title: "", price: "", isPurchased: false)
+    @Published var enableTorch = PurchaseItem(id: enableTorchPID, title: "", price: "", isPurchased: false)
+    @Published var enableVideo = PurchaseItem(id: enableVideoOnlyPID, title: "", price: "", isPurchased: false)
+    @Published var tapToFocus = PurchaseItem(id: tapToFocusPID, title: "", price: "", isPurchased: false)
+    /// True once the StoreKit product fetch has completed (success or not), so
+    /// the paywall can swap skeleton rows for real names/prices.
+    @Published var productsLoaded = false
 
     @Published var isRestoringPurchases = false
     @Published var isPurchasing = false
@@ -73,6 +79,7 @@ final class SettingsViewModel: ObservableObject, PurchaseManaging {
         Task { @MainActor in
             await StoreManager.shared.loadProducts()
             updateItems(with: StoreManager.shared.products)
+            productsLoaded = true
         }
     }
 

--- a/RemoteCam/SettingsViewModel.swift
+++ b/RemoteCam/SettingsViewModel.swift
@@ -15,10 +15,13 @@ final class SettingsViewModel: ObservableObject, PurchaseManaging {
         var isPurchased: Bool
     }
 
+    @Published var proSubscriptionMonthly = PurchaseItem(id: proMonthlyPID, title: NSLocalizedString("Pro (Monthly)", comment: ""), price: "", isPurchased: false)
+    @Published var proSubscriptionYearly = PurchaseItem(id: proYearlyPID, title: NSLocalizedString("Pro (Yearly)", comment: ""), price: "", isPurchased: false)
     @Published var proMode = PurchaseItem(id: enableVideoPID, title: NSLocalizedString("Pro: All Features", comment: ""), price: "", isPurchased: false)
     @Published var removeAds = PurchaseItem(id: disableAdsPID, title: NSLocalizedString("Remove Ads", comment: ""), price: "", isPurchased: false)
     @Published var enableTorch = PurchaseItem(id: enableTorchPID, title: NSLocalizedString("Enable Torch", comment: ""), price: "", isPurchased: false)
     @Published var enableVideo = PurchaseItem(id: enableVideoOnlyPID, title: NSLocalizedString("Enable Video", comment: ""), price: "", isPurchased: false)
+    @Published var tapToFocus = PurchaseItem(id: tapToFocusPID, title: NSLocalizedString("Tap to Focus", comment: ""), price: "", isPurchased: false)
 
     @Published var isRestoringPurchases = false
     @Published var isPurchasing = false
@@ -119,6 +122,18 @@ final class SettingsViewModel: ObservableObject, PurchaseManaging {
                 enableVideo.title = product.displayName
                 enableVideo.price = product.displayPrice
                 enableVideo.isPurchased = store.hasVideoRecordingFeature()
+            case tapToFocusPID:
+                tapToFocus.title = product.displayName
+                tapToFocus.price = product.displayPrice
+                tapToFocus.isPurchased = store.hasTapToFocusFeature()
+            case proMonthlyPID:
+                proSubscriptionMonthly.title = product.displayName
+                proSubscriptionMonthly.price = product.displayPrice
+                proSubscriptionMonthly.isPurchased = store.hasProSubscription()
+            case proYearlyPID:
+                proSubscriptionYearly.title = product.displayName
+                proSubscriptionYearly.price = product.displayPrice
+                proSubscriptionYearly.isPurchased = store.hasProSubscription()
             default:
                 break
             }
@@ -127,10 +142,13 @@ final class SettingsViewModel: ObservableObject, PurchaseManaging {
 
     func refreshPurchaseStates() {
         let store = StoreManager.shared
+        proSubscriptionMonthly.isPurchased = store.hasProSubscription()
+        proSubscriptionYearly.isPurchased = store.hasProSubscription()
         proMode.isPurchased = store.hasProMode()
         removeAds.isPurchased = store.hasAdRemovalFeature()
         enableTorch.isPurchased = store.hasTorchFeature()
         enableVideo.isPurchased = store.hasVideoRecordingFeature()
+        tapToFocus.isPurchased = store.hasTapToFocusFeature()
     }
 
 }

--- a/RemoteCam/StoreManager.swift
+++ b/RemoteCam/StoreManager.swift
@@ -16,6 +16,8 @@ extension Notification.Name {
     static let proModeAcquired = Notification.Name("ProModeAquired")
     static let enableTorch = Notification.Name("EnableTorch")
     static let enableVideoOnly = Notification.Name("EnableVideoOnly")
+    static let tapToFocusAcquired = Notification.Name("TapToFocusAcquired")
+    static let proSubscriptionAcquired = Notification.Name("ProSubscriptionAcquired")
 }
 
 // MARK: - UserDefaults Keys
@@ -25,6 +27,12 @@ private enum PurchaseKey {
     static let proMode = "didBuyProMode"
     static let enableTorch = "didBuyEnableTorchFeature"
     static let enableVideoOnly = "didBuyEnableVideoOnlyFeature"
+    static let tapToFocus = "didBuyTapToFocusFeature"
+    // Unlike the one-time flags above, this is NOT append-only: refreshPurchaseState
+    // recomputes it from Transaction.currentEntitlements so a lapsed subscription
+    // is revoked. It is persisted only so the UI is correct at launch before the
+    // first async refresh completes.
+    static let proSubscription = "hasActiveProSubscription"
 }
 
 // MARK: - StoreManager
@@ -34,8 +42,12 @@ final class StoreManager: ObservableObject {
     static let shared = StoreManager()
 
     static let allProductIDs: Set<String> = [
-        disableAdsPID, enableVideoPID, enableTorchPID, enableVideoOnlyPID
+        disableAdsPID, enableVideoPID, enableTorchPID, enableVideoOnlyPID,
+        tapToFocusPID, proMonthlyPID, proYearlyPID
     ]
+
+    /// The auto-renewable subscription products (the "Pro" subscription group).
+    static let subscriptionProductIDs: Set<String> = [proMonthlyPID, proYearlyPID]
 
     // MARK: - Published State
 
@@ -44,19 +56,40 @@ final class StoreManager: ObservableObject {
     // MARK: - Feature Availability (synchronous, UserDefaults-backed)
 
     func hasAdRemovalFeature() -> Bool {
-        hasProMode() || UserDefaults.standard.bool(forKey: PurchaseKey.removeAds)
+        hasFullAccess() || UserDefaults.standard.bool(forKey: PurchaseKey.removeAds)
     }
 
     func hasVideoRecordingFeature() -> Bool {
-        hasProMode() || UserDefaults.standard.bool(forKey: PurchaseKey.enableVideoOnly)
+        hasFullAccess() || UserDefaults.standard.bool(forKey: PurchaseKey.enableVideoOnly)
     }
 
     func hasTorchFeature() -> Bool {
-        hasProMode() || UserDefaults.standard.bool(forKey: PurchaseKey.enableTorch)
+        hasFullAccess() || UserDefaults.standard.bool(forKey: PurchaseKey.enableTorch)
     }
 
+    /// Owns the one-time "Pro: All Features" bundle (product 06). This is the raw
+    /// 06 flag only — use `hasFullAccess()` to also honor the subscription.
     func hasProMode() -> Bool {
         UserDefaults.standard.bool(forKey: PurchaseKey.proMode)
+    }
+
+    /// An active auto-renewable Pro subscription. Recomputed from
+    /// `Transaction.currentEntitlements` on every refresh, so it clears when the
+    /// subscription lapses.
+    func hasProSubscription() -> Bool {
+        UserDefaults.standard.bool(forKey: PurchaseKey.proSubscription)
+    }
+
+    /// Any bundle that unlocks every feature: the one-time Pro (06) or the Pro
+    /// subscription. The single gate every feature check ORs against.
+    func hasFullAccess() -> Bool {
+        hasProMode() || hasProSubscription()
+    }
+
+    /// Tap-to-focus entitlement. Unlocked by full access (Pro/subscription) or
+    /// its own IAP (09).
+    func hasTapToFocusFeature() -> Bool {
+        hasFullAccess() || UserDefaults.standard.bool(forKey: PurchaseKey.tapToFocus)
     }
 
     // MARK: - Init
@@ -124,11 +157,18 @@ final class StoreManager: ObservableObject {
     }
 
     private func refreshPurchaseState() async {
+        // Subscription entitlement is derived fresh each pass so an expired
+        // subscription is revoked; one-time flags stay append-only in grantEntitlement.
+        var activeSubscription = false
         for await result in Transaction.currentEntitlements {
             if let transaction = try? checkVerified(result) {
                 grantEntitlement(for: transaction.productID)
+                if Self.subscriptionProductIDs.contains(transaction.productID) {
+                    activeSubscription = true
+                }
             }
         }
+        UserDefaults.standard.set(activeSubscription, forKey: PurchaseKey.proSubscription)
         postNotifications()
     }
 
@@ -152,6 +192,12 @@ final class StoreManager: ObservableObject {
             defaults.set(true, forKey: PurchaseKey.enableTorch)
         case enableVideoOnlyPID:
             defaults.set(true, forKey: PurchaseKey.enableVideoOnly)
+        case tapToFocusPID:
+            defaults.set(true, forKey: PurchaseKey.tapToFocus)
+        case proMonthlyPID, proYearlyPID:
+            // Live purchase/renewal is always active; refreshPurchaseState is the
+            // authority that later clears this if the subscription lapses.
+            defaults.set(true, forKey: PurchaseKey.proSubscription)
         default:
             break
         }
@@ -165,6 +211,8 @@ final class StoreManager: ObservableObject {
         if hasProMode() { post(.proModeAcquired) }
         if hasTorchFeature() { post(.enableTorch) }
         if hasVideoRecordingFeature() { post(.enableVideoOnly) }
+        if hasProSubscription() { post(.proSubscriptionAcquired) }
+        if hasTapToFocusFeature() { post(.tapToFocusAcquired) }
     }
 
     enum StoreError: Error {

--- a/RemoteCam/SwiftConstants.swift
+++ b/RemoteCam/SwiftConstants.swift
@@ -22,6 +22,11 @@ public let disableAdsPID = "05"
 public let enableVideoPID = "06"
 public let enableTorchPID = "07"
 public let enableVideoOnlyPID = "08"
+public let tapToFocusPID = "09"
+// Auto-renewable "Pro" subscription (group "Pro"). Unlocks every feature for
+// the subscription period — the recurring equivalent of the one-time 06 bundle.
+public let proMonthlyPID = "pro_monthly"
+public let proYearlyPID = "pro_yearly"
 public let reviewCounterKey = "reviewCounter"
 public let lastVersionPromptedForReviewKey = "lastVersionPromptedForReview"
 public let mediaCaptureCounterKey = "mediaCaptureCounter"

--- a/RemoteCam/UICmds.swift
+++ b/RemoteCam/UICmds.swift
@@ -174,6 +174,24 @@ public class UICmd {
         }
     }
 
+    // MARK: - Focus Commands
+
+    /// Monitor-local: the preview tap point, normalized (0..1) in the upright
+    /// display image, origin top-left. Dispatched in-process to the coordinator,
+    /// which forwards it to the camera peer as `RemoteCmd.FocusAtPoint` (that is
+    /// the only representation serialized over the wire, as FlatBuffers). No
+    /// `NSCoding` here — UICmds never leave the device.
+    public class FocusAtPoint: Message, @unchecked Sendable {
+        public let x: Float
+        public let y: Float
+
+        public init(x: Float, y: Float) {
+            self.x = x
+            self.y = y
+            super.init(sender: nil)
+        }
+    }
+
     @objc(_TtCC10ActorsDemo5UICmd12SetZoomResp)public class SetZoomResp: Message, NSCoding, @unchecked Sendable {
         public let zoomFactor: CGFloat?
         public let currentLens: CameraLensType?

--- a/RemoteCam/WelcomeView.swift
+++ b/RemoteCam/WelcomeView.swift
@@ -70,27 +70,38 @@ struct WelcomeView: View {
 
     // MARK: - Upgrades
 
+    /// Product IDs that unlock everything (the three Pro plans). The rest are
+    /// à la carte individual features.
+    private static let everythingIDs: Set<String> = [proYearlyPID, proMonthlyPID, enableVideoPID]
+
     private var upgradesSection: some View {
-        VStack(spacing: 12) {
-            // Pro item — featured card
-            if let pro = viewModel.upgrades.first, !pro.isPurchased {
-                proCard(pro)
+        // Before load: show every non-purchased item (as skeletons). After load:
+        // drop items whose product isn't on the store (empty name).
+        let ready = viewModel.productsLoaded
+        let visible = viewModel.upgrades.filter { !$0.isPurchased && (!ready || !$0.title.isEmpty) }
+        let everything = visible.filter { Self.everythingIDs.contains($0.id) }
+        let featured = everything.first                 // yearly (first in the upgrades order)
+        let otherPlans = Array(everything.dropFirst())  // monthly, lifetime
+        let alaCarte = visible.filter { !Self.everythingIDs.contains($0.id) }
+
+        return VStack(spacing: 12) {
+            // Everything tier: featured plan card + the remaining Pro plans.
+            if let featured {
+                proCard(featured)
+            }
+            if !otherPlans.isEmpty {
+                upgradeCardGroup(otherPlans)
             }
 
-            // Individual items
-            let individuals = viewModel.upgrades.dropFirst().filter { !$0.isPurchased }
-            if !individuals.isEmpty {
-                VStack(spacing: 0) {
-                    ForEach(Array(individuals.enumerated()), id: \.element.id) { index, item in
-                        upgradeRow(item)
-                        if index < individuals.count - 1 {
-                            Divider()
-                                .padding(.leading, 52)
-                        }
-                    }
-                }
-                .background(Color(.secondarySystemGroupedBackground))
-                .clipShape(RoundedRectangle(cornerRadius: 12))
+            // À la carte: individual features.
+            if !alaCarte.isEmpty {
+                Text(NSLocalizedString("À la carte", comment: ""))
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.top, 4)
+                upgradeCardGroup(alaCarte)
             }
 
             // Restore
@@ -106,35 +117,50 @@ struct WelcomeView: View {
         }
     }
 
+    /// A rounded card of upgrade rows separated by dividers.
+    private func upgradeCardGroup(_ items: [WelcomeViewModel.UpgradeItem]) -> some View {
+        VStack(spacing: 0) {
+            ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                upgradeRow(item)
+                if index < items.count - 1 {
+                    Divider()
+                        .padding(.leading, 52)
+                }
+            }
+        }
+        .background(Color(.secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
     private func proCard(_ item: WelcomeViewModel.UpgradeItem) -> some View {
         Button {
             viewModel.purchase(item)
         } label: {
+            let ready = viewModel.productsLoaded
             VStack(spacing: 12) {
                 HStack {
                     Image(systemName: item.icon)
                         .font(.title2)
                         .foregroundColor(AppTheme.accent)
-                    Text(item.title)
+                    // Plan name from StoreKit; placeholder sizes the skeleton.
+                    Text(ready ? item.title : "Placeholder plan")
                         .font(.headline)
                         .foregroundColor(.primary)
+                        .redacted(reason: ready ? [] : .placeholder)
                     Spacer()
                 }
 
-                Text(NSLocalizedString("Pro subscription — unlock every feature: video recording, torch control, tap to focus, and no ads.", comment: ""))
+                Text(NSLocalizedString("Any Pro plan unlocks every feature: video recording, torch control, tap to focus, and no ads.", comment: ""))
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
-                if item.price.isEmpty {
-                    ProgressView()
-                } else {
-                    Text(item.price)
-                        .font(.title3)
-                        .fontWeight(.semibold)
-                        .foregroundColor(AppTheme.accent)
-                        .frame(maxWidth: .infinity, alignment: .trailing)
-                }
+                Text(ready ? item.price : "$00.00")
+                    .font(.title3)
+                    .fontWeight(.semibold)
+                    .foregroundColor(AppTheme.accent)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                    .redacted(reason: ready ? [] : .placeholder)
             }
             .padding(16)
             .background(.ultraThinMaterial)
@@ -145,11 +171,12 @@ struct WelcomeView: View {
             )
             .shadow(color: AppTheme.accent.opacity(0.1), radius: 8, y: 4)
         }
-        .disabled(viewModel.isPurchasing)
+        .disabled(viewModel.isPurchasing || !viewModel.productsLoaded)
     }
 
     private func upgradeRow(_ item: WelcomeViewModel.UpgradeItem) -> some View {
-        Button {
+        let ready = viewModel.productsLoaded
+        return Button {
             viewModel.purchase(item)
         } label: {
             HStack(spacing: 12) {
@@ -160,25 +187,22 @@ struct WelcomeView: View {
                     .background(AppTheme.accentSubtle)
                     .clipShape(RoundedRectangle(cornerRadius: 8))
 
-                Text(item.title)
+                Text(ready ? item.title : "Placeholder feature")
                     .font(.body)
                     .foregroundColor(.primary)
 
                 Spacer()
 
-                if item.price.isEmpty {
-                    ProgressView()
-                } else {
-                    Text(item.price)
-                        .font(.subheadline)
-                        .fontWeight(.medium)
-                        .foregroundColor(AppTheme.accent)
-                }
+                Text(ready ? item.price : "$0.00")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundColor(AppTheme.accent)
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 12)
+            .redacted(reason: ready ? [] : .placeholder)
         }
-        .disabled(viewModel.isPurchasing)
+        .disabled(viewModel.isPurchasing || !ready)
     }
 
     // MARK: - Continue

--- a/RemoteCam/WelcomeView.swift
+++ b/RemoteCam/WelcomeView.swift
@@ -150,7 +150,7 @@ struct WelcomeView: View {
                     Spacer()
                 }
 
-                Text(NSLocalizedString("Any Pro plan unlocks every feature: video recording, torch control, tap to focus, and no ads.", comment: ""))
+                Text(NSLocalizedString("Unlock every feature: video recording, torch control, tap to focus, and no ads.", comment: ""))
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/RemoteCam/WelcomeView.swift
+++ b/RemoteCam/WelcomeView.swift
@@ -112,7 +112,7 @@ struct WelcomeView: View {
         } label: {
             VStack(spacing: 12) {
                 HStack {
-                    Image(systemName: "star.fill")
+                    Image(systemName: item.icon)
                         .font(.title2)
                         .foregroundColor(AppTheme.accent)
                     Text(item.title)
@@ -121,7 +121,7 @@ struct WelcomeView: View {
                     Spacer()
                 }
 
-                Text(NSLocalizedString("Unlock all features: video recording, torch control, and ad-free experience.", comment: ""))
+                Text(NSLocalizedString("Pro subscription — unlock every feature: video recording, torch control, tap to focus, and no ads.", comment: ""))
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/RemoteCam/WelcomeViewController.swift
+++ b/RemoteCam/WelcomeViewController.swift
@@ -25,7 +25,7 @@ class WelcomeViewController: UIViewController {
 
         if isInitialAppLaunch {
             isInitialAppLaunch = false
-            if StoreManager.shared.hasProMode() {
+            if StoreManager.shared.hasFullAccess() {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
                     self?.goToConnectViewController()
                 }

--- a/RemoteCam/WelcomeViewModel.swift
+++ b/RemoteCam/WelcomeViewModel.swift
@@ -84,6 +84,11 @@ final class WelcomeViewModel: ObservableObject, PurchaseManaging {
     private func buildUpgradeItems() {
         let store = StoreManager.shared
         upgrades = [
+            // Featured card: the Pro subscription (best value, yearly).
+            UpgradeItem(id: proYearlyPID, title: NSLocalizedString("Pro (Yearly)", comment: ""), price: "",
+                        isPurchased: store.hasProSubscription(), icon: "crown.fill", tint: "purple"),
+            UpgradeItem(id: proMonthlyPID, title: NSLocalizedString("Pro (Monthly)", comment: ""), price: "",
+                        isPurchased: store.hasProSubscription(), icon: "crown", tint: "purple"),
             UpgradeItem(id: enableVideoPID, title: NSLocalizedString("Pro: All Features", comment: ""), price: "",
                         isPurchased: store.hasProMode(), icon: "star.fill", tint: "purple"),
             UpgradeItem(id: disableAdsPID, title: NSLocalizedString("Remove Ads", comment: ""), price: "",
@@ -92,6 +97,8 @@ final class WelcomeViewModel: ObservableObject, PurchaseManaging {
                         isPurchased: store.hasTorchFeature(), icon: "flashlight.on.fill", tint: "orange"),
             UpgradeItem(id: enableVideoOnlyPID, title: NSLocalizedString("Enable Video", comment: ""), price: "",
                         isPurchased: store.hasVideoRecordingFeature(), icon: "video.fill", tint: "red"),
+            UpgradeItem(id: tapToFocusPID, title: NSLocalizedString("Tap to Focus", comment: ""), price: "",
+                        isPurchased: store.hasTapToFocusFeature(), icon: "camera.metering.spot", tint: "green"),
         ]
         updateFeatureFlags()
     }
@@ -109,6 +116,8 @@ final class WelcomeViewModel: ObservableObject, PurchaseManaging {
         let store = StoreManager.shared
         for i in upgrades.indices {
             switch upgrades[i].id {
+            case proMonthlyPID, proYearlyPID:
+                upgrades[i].isPurchased = store.hasProSubscription()
             case enableVideoPID:
                 upgrades[i].isPurchased = store.hasProMode()
             case disableAdsPID:
@@ -117,6 +126,8 @@ final class WelcomeViewModel: ObservableObject, PurchaseManaging {
                 upgrades[i].isPurchased = store.hasTorchFeature()
             case enableVideoOnlyPID:
                 upgrades[i].isPurchased = store.hasVideoRecordingFeature()
+            case tapToFocusPID:
+                upgrades[i].isPurchased = store.hasTapToFocusFeature()
             default:
                 break
             }
@@ -126,9 +137,10 @@ final class WelcomeViewModel: ObservableObject, PurchaseManaging {
 
     private func updateFeatureFlags() {
         let store = StoreManager.shared
-        hasAllFeatures = store.hasProMode()
+        hasAllFeatures = store.hasFullAccess()
         hasAnyPurchase = store.hasAdRemovalFeature() || store.hasTorchFeature()
-            || store.hasVideoRecordingFeature() || store.hasProMode()
+            || store.hasVideoRecordingFeature() || store.hasFullAccess()
+            || store.hasTapToFocusFeature()
     }
 
 }

--- a/RemoteCam/WelcomeViewModel.swift
+++ b/RemoteCam/WelcomeViewModel.swift
@@ -16,6 +16,9 @@ final class WelcomeViewModel: ObservableObject, PurchaseManaging {
     // MARK: - Published State
 
     @Published var upgrades: [UpgradeItem] = []
+    /// True once the StoreKit product fetch has completed, so the paywall can
+    /// swap skeleton rows for the real StoreKit names/prices.
+    @Published var productsLoaded = false
     @Published var hasAnyPurchase = false
     @Published var hasAllFeatures = false
     @Published var isPurchasing = false
@@ -45,6 +48,7 @@ final class WelcomeViewModel: ObservableObject, PurchaseManaging {
         Task { @MainActor in
             await StoreManager.shared.loadProducts()
             updatePrices()
+            productsLoaded = true
         }
     }
 
@@ -82,22 +86,25 @@ final class WelcomeViewModel: ObservableObject, PurchaseManaging {
     // MARK: - Private Helpers
 
     private func buildUpgradeItems() {
+        // Titles/prices come from StoreKit (product.displayName/displayPrice) —
+        // left empty here; the UI skeletons until `productsLoaded`. Only the id,
+        // icon, tint and entitlement state are app-side.
         let store = StoreManager.shared
         upgrades = [
             // Featured card: the Pro subscription (best value, yearly).
-            UpgradeItem(id: proYearlyPID, title: NSLocalizedString("Pro (Yearly)", comment: ""), price: "",
+            UpgradeItem(id: proYearlyPID, title: "", price: "",
                         isPurchased: store.hasProSubscription(), icon: "crown.fill", tint: "purple"),
-            UpgradeItem(id: proMonthlyPID, title: NSLocalizedString("Pro (Monthly)", comment: ""), price: "",
+            UpgradeItem(id: proMonthlyPID, title: "", price: "",
                         isPurchased: store.hasProSubscription(), icon: "crown", tint: "purple"),
-            UpgradeItem(id: enableVideoPID, title: NSLocalizedString("Pro: All Features", comment: ""), price: "",
+            UpgradeItem(id: enableVideoPID, title: "", price: "",
                         isPurchased: store.hasProMode(), icon: "star.fill", tint: "purple"),
-            UpgradeItem(id: disableAdsPID, title: NSLocalizedString("Remove Ads", comment: ""), price: "",
+            UpgradeItem(id: disableAdsPID, title: "", price: "",
                         isPurchased: store.hasAdRemovalFeature(), icon: "eye.slash.fill", tint: "blue"),
-            UpgradeItem(id: enableTorchPID, title: NSLocalizedString("Enable Torch", comment: ""), price: "",
+            UpgradeItem(id: enableTorchPID, title: "", price: "",
                         isPurchased: store.hasTorchFeature(), icon: "flashlight.on.fill", tint: "orange"),
-            UpgradeItem(id: enableVideoOnlyPID, title: NSLocalizedString("Enable Video", comment: ""), price: "",
+            UpgradeItem(id: enableVideoOnlyPID, title: "", price: "",
                         isPurchased: store.hasVideoRecordingFeature(), icon: "video.fill", tint: "red"),
-            UpgradeItem(id: tapToFocusPID, title: NSLocalizedString("Tap to Focus", comment: ""), price: "",
+            UpgradeItem(id: tapToFocusPID, title: "", price: "",
                         isPurchased: store.hasTapToFocusFeature(), icon: "camera.metering.spot", tint: "green"),
         ]
         updateFeatureFlags()

--- a/RemoteCam/WelcomeViewModel.swift
+++ b/RemoteCam/WelcomeViewModel.swift
@@ -90,12 +90,16 @@ final class WelcomeViewModel: ObservableObject, PurchaseManaging {
         // left empty here; the UI skeletons until `productsLoaded`. Only the id,
         // icon, tint and entitlement state are app-side.
         let store = StoreManager.shared
-        upgrades = [
-            // Featured card: the Pro subscription (best value, yearly).
-            UpgradeItem(id: proYearlyPID, title: "", price: "",
-                        isPurchased: store.hasProSubscription(), icon: "crown.fill", tint: "purple"),
-            UpgradeItem(id: proMonthlyPID, title: "", price: "",
-                        isPurchased: store.hasProSubscription(), icon: "crown", tint: "purple"),
+        var items: [UpgradeItem] = []
+        // Featured "everything" plans: the Pro subscription (behind a flag until
+        // it's a validated experiment), then the one-time Pro.
+        if FeatureFlags.ENABLE_PRO_SUBSCRIPTION {
+            items.append(UpgradeItem(id: proYearlyPID, title: "", price: "",
+                                     isPurchased: store.hasProSubscription(), icon: "crown.fill", tint: "purple"))
+            items.append(UpgradeItem(id: proMonthlyPID, title: "", price: "",
+                                     isPurchased: store.hasProSubscription(), icon: "crown", tint: "purple"))
+        }
+        items.append(contentsOf: [
             UpgradeItem(id: enableVideoPID, title: "", price: "",
                         isPurchased: store.hasProMode(), icon: "star.fill", tint: "purple"),
             UpgradeItem(id: disableAdsPID, title: "", price: "",
@@ -106,7 +110,8 @@ final class WelcomeViewModel: ObservableObject, PurchaseManaging {
                         isPurchased: store.hasVideoRecordingFeature(), icon: "video.fill", tint: "red"),
             UpgradeItem(id: tapToFocusPID, title: "", price: "",
                         isPurchased: store.hasTapToFocusFeature(), icon: "camera.metering.spot", tint: "green"),
-        ]
+        ])
+        upgrades = items
         updateFeatureFlags()
     }
 

--- a/RemoteCamTests/FocusPointMappingTests.swift
+++ b/RemoteCamTests/FocusPointMappingTests.swift
@@ -1,0 +1,124 @@
+//
+//  FocusPointMappingTests.swift
+//  RemoteShutterTests
+//
+//  Pure geometry tests for tap-to-focus. These pin the intended math; the
+//  orientation/mirroring conventions are additionally validated against real
+//  hardware in CaptureIntegrationTests.
+//
+
+import XCTest
+import CoreGraphics
+import AVFoundation
+@testable import RemoteShutter
+
+final class FocusPointMappingTests: XCTestCase {
+
+    private let acc: CGFloat = 0.0001
+
+    // MARK: - normalizedImagePoint (tap -> normalized image, letterbox aware)
+
+    func testCenterTapMapsToImageCenter() {
+        let p = FocusPointMapping.normalizedImagePoint(
+            tap: CGPoint(x: 50, y: 50),
+            viewSize: CGSize(width: 100, height: 100),
+            imageSize: CGSize(width: 100, height: 100))
+        XCTAssertNotNil(p)
+        XCTAssertEqual(p!.x, 0.5, accuracy: acc)
+        XCTAssertEqual(p!.y, 0.5, accuracy: acc)
+    }
+
+    func testLetterboxedImageCenterTapIgnoresBars() {
+        // 2:1 image in a square view -> fitted 100x50, bars of 25 top and bottom.
+        let view = CGSize(width: 100, height: 100)
+        let image = CGSize(width: 200, height: 100)
+        let center = FocusPointMapping.normalizedImagePoint(
+            tap: CGPoint(x: 50, y: 50), viewSize: view, imageSize: image)
+        XCTAssertEqual(center?.x ?? -1, 0.5, accuracy: acc)
+        XCTAssertEqual(center?.y ?? -1, 0.5, accuracy: acc)
+
+        // Tap inside the image at its top edge.
+        let topEdge = FocusPointMapping.normalizedImagePoint(
+            tap: CGPoint(x: 50, y: 25), viewSize: view, imageSize: image)
+        XCTAssertEqual(topEdge?.y ?? -1, 0.0, accuracy: acc)
+    }
+
+    func testTapInLetterboxBarReturnsNil() {
+        let view = CGSize(width: 100, height: 100)
+        let image = CGSize(width: 200, height: 100)   // horizontal bars at y<25 and y>75
+        XCTAssertNil(FocusPointMapping.normalizedImagePoint(
+            tap: CGPoint(x: 50, y: 10), viewSize: view, imageSize: image))
+        XCTAssertNil(FocusPointMapping.normalizedImagePoint(
+            tap: CGPoint(x: 50, y: 90), viewSize: view, imageSize: image))
+    }
+
+    func testTapInPillarboxBarReturnsNil() {
+        // 1:2 image in a square view -> fitted 50x100, vertical bars at x<25 and x>75.
+        let view = CGSize(width: 100, height: 100)
+        let image = CGSize(width: 100, height: 200)
+        XCTAssertNil(FocusPointMapping.normalizedImagePoint(
+            tap: CGPoint(x: 10, y: 50), viewSize: view, imageSize: image))
+        XCTAssertNil(FocusPointMapping.normalizedImagePoint(
+            tap: CGPoint(x: 90, y: 50), viewSize: view, imageSize: image))
+    }
+
+    func testZeroSizesReturnNil() {
+        XCTAssertNil(FocusPointMapping.normalizedImagePoint(
+            tap: CGPoint(x: 1, y: 1), viewSize: .zero, imageSize: CGSize(width: 10, height: 10)))
+        XCTAssertNil(FocusPointMapping.normalizedImagePoint(
+            tap: CGPoint(x: 1, y: 1), viewSize: CGSize(width: 10, height: 10), imageSize: .zero))
+    }
+
+    // MARK: - devicePoint (display-normalized -> focusPointOfInterest space)
+
+    func testLandscapeRightIsIdentity() {
+        let p = FocusPointMapping.devicePoint(
+            displayNormalized: CGPoint(x: 0.2, y: 0.3),
+            videoOrientation: .landscapeRight, mirrored: false)
+        XCTAssertEqual(p.x, 0.2, accuracy: acc)
+        XCTAssertEqual(p.y, 0.3, accuracy: acc)
+    }
+
+    func testFrontMirrorFlipsX() {
+        let p = FocusPointMapping.devicePoint(
+            displayNormalized: CGPoint(x: 0.2, y: 0.3),
+            videoOrientation: .landscapeRight, mirrored: true)
+        XCTAssertEqual(p.x, 0.8, accuracy: acc)
+        XCTAssertEqual(p.y, 0.3, accuracy: acc)
+    }
+
+    func testPortraitRotation() {
+        let p = FocusPointMapping.devicePoint(
+            displayNormalized: CGPoint(x: 0.2, y: 0.3),
+            videoOrientation: .portrait, mirrored: false)
+        // (px, py) -> (py, 1 - px)
+        XCTAssertEqual(p.x, 0.3, accuracy: acc)
+        XCTAssertEqual(p.y, 0.8, accuracy: acc)
+    }
+
+    func testPortraitUpsideDownRotation() {
+        let p = FocusPointMapping.devicePoint(
+            displayNormalized: CGPoint(x: 0.2, y: 0.3),
+            videoOrientation: .portraitUpsideDown, mirrored: false)
+        // (px, py) -> (1 - py, px)
+        XCTAssertEqual(p.x, 0.7, accuracy: acc)
+        XCTAssertEqual(p.y, 0.2, accuracy: acc)
+    }
+
+    func testLandscapeLeftRotation() {
+        let p = FocusPointMapping.devicePoint(
+            displayNormalized: CGPoint(x: 0.2, y: 0.3),
+            videoOrientation: .landscapeLeft, mirrored: false)
+        // (px, py) -> (1 - px, 1 - py)
+        XCTAssertEqual(p.x, 0.8, accuracy: acc)
+        XCTAssertEqual(p.y, 0.7, accuracy: acc)
+    }
+
+    func testOutOfRangeInputIsClamped() {
+        let p = FocusPointMapping.devicePoint(
+            displayNormalized: CGPoint(x: 1.5, y: -0.5),
+            videoOrientation: .landscapeRight, mirrored: false)
+        XCTAssertEqual(p.x, 1.0, accuracy: acc)
+        XCTAssertEqual(p.y, 0.0, accuracy: acc)
+    }
+}

--- a/RemoteCamTests/LoopbackSessionTests.swift
+++ b/RemoteCamTests/LoopbackSessionTests.swift
@@ -576,6 +576,48 @@ class LoopbackSessionTests: XCTestCase {
         XCTAssertEqual(monitorState, .monitor)
     }
 
+    // MARK: - Tap to focus
+
+    func testFocusAtPointHappyPathAcrossTheWire() async {
+        let fakeCamera = await connectCameraAndMonitor()
+
+        monitorCoordinator.tell(UICmd.FocusAtPoint(x: 0.25, y: 0.75))
+        await drainBothSessions()
+
+        XCTAssertEqual(fakeCamera.focusCalls.count, 1)
+        XCTAssertEqual(fakeCamera.focusCalls.first?.x ?? -1, 0.25, accuracy: 0.001)
+        XCTAssertEqual(fakeCamera.focusCalls.first?.y ?? -1, 0.75, accuracy: 0.001)
+        // Fire-and-forget: no response is sent, and it was never a TakePicture.
+        XCTAssertTrue(fakeCamera.takePictureCalls.isEmpty)
+        let monitorState = await monitorCoordinator.currentStateName()
+        XCTAssertEqual(monitorState, .monitor)
+    }
+
+    /// Safety gate mirroring SelectCameraDevice: old peers decode the unknown
+    /// FocusAtPoint action as TakePicture, so the monitor must never send it to a
+    /// peer whose capabilities did not advertise focus-point support.
+    func testFocusAtPointIsNeverSentToLegacyPeer() async {
+        await connectBothSessions()
+        let fakeCamera = LoopbackFakeCamera()
+        fakeCamera.advertisesFocusPoint = false   // peer predates tap-to-focus
+        fakeCamera.coordinator = cameraCoordinator
+        cameraCoordinator.tell(UICmd.BecomeCamera(sender: nil, ctrl: fakeCamera))
+        await drainBothSessions()
+        await becomeMonitor(mode: .Photo)
+        monitorTransport.sentMessages.removeAll()
+
+        monitorCoordinator.tell(UICmd.FocusAtPoint(x: 0.4, y: 0.6))
+        await drainBothSessions()
+
+        XCTAssertFalse(monitorTransport.sentMessages.contains { $0 is RemoteCmd.FocusAtPoint },
+                       "FocusAtPoint must be gated on advertised supports_focus_point")
+        XCTAssertTrue(fakeCamera.focusCalls.isEmpty)
+        XCTAssertTrue(fakeCamera.takePictureCalls.isEmpty,
+                      "an ungated command would decode as TakePicture on an old peer")
+        let monitorState = await monitorCoordinator.currentStateName()
+        XCTAssertEqual(monitorState, .monitor)
+    }
+
     func testSwitchLensHappyPathAcrossTheWire() async {
         let fakeCamera = await connectCameraAndMonitor()
 

--- a/RemoteCamTests/MonitorScreenSnapshotTests.swift
+++ b/RemoteCamTests/MonitorScreenSnapshotTests.swift
@@ -26,7 +26,8 @@ final class MonitorScreenSnapshotTests: SnapshotTestCase {
             onZoomChange: { _ in },
             onVideoQualityChange: { _, _ in },
             onPhotoQualityChange: { _, _ in },
-            onAspectRatioChange: { _ in })
+            onAspectRatioChange: { _ in },
+            onFocusTap: { _ in })
     }
 
     /// A connected monitor with a live frame and the full lens/zoom surface.

--- a/RemoteCamTests/RemoteCmdSerializationTests.swift
+++ b/RemoteCamTests/RemoteCmdSerializationTests.swift
@@ -49,6 +49,7 @@ final class RemoteCmdSerializationTests: XCTestCase {
         case let m as RemoteCmd.RequestKeyframe: return m.toFlatBuffer()
         case let m as RemoteCmd.SetZoom: return m.toFlatBuffer()
         case let m as RemoteCmd.SetZoomResp: return m.toFlatBuffer()
+        case let m as RemoteCmd.FocusAtPoint: return m.toFlatBuffer()
         case let m as RemoteCmd.CameraCapabilitiesResp: return m.toFlatBuffer()
         case let m as RemoteCmd.SwitchLens: return m.toFlatBuffer()
         case let m as RemoteCmd.SwitchLensResp: return m.toFlatBuffer()
@@ -300,6 +301,24 @@ final class RemoteCmdSerializationTests: XCTestCase {
         let original = RemoteCmd.SetZoom(zoomFactor: 1.0)
         let decoded: RemoteCmd.SetZoom = roundTrip(original)
         XCTAssertEqual(decoded.zoomFactor, 1.0, accuracy: 0.001)
+    }
+
+    // MARK: - 11b. FocusAtPoint
+
+    func testFocusAtPoint_roundTrip() {
+        let original = RemoteCmd.FocusAtPoint(x: 0.25, y: 0.75)
+        let decoded: RemoteCmd.FocusAtPoint = roundTrip(original)
+        XCTAssertEqual(decoded.x, 0.25, accuracy: 0.0001)
+        XCTAssertEqual(decoded.y, 0.75, accuracy: 0.0001)
+    }
+
+    func testCameraCapabilities_supportsFocusPointRoundTrip() {
+        let original = RemoteCmd.CameraCapabilitiesResp(
+            frontCamera: nil, backCamera: nil,
+            currentCamera: .back, currentLens: .wideAngle, currentZoom: 1.0,
+            supportsFocusPoint: true, error: nil)
+        let decoded: RemoteCmd.CameraCapabilitiesResp = roundTrip(original)
+        XCTAssertTrue(decoded.supportsFocusPoint)
     }
 
     // MARK: - 12. SetZoomResp

--- a/RemoteCamTests/SessionTestSupport.swift
+++ b/RemoteCamTests/SessionTestSupport.swift
@@ -112,6 +112,7 @@ class FakeCameraControlling: CameraControlling, @unchecked Sendable {
     var countdownTicks: [Int] = []
     var gatherCapabilitiesCalls = 0
     var zoomCalls: [CGFloat] = []
+    var focusCalls: [CGPoint] = []
     var lensSwitches: [CameraLensType] = []
     var torchToggles = 0
     var chimes: [Int] = []
@@ -135,6 +136,10 @@ class FakeCameraControlling: CameraControlling, @unchecked Sendable {
         if let errorToThrow { throw errorToThrow }
         zoomCalls.append(zoomFactor)
         return (zoomFactor, .wideAngle, RemoteCmd.ZoomRange(minZoom: 1, maxZoom: 10))
+    }
+    func focusAtPoint(x: Float, y: Float) async throws {
+        if let errorToThrow { throw errorToThrow }
+        focusCalls.append(CGPoint(x: CGFloat(x), y: CGFloat(y)))
     }
     // swiftlint:disable:next large_tuple
     func switchLens(to lensType: CameraLensType) async throws -> (CameraLensType, [CameraLensType], CGFloat, RemoteCmd.ZoomRange) {
@@ -209,6 +214,11 @@ class FakeCameraControlling: CameraControlling, @unchecked Sendable {
     /// — the monitor must never send SelectCameraDevice to it.
     var advertisesCameraDevices = true
 
+    /// False simulates a peer whose capabilities omit focus-point support — the
+    /// monitor must never send FocusAtPoint to it (old peers decode it as
+    /// TakePicture).
+    var advertisesFocusPoint = true
+
     /// Devices that accept the input swap but never deliver a frame (a
     /// wedged virtual camera). While one is active, awaitFrameDelivery fails.
     var stalledDeviceIDs: Set<String> = []
@@ -236,6 +246,7 @@ class FakeCameraControlling: CameraControlling, @unchecked Sendable {
             currentCamera: .back, currentLens: .wideAngle, currentZoom: 1.0,
             cameraDevices: entries,
             activeDeviceID: advertisesCameraDevices ? activeDeviceID : nil,
+            supportsFocusPoint: advertisesFocusPoint,
             error: nil)
     }
 

--- a/RemoteCamTests/SettingsViewModelTests.swift
+++ b/RemoteCamTests/SettingsViewModelTests.swift
@@ -70,6 +70,9 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.removeAds.isPurchased, store.hasAdRemovalFeature())
         XCTAssertEqual(vm.enableTorch.isPurchased, store.hasTorchFeature())
         XCTAssertEqual(vm.enableVideo.isPurchased, store.hasVideoRecordingFeature())
+        XCTAssertEqual(vm.tapToFocus.isPurchased, store.hasTapToFocusFeature())
+        XCTAssertEqual(vm.proSubscriptionMonthly.isPurchased, store.hasProSubscription())
+        XCTAssertEqual(vm.proSubscriptionYearly.isPurchased, store.hasProSubscription())
     }
 
     func testPurchaseItemIdsMatchProductConstants() {
@@ -78,6 +81,9 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.removeAds.id, disableAdsPID)
         XCTAssertEqual(vm.enableTorch.id, enableTorchPID)
         XCTAssertEqual(vm.enableVideo.id, enableVideoOnlyPID)
+        XCTAssertEqual(vm.tapToFocus.id, tapToFocusPID)
+        XCTAssertEqual(vm.proSubscriptionMonthly.id, proMonthlyPID)
+        XCTAssertEqual(vm.proSubscriptionYearly.id, proYearlyPID)
     }
 
     // MARK: - Purchase Notification Handling

--- a/RemoteCamTests/SettingsViewModelTests.swift
+++ b/RemoteCamTests/SettingsViewModelTests.swift
@@ -5,10 +5,27 @@ final class SettingsViewModelTests: XCTestCase {
 
     private let sendMediaKey = "sendMediaToRemote"
 
+    private let proSubscriptionKey = "hasActiveProSubscription"
+
     override func tearDown() {
         super.tearDown()
         // Clean up UserDefaults changes made during tests
         UserDefaults.standard.removeObject(forKey: sendMediaKey)
+        UserDefaults.standard.removeObject(forKey: proSubscriptionKey)
+    }
+
+    // MARK: - Double-charge protection
+
+    func testSubscriberCannotRedundantlyBuyOneTimePro() {
+        UserDefaults.standard.set(true, forKey: proSubscriptionKey)
+        let vm = SettingsViewModel()
+        vm.refreshPurchaseStates()
+        // A subscriber already has full access, so the one-time "Pro: All
+        // Features" and both subscription rows are marked owned (purchase blocked).
+        XCTAssertTrue(vm.proMode.isPurchased)
+        XCTAssertTrue(vm.proSubscriptionMonthly.isPurchased)
+        XCTAssertTrue(vm.proSubscriptionYearly.isPurchased)
+        XCTAssertTrue(vm.tapToFocus.isPurchased)
     }
 
     // MARK: - Send Media to Remote
@@ -66,13 +83,15 @@ final class SettingsViewModelTests: XCTestCase {
         let vm = SettingsViewModel()
         let store = StoreManager.shared
 
-        XCTAssertEqual(vm.proMode.isPurchased, store.hasProMode())
+        XCTAssertEqual(vm.proMode.isPurchased, store.hasFullAccess())
         XCTAssertEqual(vm.removeAds.isPurchased, store.hasAdRemovalFeature())
         XCTAssertEqual(vm.enableTorch.isPurchased, store.hasTorchFeature())
         XCTAssertEqual(vm.enableVideo.isPurchased, store.hasVideoRecordingFeature())
         XCTAssertEqual(vm.tapToFocus.isPurchased, store.hasTapToFocusFeature())
-        XCTAssertEqual(vm.proSubscriptionMonthly.isPurchased, store.hasProSubscription())
-        XCTAssertEqual(vm.proSubscriptionYearly.isPurchased, store.hasProSubscription())
+        // Full-access products block each other so a subscriber can't re-buy the
+        // one-time Pro (and vice-versa).
+        XCTAssertEqual(vm.proSubscriptionMonthly.isPurchased, store.hasFullAccess())
+        XCTAssertEqual(vm.proSubscriptionYearly.isPurchased, store.hasFullAccess())
     }
 
     func testPurchaseItemIdsMatchProductConstants() {

--- a/RemoteCamTests/StoreManagerTests.swift
+++ b/RemoteCamTests/StoreManagerTests.swift
@@ -8,13 +8,16 @@ final class StoreManagerTests: XCTestCase {
     private let proModeKey = "didBuyProMode"
     private let torchKey = "didBuyEnableTorchFeature"
     private let videoOnlyKey = "didBuyEnableVideoOnlyFeature"
+    private let tapToFocusKey = "didBuyTapToFocusFeature"
+    private let proSubscriptionKey = "hasActiveProSubscription"
 
     private var savedValues: [String: Bool] = [:]
 
     override func setUp() {
         super.setUp()
         // Save existing values so tests don't corrupt real state
-        let keys = [removeAdsKey, proModeKey, torchKey, videoOnlyKey]
+        let keys = [removeAdsKey, proModeKey, torchKey, videoOnlyKey,
+                    tapToFocusKey, proSubscriptionKey]
         for key in keys {
             savedValues[key] = UserDefaults.standard.bool(forKey: key)
             UserDefaults.standard.removeObject(forKey: key)
@@ -38,6 +41,9 @@ final class StoreManagerTests: XCTestCase {
         XCTAssertFalse(store.hasAdRemovalFeature())
         XCTAssertFalse(store.hasTorchFeature())
         XCTAssertFalse(store.hasVideoRecordingFeature())
+        XCTAssertFalse(store.hasProSubscription())
+        XCTAssertFalse(store.hasFullAccess())
+        XCTAssertFalse(store.hasTapToFocusFeature())
     }
 
     // MARK: - Individual Feature Flags
@@ -64,9 +70,56 @@ final class StoreManagerTests: XCTestCase {
 
         let store = StoreManager.shared
         XCTAssertTrue(store.hasProMode())
+        XCTAssertTrue(store.hasFullAccess())
         XCTAssertTrue(store.hasAdRemovalFeature(), "Pro mode should include ad removal")
         XCTAssertTrue(store.hasTorchFeature(), "Pro mode should include torch")
         XCTAssertTrue(store.hasVideoRecordingFeature(), "Pro mode should include video recording")
+        XCTAssertTrue(store.hasTapToFocusFeature(), "Pro mode should include tap to focus")
+    }
+
+    // MARK: - Pro Subscription Grants All Features
+
+    func testProSubscriptionGrantsAllFeatures() {
+        UserDefaults.standard.set(true, forKey: proSubscriptionKey)
+
+        let store = StoreManager.shared
+        XCTAssertTrue(store.hasProSubscription())
+        XCTAssertTrue(store.hasFullAccess())
+        XCTAssertTrue(store.hasAdRemovalFeature(), "Subscription should include ad removal")
+        XCTAssertTrue(store.hasTorchFeature(), "Subscription should include torch")
+        XCTAssertTrue(store.hasVideoRecordingFeature(), "Subscription should include video recording")
+        XCTAssertTrue(store.hasTapToFocusFeature(), "Subscription should include tap to focus")
+        // The subscription is not the one-time Pro bundle.
+        XCTAssertFalse(store.hasProMode(), "Subscription must not be conflated with the one-time 06 bundle")
+    }
+
+    /// The subscription flag is revocable (unlike the append-only one-time
+    /// flags): clearing it — as refreshPurchaseState does when the subscription
+    /// is absent from currentEntitlements — removes access, while an
+    /// independently-owned one-time feature survives.
+    func testClearingSubscriptionRevokesAccessButKeepsOneTimePurchases() {
+        UserDefaults.standard.set(true, forKey: proSubscriptionKey)
+        UserDefaults.standard.set(true, forKey: torchKey)   // separately owned one-time IAP
+        let store = StoreManager.shared
+        XCTAssertTrue(store.hasVideoRecordingFeature())
+
+        UserDefaults.standard.set(false, forKey: proSubscriptionKey)   // lapsed
+
+        XCTAssertFalse(store.hasProSubscription())
+        XCTAssertFalse(store.hasFullAccess())
+        XCTAssertFalse(store.hasVideoRecordingFeature(), "video was only via the lapsed subscription")
+        XCTAssertTrue(store.hasTorchFeature(), "the separately-owned one-time torch survives")
+    }
+
+    // MARK: - Tap to Focus
+
+    func testTapToFocusUnlockedByOwnPurchase() {
+        UserDefaults.standard.set(true, forKey: tapToFocusKey)
+        let store = StoreManager.shared
+        XCTAssertTrue(store.hasTapToFocusFeature())
+        // The dedicated IAP unlocks only tap-to-focus, nothing else.
+        XCTAssertFalse(store.hasVideoRecordingFeature())
+        XCTAssertFalse(store.hasTorchFeature())
     }
 
     // MARK: - Individual Purchase Does Not Grant Other Features
@@ -93,15 +146,25 @@ final class StoreManagerTests: XCTestCase {
         XCTAssertEqual(enableVideoPID, "06")
         XCTAssertEqual(enableTorchPID, "07")
         XCTAssertEqual(enableVideoOnlyPID, "08")
+        XCTAssertEqual(tapToFocusPID, "09")
+        XCTAssertEqual(proMonthlyPID, "pro_monthly")
+        XCTAssertEqual(proYearlyPID, "pro_yearly")
     }
 
-    func testAllProductIDsContainsAllFour() {
+    func testAllProductIDsContainsEveryProduct() {
         let ids = StoreManager.allProductIDs
-        XCTAssertEqual(ids.count, 4)
+        XCTAssertEqual(ids.count, 7)
         XCTAssertTrue(ids.contains(disableAdsPID))
         XCTAssertTrue(ids.contains(enableVideoPID))
         XCTAssertTrue(ids.contains(enableTorchPID))
         XCTAssertTrue(ids.contains(enableVideoOnlyPID))
+        XCTAssertTrue(ids.contains(tapToFocusPID))
+        XCTAssertTrue(ids.contains(proMonthlyPID))
+        XCTAssertTrue(ids.contains(proYearlyPID))
+    }
+
+    func testSubscriptionProductIDs() {
+        XCTAssertEqual(StoreManager.subscriptionProductIDs, [proMonthlyPID, proYearlyPID])
     }
 
     // MARK: - Notification Names

--- a/RemoteShutter.xcodeproj/project.pbxproj
+++ b/RemoteShutter.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		067327692E2E0293003E5F94 /* RemoteShutterHelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 067327682E2E0293003E5F94 /* RemoteShutterHelpView.swift */; };
 		067BEFCC2E2CD1A200F54B4E /* LocalNetworkPermissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 067BEFCB2E2CD1A200F54B4E /* LocalNetworkPermissionView.swift */; };
 		0684A2D11BE65A9800F0B238 /* OrientationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0684A2D01BE65A9800F0B238 /* OrientationUtils.swift */; };
+		FC0CF5A101FE65A9800F0B238 /* FocusPointMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC0CF5A201FE65A9800F0B238 /* FocusPointMapping.swift */; };
 		0684A2E81BE7049800F0B238 /* beep.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 0684A2E61BE7049800F0B238 /* beep.m4a */; };
 		0684A2EB1BE704C600F0B238 /* fastBeep.aif in Resources */ = {isa = PBXBuildFile; fileRef = 0684A2E91BE704C600F0B238 /* fastBeep.aif */; };
 		068DF59D2E3544AD00A49279 /* MonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068DF59A2E3544AD00A49279 /* MonitorView.swift */; };
@@ -149,6 +150,7 @@
 		CADE5E1EC000000000000004 /* CameraDeviceSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADE5E1EC000000000000003 /* CameraDeviceSelectionTests.swift */; };
 		CADE5E1EC000000000000006 /* CaptureIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADE5E1EC000000000000005 /* CaptureIntegrationTests.swift */; };
 		CAFEBABE0001000000000002 /* CropRectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE0001000000000001 /* CropRectTests.swift */; };
+		CAFEBABE00F0000000000002 /* FocusPointMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE00F0000000000001 /* FocusPointMappingTests.swift */; };
 		CAFEBABE0002000000000002 /* WatchCaptureCountdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE0002000000000001 /* WatchCaptureCountdownTests.swift */; };
 		CAFEBABE0003000000000002 /* WatchSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE0003000000000001 /* WatchSerializationTests.swift */; };
 		CAFEBABE0004000000000002 /* WatchRemoteCamStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFEBABE0004000000000001 /* WatchRemoteCamStateTests.swift */; };
@@ -277,6 +279,7 @@
 		067327682E2E0293003E5F94 /* RemoteShutterHelpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteShutterHelpView.swift; sourceTree = "<group>"; };
 		067BEFCB2E2CD1A200F54B4E /* LocalNetworkPermissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNetworkPermissionView.swift; sourceTree = "<group>"; };
 		0684A2D01BE65A9800F0B238 /* OrientationUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrientationUtils.swift; sourceTree = "<group>"; };
+		FC0CF5A201FE65A9800F0B238 /* FocusPointMapping.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FocusPointMapping.swift; sourceTree = "<group>"; };
 		0684A2E61BE7049800F0B238 /* beep.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = beep.m4a; sourceTree = "<group>"; };
 		0684A2E91BE704C600F0B238 /* fastBeep.aif */ = {isa = PBXFileReference; lastKnownFileType = file; path = fastBeep.aif; sourceTree = "<group>"; };
 		068DF59A2E3544AD00A49279 /* MonitorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorView.swift; sourceTree = "<group>"; };
@@ -393,6 +396,7 @@
 		CADE5E1EC000000000000003 /* CameraDeviceSelectionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CameraDeviceSelectionTests.swift; sourceTree = "<group>"; };
 		CADE5E1EC000000000000005 /* CaptureIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CaptureIntegrationTests.swift; sourceTree = "<group>"; };
 		CAFEBABE0001000000000001 /* CropRectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropRectTests.swift; sourceTree = "<group>"; };
+		CAFEBABE00F0000000000001 /* FocusPointMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusPointMappingTests.swift; sourceTree = "<group>"; };
 		CAFEBABE0002000000000001 /* WatchCaptureCountdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchCaptureCountdownTests.swift; sourceTree = "<group>"; };
 		CAFEBABE0003000000000001 /* WatchSerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchSerializationTests.swift; sourceTree = "<group>"; };
 		CAFEBABE0004000000000001 /* WatchRemoteCamStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchRemoteCamStateTests.swift; sourceTree = "<group>"; };
@@ -559,6 +563,7 @@
 				AABB00332E930033009TESTS /* FrameStreamingTests.swift */,
 				AABB00032E930002009TESTS /* RemoteCmdSerializationTests.swift */,
 				CAFEBABE0001000000000001 /* CropRectTests.swift */,
+				CAFEBABE00F0000000000001 /* FocusPointMappingTests.swift */,
 				CAFEBABE0002000000000001 /* WatchCaptureCountdownTests.swift */,
 				CAFEBABE0003000000000001 /* WatchSerializationTests.swift */,
 				CAFEBABE0006000000000001 /* WatchPreviewStreamerTests.swift */,
@@ -645,6 +650,7 @@
 				069284451BE5C0E600AF4678 /* MultipeerMessages.swift */,
 				0684A2D81BE6E9D400F0B238 /* RemoteCamSession */,
 				0684A2D01BE65A9800F0B238 /* OrientationUtils.swift */,
+				FC0CF5A201FE65A9800F0B238 /* FocusPointMapping.swift */,
 				060B1E141BE7079800077BCC /* Helpers */,
 				06E965202535199400E5A8B3 /* MediaProcessors.swift */,
 				06E9652625351E3F00E5A8B3 /* SwiftConstants.swift */,
@@ -1123,6 +1129,7 @@
 				06CDFB17252E9A7900EA56FB /* RemoteCmds.swift in Sources */,
 				0673275D2E2DF142003E5F94 /* PermissionManager.swift in Sources */,
 				0684A2D11BE65A9800F0B238 /* OrientationUtils.swift in Sources */,
+				FC0CF5A101FE65A9800F0B238 /* FocusPointMapping.swift in Sources */,
 				06BB79B82E374D410094E085 /* FeatureFlags.swift in Sources */,
 				0692844F1BE5C0E600AF4678 /* MultipeerMessages.swift in Sources */,
 				069284531BE5C0E600AF4678 /* RemoteCamStateNames.swift in Sources */,
@@ -1191,6 +1198,7 @@
 				AABB00342E930033009TESTS /* FrameStreamingTests.swift in Sources */,
 				AABB00042E930002009TESTS /* RemoteCmdSerializationTests.swift in Sources */,
 				CAFEBABE0001000000000002 /* CropRectTests.swift in Sources */,
+				CAFEBABE00F0000000000002 /* FocusPointMappingTests.swift in Sources */,
 				CAFEBABE0002000000000002 /* WatchCaptureCountdownTests.swift in Sources */,
 				CAFEBABE0003000000000002 /* WatchSerializationTests.swift in Sources */,
 				CAFEBABE0006000000000002 /* WatchPreviewStreamerTests.swift in Sources */,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -144,6 +144,9 @@ platform :ios do
       # ones removed locally, so ASC mirrors fastlane/screenshots/ without
       # re-uploading every image each release.
       sync_screenshots: true,
+      # To force a full re-upload instead (delete ALL on ASC first), comment out
+      # sync_screenshots above and uncomment this — the two are mutually exclusive:
+      # overwrite_screenshots: true,
       precheck_include_in_app_purchases: false,
       force: true,
       submit_for_review: false
@@ -206,6 +209,9 @@ platform :ios do
       screenshots_path: "./fastlane/screenshots_mac",
       # Only upload changed screenshots and remove ones deleted locally.
       sync_screenshots: true,
+      # Swap to a full re-upload (delete ALL first) by commenting out
+      # sync_screenshots above and uncommenting this — mutually exclusive:
+      # overwrite_screenshots: true,
       precheck_include_in_app_purchases: false,
       force: true,
       submit_for_review: false

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -140,9 +140,10 @@ platform :ios do
     upload_to_app_store(
       skip_metadata: false,
       skip_screenshots: false,
-      # Delete ALL screenshots on App Store Connect before uploading, so ASC
-      # exactly mirrors fastlane/screenshots/ (otherwise deliver only appends).
-      overwrite_screenshots: true,
+      # Upload only screenshots that changed (matched by checksum) and delete
+      # ones removed locally, so ASC mirrors fastlane/screenshots/ without
+      # re-uploading every image each release.
+      sync_screenshots: true,
       precheck_include_in_app_purchases: false,
       force: true,
       submit_for_review: false
@@ -199,11 +200,12 @@ platform :ios do
       platform: "osx",
       skip_metadata: false,
       skip_screenshots: false,
-      # Mac screenshots live in their own tree: deliver uploads EVERY file in
+      # Mac screenshots live in their own tree: deliver uploads files in
       # screenshots_path to the run's platform, and APP_DESKTOP display types
       # are invalid on the iOS version (run 29181223484) — and vice versa.
       screenshots_path: "./fastlane/screenshots_mac",
-      overwrite_screenshots: true,
+      # Only upload changed screenshots and remove ones deleted locally.
+      sync_screenshots: true,
       precheck_include_in_app_purchases: false,
       force: true,
       submit_for_review: false

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -63,7 +63,7 @@ platform :ios do
     )
   end
 
-  desc "Sync in-app purchase localizations on ASC from fastlane/iap_localizations.json"
+  desc "Sync in-app purchase & subscription localizations on ASC from fastlane/iap_localizations.json"
   lane :sync_iap do
     load_asc_api_key
     token = Spaceship::ConnectAPI::Token.create(

--- a/fastlane/iap_localizations.json
+++ b/fastlane/iap_localizations.json
@@ -65,64 +65,64 @@
     },
     "06": {
       "en-US": {
-        "name": "Pro (Lifetime)",
-        "description": "Every feature forever — one-time."
+        "name": "Pro: All Features",
+        "description": "Video, torch control, and no ads."
       },
       "da": {
-        "name": "Pro (livstid)",
-        "description": "Alle funktioner for altid, engangskøb."
+        "name": "Pro: Alle funktioner",
+        "description": "Video, lommelygte og ingen reklamer."
       },
       "de-DE": {
-        "name": "Pro (lebenslang)",
-        "description": "Alle Funktionen für immer, einmalig."
+        "name": "Pro: Alle Funktionen",
+        "description": "Video, Licht-Steuerung, keine Werbung."
       },
       "es-MX": {
-        "name": "Pro (de por vida)",
-        "description": "Todas las funciones, pago único."
+        "name": "Pro: Todas las funciones",
+        "description": "Video, linterna y sin anuncios."
       },
       "fr-FR": {
-        "name": "Pro (à vie)",
-        "description": "Toutes les fonctions à vie, une fois."
+        "name": "Pro : toutes les fonctions",
+        "description": "Vidéo, torche et zéro publicité."
       },
       "it": {
-        "name": "Pro (a vita)",
-        "description": "Tutte le funzioni per sempre, una volta."
+        "name": "Pro: tutte le funzioni",
+        "description": "Video, torcia e niente pubblicità."
       },
       "ja": {
-        "name": "プロ（永久）",
-        "description": "すべての機能を永久に、買い切り。"
+        "name": "プロ: 全機能",
+        "description": "ビデオ、ライト操作、広告なし。"
       },
       "ko": {
-        "name": "프로(평생)",
-        "description": "모든 기능 평생, 일회성 결제."
+        "name": "프로: 전체 기능",
+        "description": "비디오, 손전등 제어, 광고 제거."
       },
       "pt-BR": {
-        "name": "Pro (vitalício)",
-        "description": "Todos os recursos para sempre, único."
+        "name": "Pro: todos os recursos",
+        "description": "Vídeo, lanterna e sem anúncios."
       },
       "zh-Hans": {
-        "name": "专业版（永久）",
-        "description": "永久解锁全部功能，一次性。"
+        "name": "专业版：全部功能",
+        "description": "视频、手电筒控制，无广告。"
       },
       "vi": {
-        "name": "Pro (trọn đời)",
-        "description": "Mọi tính năng mãi mãi, trả một lần."
+        "name": "Pro: Tất cả tính năng",
+        "description": "Video, đèn pin và không quảng cáo."
       },
       "hi": {
-        "name": "प्रो (लाइफटाइम)",
-        "description": "सभी सुविधाएँ हमेशा के लिए, एक बार।"
+        "name": "प्रो: सभी सुविधाएँ",
+        "description": "वीडियो, टॉर्च कंट्रोल और विज्ञापन-मुक्त।"
       },
       "ms": {
-        "name": "Pro (Seumur Hidup)",
-        "description": "Semua ciri selamanya, bayar sekali."
+        "name": "Pro: Semua Ciri",
+        "description": "Video, kawalan lampu suluh, tiada iklan."
       },
       "tr": {
-        "name": "Pro (Ömür Boyu)",
-        "description": "Tüm özellikler kalıcı, tek seferlik."
+        "name": "Pro: Tüm Özellikler",
+        "description": "Video, el feneri kontrolü, reklamsız."
       },
       "ru": {
-        "name": "Pro (навсегда)",
-        "description": "Все функции навсегда, разовая оплата."
+        "name": "Pro: все функции",
+        "description": "Видео, управление фонариком, без рекламы."
       }
     },
     "07": {

--- a/fastlane/iap_localizations.json
+++ b/fastlane/iap_localizations.json
@@ -248,6 +248,192 @@
         "name": "Запись видео",
         "description": "Снимайте видео удалённой камерой."
       }
+    },
+    "09": {
+      "en-US": {
+        "name": "Tap to Focus",
+        "description": "Tap the preview to set focus & exposure."
+      },
+      "da": {
+        "name": "Tryk for fokus",
+        "description": "Tryk på forhåndsvisningen for fokus."
+      },
+      "de-DE": {
+        "name": "Tippen zum Fokussieren",
+        "description": "Tippen für Fokus und Belichtung."
+      },
+      "es-MX": {
+        "name": "Toca para enfocar",
+        "description": "Toca la vista previa para enfocar."
+      },
+      "fr-FR": {
+        "name": "Toucher pour la mise au point",
+        "description": "Touchez l'aperçu pour faire le point."
+      },
+      "it": {
+        "name": "Tocca per mettere a fuoco",
+        "description": "Tocca l'anteprima per la messa a fuoco."
+      },
+      "ja": {
+        "name": "タップでフォーカス",
+        "description": "プレビューをタップしてフォーカスと露出を設定。"
+      },
+      "ko": {
+        "name": "탭하여 초점",
+        "description": "미리보기를 탭해 초점과 노출을 설정."
+      },
+      "pt-BR": {
+        "name": "Toque para focar",
+        "description": "Toque na prévia para focar e expor."
+      },
+      "zh-Hans": {
+        "name": "点按对焦",
+        "description": "点按预览设置对焦和曝光。"
+      },
+      "vi": {
+        "name": "Chạm để lấy nét",
+        "description": "Chạm vào bản xem trước để lấy nét."
+      },
+      "hi": {
+        "name": "फ़ोकस के लिए टैप",
+        "description": "फोकस सेट करने के लिए प्रीव्यू टैप करें।"
+      },
+      "ms": {
+        "name": "Ketik untuk Fokus",
+        "description": "Ketik pratonton untuk tetapkan fokus."
+      },
+      "tr": {
+        "name": "Odaklamak için dokun",
+        "description": "Önizlemeye dokunup odak ayarlayın."
+      },
+      "ru": {
+        "name": "Тап для фокуса",
+        "description": "Коснитесь превью для фокуса."
+      }
+    },
+    "pro_monthly": {
+      "en-US": {
+        "name": "Pro (Monthly)",
+        "description": "Every feature, billed monthly."
+      },
+      "da": {
+        "name": "Pro (månedlig)",
+        "description": "Alle funktioner, månedligt."
+      },
+      "de-DE": {
+        "name": "Pro (monatlich)",
+        "description": "Alle Funktionen, monatlich."
+      },
+      "es-MX": {
+        "name": "Pro (mensual)",
+        "description": "Todas las funciones, cada mes."
+      },
+      "fr-FR": {
+        "name": "Pro (mensuel)",
+        "description": "Toutes les fonctions, chaque mois."
+      },
+      "it": {
+        "name": "Pro (mensile)",
+        "description": "Tutte le funzioni, ogni mese."
+      },
+      "ja": {
+        "name": "プロ（月額）",
+        "description": "すべての機能、毎月課金。"
+      },
+      "ko": {
+        "name": "프로(월간)",
+        "description": "모든 기능, 매월 청구."
+      },
+      "pt-BR": {
+        "name": "Pro (mensal)",
+        "description": "Todos os recursos, por mês."
+      },
+      "zh-Hans": {
+        "name": "专业版（月付）",
+        "description": "全部功能，按月付费。"
+      },
+      "vi": {
+        "name": "Pro (hàng tháng)",
+        "description": "Mọi tính năng, tính phí hàng tháng."
+      },
+      "hi": {
+        "name": "प्रो (मासिक)",
+        "description": "सभी सुविधाएँ, मासिक शुल्क।"
+      },
+      "ms": {
+        "name": "Pro (Bulanan)",
+        "description": "Semua ciri, dicaj bulanan."
+      },
+      "tr": {
+        "name": "Pro (Aylık)",
+        "description": "Tüm özellikler, aylık ödeme."
+      },
+      "ru": {
+        "name": "Pro (месяц)",
+        "description": "Все функции, ежемесячно."
+      }
+    },
+    "pro_yearly": {
+      "en-US": {
+        "name": "Pro (Yearly)",
+        "description": "Every feature, billed yearly."
+      },
+      "da": {
+        "name": "Pro (årlig)",
+        "description": "Alle funktioner, årligt."
+      },
+      "de-DE": {
+        "name": "Pro (jährlich)",
+        "description": "Alle Funktionen, jährlich."
+      },
+      "es-MX": {
+        "name": "Pro (anual)",
+        "description": "Todas las funciones, cada año."
+      },
+      "fr-FR": {
+        "name": "Pro (annuel)",
+        "description": "Toutes les fonctions, chaque année."
+      },
+      "it": {
+        "name": "Pro (annuale)",
+        "description": "Tutte le funzioni, ogni anno."
+      },
+      "ja": {
+        "name": "プロ（年額）",
+        "description": "すべての機能、毎年課金。"
+      },
+      "ko": {
+        "name": "프로(연간)",
+        "description": "모든 기능, 매년 청구."
+      },
+      "pt-BR": {
+        "name": "Pro (anual)",
+        "description": "Todos os recursos, por ano."
+      },
+      "zh-Hans": {
+        "name": "专业版（年付）",
+        "description": "全部功能，按年付费。"
+      },
+      "vi": {
+        "name": "Pro (hàng năm)",
+        "description": "Mọi tính năng, tính phí hàng năm."
+      },
+      "hi": {
+        "name": "प्रो (वार्षिक)",
+        "description": "सभी सुविधाएँ, वार्षिक शुल्क।"
+      },
+      "ms": {
+        "name": "Pro (Tahunan)",
+        "description": "Semua ciri, dicaj tahunan."
+      },
+      "tr": {
+        "name": "Pro (Yıllık)",
+        "description": "Tüm özellikler, yıllık ödeme."
+      },
+      "ru": {
+        "name": "Pro (год)",
+        "description": "Все функции, ежегодно."
+      }
     }
   }
 }

--- a/fastlane/iap_localizations.json
+++ b/fastlane/iap_localizations.json
@@ -65,64 +65,64 @@
     },
     "06": {
       "en-US": {
-        "name": "Pro: All Features",
-        "description": "Video, torch control, and no ads."
+        "name": "Pro (Lifetime)",
+        "description": "Every feature forever — one-time."
       },
       "da": {
-        "name": "Pro: Alle funktioner",
-        "description": "Video, lommelygte og ingen reklamer."
+        "name": "Pro (livstid)",
+        "description": "Alle funktioner for altid, engangskøb."
       },
       "de-DE": {
-        "name": "Pro: Alle Funktionen",
-        "description": "Video, Licht-Steuerung, keine Werbung."
+        "name": "Pro (lebenslang)",
+        "description": "Alle Funktionen für immer, einmalig."
       },
       "es-MX": {
-        "name": "Pro: Todas las funciones",
-        "description": "Video, linterna y sin anuncios."
+        "name": "Pro (de por vida)",
+        "description": "Todas las funciones, pago único."
       },
       "fr-FR": {
-        "name": "Pro : toutes les fonctions",
-        "description": "Vidéo, torche et zéro publicité."
+        "name": "Pro (à vie)",
+        "description": "Toutes les fonctions à vie, une fois."
       },
       "it": {
-        "name": "Pro: tutte le funzioni",
-        "description": "Video, torcia e niente pubblicità."
+        "name": "Pro (a vita)",
+        "description": "Tutte le funzioni per sempre, una volta."
       },
       "ja": {
-        "name": "プロ: 全機能",
-        "description": "ビデオ、ライト操作、広告なし。"
+        "name": "プロ（永久）",
+        "description": "すべての機能を永久に、買い切り。"
       },
       "ko": {
-        "name": "프로: 전체 기능",
-        "description": "비디오, 손전등 제어, 광고 제거."
+        "name": "프로(평생)",
+        "description": "모든 기능 평생, 일회성 결제."
       },
       "pt-BR": {
-        "name": "Pro: todos os recursos",
-        "description": "Vídeo, lanterna e sem anúncios."
+        "name": "Pro (vitalício)",
+        "description": "Todos os recursos para sempre, único."
       },
       "zh-Hans": {
-        "name": "专业版：全部功能",
-        "description": "视频、手电筒控制，无广告。"
+        "name": "专业版（永久）",
+        "description": "永久解锁全部功能，一次性。"
       },
       "vi": {
-        "name": "Pro: Tất cả tính năng",
-        "description": "Video, đèn pin và không quảng cáo."
+        "name": "Pro (trọn đời)",
+        "description": "Mọi tính năng mãi mãi, trả một lần."
       },
       "hi": {
-        "name": "प्रो: सभी सुविधाएँ",
-        "description": "वीडियो, टॉर्च कंट्रोल और विज्ञापन-मुक्त।"
+        "name": "प्रो (लाइफटाइम)",
+        "description": "सभी सुविधाएँ हमेशा के लिए, एक बार।"
       },
       "ms": {
-        "name": "Pro: Semua Ciri",
-        "description": "Video, kawalan lampu suluh, tiada iklan."
+        "name": "Pro (Seumur Hidup)",
+        "description": "Semua ciri selamanya, bayar sekali."
       },
       "tr": {
-        "name": "Pro: Tüm Özellikler",
-        "description": "Video, el feneri kontrolü, reklamsız."
+        "name": "Pro (Ömür Boyu)",
+        "description": "Tüm özellikler kalıcı, tek seferlik."
       },
       "ru": {
-        "name": "Pro: все функции",
-        "description": "Видео, управление фонариком, без рекламы."
+        "name": "Pro (навсегда)",
+        "description": "Все функции навсегда, разовая оплата."
       }
     },
     "07": {

--- a/fastlane/iap_sync.rb
+++ b/fastlane/iap_sync.rb
@@ -1,16 +1,45 @@
-# Syncs in-app purchase localizations on App Store Connect to match
-# fastlane/iap_localizations.json. Uses the App Store Connect API directly —
-# deliver does not manage IAP metadata. Invoked by the `sync_iap` lane.
+# Syncs in-app purchase AND auto-renewable subscription localizations on App
+# Store Connect to match fastlane/iap_localizations.json. Uses the App Store
+# Connect API directly — deliver does not manage IAP metadata. Invoked by the
+# `sync_iap` lane.
 #
-# ASC state model: a localization in ACTIVE state (live on the store) is
-# immutable — posting a NEW localization for the same locale creates the
+# One-time IAPs and subscriptions are distinct ASC resources with parallel but
+# separate localization endpoints (inAppPurchaseLocalizations vs
+# subscriptionLocalizations); both carry the same name/description/locale shape,
+# so the per-locale sync is shared and only the endpoints differ (see ENDPOINTS).
+#
+# This script only syncs LOCALIZATIONS of products that already exist on ASC —
+# it never creates products. Create product 09, the "Pro" subscription group,
+# and the subscriptions (with pricing) manually in App Store Connect first; a
+# product ID not found on ASC is skipped.
+#
+# ASC state model: a localization in a live/immutable state (ACTIVE/APPROVED) is
+# not editable — posting a NEW localization for the same locale creates the
 # pending edit that goes to review with the next submission. Editable states
-# (PREPARE_FOR_SUBMISSION, REJECTED, ...) are patched in place.
+# (PREPARE_FOR_SUBMISSION, REJECTED) are patched in place.
 require "net/http"
 require "json"
 
 module IapSync
   BASE = "https://api.appstoreconnect.apple.com".freeze
+  EDITABLE_STATES = %w[PREPARE_FOR_SUBMISSION REJECTED].freeze
+
+  # Per-resource localization endpoints. `list` is relative to the parent
+  # product; `rel` is the create-time relationship to that product.
+  ENDPOINTS = {
+    iap: {
+      list: ->(id) { "/v2/inAppPurchases/#{id}/inAppPurchaseLocalizations?limit=200" },
+      collection: "/v1/inAppPurchaseLocalizations",
+      type: "inAppPurchaseLocalizations",
+      rel: ->(id) { { inAppPurchaseV2: { data: { type: "inAppPurchases", id: id } } } },
+    },
+    subscription: {
+      list: ->(id) { "/v1/subscriptions/#{id}/subscriptionLocalizations?limit=200" },
+      collection: "/v1/subscriptionLocalizations",
+      type: "subscriptionLocalizations",
+      rel: ->(id) { { subscription: { data: { type: "subscriptions", id: id } } } },
+    },
+  }.freeze
 
   def self.run(bearer_token)
     @bearer = bearer_token
@@ -19,51 +48,70 @@ module IapSync
 
     app = req(:get, "/v1/apps?filter[bundleId]=#{data.fetch('bundle_id')}")
       .fetch("data").first or raise "app not found for #{data['bundle_id']}"
-    iaps = req(:get, "/v1/apps/#{app['id']}/inAppPurchasesV2?limit=200").fetch("data")
+
+    # productId -> { kind:, id: } across both one-time IAPs and subscriptions.
+    products = {}
+    req(:get, "/v1/apps/#{app['id']}/inAppPurchasesV2?limit=200").fetch("data").each do |iap|
+      products[iap.dig("attributes", "productId")] = { kind: :iap, id: iap["id"] }
+    end
+    subscriptions_for(app["id"]).each do |sub|
+      products[sub.dig("attributes", "productId")] = { kind: :subscription, id: sub["id"] }
+    end
 
     data.fetch("products").each do |product_id, locales|
-      iap = iaps.find { |i| i.dig("attributes", "productId") == product_id }
-      unless iap
+      product = products[product_id]
+      unless product
         puts "SKIP product #{product_id}: not found on App Store Connect"
         next
       end
-      existing = req(:get, "/v2/inAppPurchases/#{iap['id']}/inAppPurchaseLocalizations?limit=200")
+      endpoints = ENDPOINTS.fetch(product[:kind])
+      existing = req(:get, endpoints[:list].call(product[:id]))
         .fetch("data")
         .group_by { |l| l.dig("attributes", "locale") }
 
       locales.each do |locale, strings|
-        attrs = { "name" => strings.fetch("name"), "description" => strings.fetch("description") }
-        group = existing[locale] || []
-        editable = group.find { |l| %w[PREPARE_FOR_SUBMISSION REJECTED].include?(l.dig("attributes", "state")) }
-        target = editable || group.first
-        state = target&.dig("attributes", "state")
-        begin
-          if target && target["attributes"].values_at("name", "description") == attrs.values_at("name", "description")
-            puts "ok      #{product_id} #{locale}"
-          elsif editable
-            req(:patch, "/v1/inAppPurchaseLocalizations/#{editable['id']}", {
-              data: { type: "inAppPurchaseLocalizations", id: editable["id"], attributes: attrs },
-            })
-            puts "UPDATED #{product_id} #{locale}"
-          else
-            # No editable entry: either the locale is new, or only an immutable
-            # ACTIVE entry exists — POST creates the (pending) localization.
-            req(:post, "/v1/inAppPurchaseLocalizations", {
-              data: {
-                type: "inAppPurchaseLocalizations",
-                attributes: attrs.merge("locale" => locale),
-                relationships: { inAppPurchaseV2: { data: { type: "inAppPurchases", id: iap["id"] } } },
-              },
-            })
-            puts group.empty? ? "CREATED #{product_id} #{locale}" : "EDITED  #{product_id} #{locale} (pending review)"
-          end
-        rescue => e
-          puts "FAILED  #{product_id} #{locale} (state=#{state}): #{e.message.lines.first&.strip}"
-          failures << "#{product_id} #{locale}"
-        end
+        sync_locale(product_id, product[:id], endpoints, locale, strings, existing, failures)
       end
     end
     raise "sync failed for: #{failures.join(', ')}" unless failures.empty?
+  end
+
+  # All subscriptions across the app's subscription groups.
+  def self.subscriptions_for(app_id)
+    resp = req(:get, "/v1/apps/#{app_id}/subscriptionGroups?include=subscriptions&limit=200")
+    (resp["included"] || []).select { |r| r["type"] == "subscriptions" }
+  end
+
+  def self.sync_locale(product_id, resource_id, endpoints, locale, strings, existing, failures)
+    attrs = { "name" => strings.fetch("name"), "description" => strings.fetch("description") }
+    group = existing[locale] || []
+    editable = group.find { |l| EDITABLE_STATES.include?(l.dig("attributes", "state")) }
+    target = editable || group.first
+    state = target&.dig("attributes", "state")
+    begin
+      if target && target["attributes"].values_at("name", "description") == attrs.values_at("name", "description")
+        puts "ok      #{product_id} #{locale}"
+      elsif editable
+        req(:patch, "#{endpoints[:collection]}/#{editable['id']}", {
+          data: { type: endpoints[:type], id: editable["id"], attributes: attrs },
+        })
+        puts "UPDATED #{product_id} #{locale}"
+      else
+        # No editable entry: either the locale is new, or only an immutable
+        # live entry exists — POST creates the (pending) localization.
+        req(:post, endpoints[:collection], {
+          data: {
+            type: endpoints[:type],
+            attributes: attrs.merge("locale" => locale),
+            relationships: endpoints[:rel].call(resource_id),
+          },
+        })
+        puts group.empty? ? "CREATED #{product_id} #{locale}" : "EDITED  #{product_id} #{locale} (pending review)"
+      end
+    rescue => e
+      puts "FAILED  #{product_id} #{locale} (state=#{state}): #{e.message.lines.first&.strip}"
+      failures << "#{product_id} #{locale}"
+    end
   end
 
   def self.req(method, path, body = nil)


### PR DESCRIPTION
## What

Adds **tap-to-focus** for iOS and Mac Catalyst monitors (watchOS stays on auto). The monitor user taps the live preview to set the remote camera's **focus and exposure** point of interest, with a reticle animation. The feature is gated behind an entitlement and monetized two ways.

## Mechanics

- **Wire**: new FlatBuffers command `FocusAtPoint` (action `21`) carrying a normalized point, plus a `supports_focus_point` capability flag. Action 21 decodes as `TakePicture` on out-of-date peers, so the monitor only sends it to a camera that advertised support — the same wire-safety gate as `SelectCameraDevice`, pinned by a loopback test (`testFocusAtPointIsNeverSentToLegacyPeer`).
- **Camera**: `CaptureEngine` sets focus + exposure POI (continuous-auto on both), guarded by hardware support, and resets to center/auto on every camera swap.
- **Mapping**: `FocusPointMapping` — pure, unit-tested geometry that maps a letterboxed `.fit` preview tap into `focusPointOfInterest` space (orientation + front-camera mirror).
- **UI**: single-tap focus via `ExclusiveGesture` (double-tap-to-toggle-camera and pinch-zoom still work) + `FocusReticleView`.

## Monetization

- New one-time IAP **`09` (Tap to Focus)** and an **auto-renewable Pro subscription** (group "Pro": `pro_monthly` + `pro_yearly`) that unlocks **every** feature — the recurring equivalent of the **kept** one-time `06` bundle.
- Subscription entitlement is **derived from `Transaction.currentEntitlements`** each refresh (not append-only), so a lapsed subscription is revoked. `hasFullAccess()` folds it into every feature accessor.
- Paywall UI (Welcome featured card + rows, Settings rows), `Configuration.storekit` subscription group, and `iap_localizations.json` for all 15 locales (names ≤30, descriptions ≤45).

## Testing

- New: `FocusPointMapping` unit tests, `FocusAtPoint` loopback happy-path + legacy-peer gate, serialization round-trips, StoreManager subscription/expiry/tap-to-focus entitlement tests.
- **Full suite green under Thread Sanitizer (540 tests, 0 failures, 7 hardware tests skipped); iOS + Mac Catalyst both build.**

## ⚠️ Needs on-device validation

The `FocusPointMapping` orientation/mirror constants are code-derived, **not** hardware-verified (the classic AVFoundation coordinate trap). Please tap-to-focus on real devices — front camera + a rotated iPhone especially — to confirm focus lands where you tap. Any flip is a one-line fix in `FocusPointMapping.swift`.

Real IAP prices and the subscription group are configured in App Store Connect; the `.storekit` file uses placeholder prices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)