### PR TITLE
Fix release: opt into deliver sync_screenshots beta

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,6 +3,11 @@ require 'openssl'
 
 default_platform(:ios)
 
+# The release lanes use deliver's `sync_screenshots` (upload only changed/new
+# screenshots, delete removed ones). It's a beta feature that fastlane refuses to
+# run unless this env var opts in — set here so it applies wherever deliver runs.
+ENV["FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS"] = "1"
+
 # Fix PEM content that has had its newlines stripped.
 # OpenSSL requires newlines after the header, between body lines (every 64 chars),
 # and before the footer. Without them it produces a misleading "invalid curve name" error.


### PR DESCRIPTION
## Problem

The last release failed at `upload_to_app_store`:

> Please set a value to `FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS` environment variable if you acknowledge the risk and try this out.

The release lanes were switched to `sync_screenshots: true` (upload only changed/new screenshots instead of re-uploading everything). That's a **beta** feature in fastlane `deliver`, and fastlane refuses to run it unless you explicitly opt in via `FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS`. The build + signing succeeded; only the upload gate failed.

## Fix

Set `ENV["FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS"] = "1"` at the top of the Fastfile so both the iOS and Mac release lanes can use `sync_screenshots`.

Metadata/CI-config only — no app code. If `sync_screenshots` ever misbehaves (it is beta), the commented `overwrite_screenshots: true` fallback is still one uncomment away in both lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)