### PR TITLE
Use overwrite_screenshots for releases (drop flaky sync_screenshots beta)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,11 +3,6 @@ require 'openssl'
 
 default_platform(:ios)
 
-# The release lanes use deliver's `sync_screenshots` (upload only changed/new
-# screenshots, delete removed ones). It's a beta feature that fastlane refuses to
-# run unless this env var opts in — set here so it applies wherever deliver runs.
-ENV["FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS"] = "1"
-
 # Fix PEM content that has had its newlines stripped.
 # OpenSSL requires newlines after the header, between body lines (every 64 chars),
 # and before the footer. Without them it produces a misleading "invalid curve name" error.
@@ -145,13 +140,13 @@ platform :ios do
     upload_to_app_store(
       skip_metadata: false,
       skip_screenshots: false,
-      # Upload only screenshots that changed (matched by checksum) and delete
-      # ones removed locally, so ASC mirrors fastlane/screenshots/ without
-      # re-uploading every image each release.
-      sync_screenshots: true,
-      # To force a full re-upload instead (delete ALL on ASC first), comment out
-      # sync_screenshots above and uncomment this — the two are mutually exclusive:
-      # overwrite_screenshots: true,
+      # Delete ALL screenshots on App Store Connect before uploading, so ASC
+      # exactly mirrors fastlane/screenshots/ (otherwise deliver only appends).
+      overwrite_screenshots: true,
+      # Alternative — upload only changed screenshots — but it is a fastlane
+      # BETA that needs FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS=1 and has
+      # flaked on ASC processing; mutually exclusive with overwrite_screenshots:
+      # sync_screenshots: true,
       precheck_include_in_app_purchases: false,
       force: true,
       submit_for_review: false
@@ -212,11 +207,11 @@ platform :ios do
       # screenshots_path to the run's platform, and APP_DESKTOP display types
       # are invalid on the iOS version (run 29181223484) — and vice versa.
       screenshots_path: "./fastlane/screenshots_mac",
-      # Only upload changed screenshots and remove ones deleted locally.
-      sync_screenshots: true,
-      # Swap to a full re-upload (delete ALL first) by commenting out
-      # sync_screenshots above and uncommenting this — mutually exclusive:
-      # overwrite_screenshots: true,
+      # Delete ALL Mac screenshots on ASC before uploading (mirror the local set).
+      overwrite_screenshots: true,
+      # Beta alternative (upload only changed) — needs
+      # FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS=1, mutually exclusive:
+      # sync_screenshots: true,
       precheck_include_in_app_purchases: false,
       force: true,
       submit_for_review: false


### PR DESCRIPTION
## Problem

After opting into the `sync_screenshots` beta (PR #172), the release got past the beta gate but then failed:

> Retried uploading screenshots 0 but there are still failures of processing screenshots.

`sync_screenshots` is a fastlane **beta** and flaked on App Store Connect's server-side screenshot processing — the second failure it's caused.

## Fix

Both release lanes go back to **`overwrite_screenshots: true`** (delete all on ASC, re-upload all) — non-beta and the behavior this app released on for months — and the beta env var is removed. `sync_screenshots` stays as a commented, clearly-labeled beta alternative in both lanes for anyone who wants to revisit it later.

Trade-off: releases re-upload all screenshots each time (slower) but reliably. CI-config only, no app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)