### PR TITLE
Add overwrite_screenshots toggle to the iOS release lane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
         type: choice
         options: [both, ios, mac]
         default: both
+      overwrite_screenshots:
+        description: "Delete all App Store screenshots and re-upload (iOS lane). Uncheck to leave ASC screenshots untouched."
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -35,7 +39,7 @@ jobs:
       - name: Build and upload iOS to App Store
         if: ${{ inputs.platform != 'mac' }}
         timeout-minutes: 30
-        run: bundle exec fastlane release
+        run: bundle exec fastlane release overwrite_screenshots:${{ inputs.overwrite_screenshots }}
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -74,7 +74,15 @@ platform :ios do
   end
 
   desc "Build and upload to App Store Connect"
-  lane :release do
+  desc "Options:"
+  desc "  overwrite_screenshots — when true (default) delete ALL screenshots on"
+  desc "    ASC and re-upload fastlane/screenshots/; when false, leave ASC"
+  desc "    screenshots untouched (skip them entirely). e.g."
+  desc "    fastlane release overwrite_screenshots:false"
+  lane :release do |options|
+    # Coerce to a real boolean: CLI args and GitHub workflow_dispatch inputs
+    # both arrive as the strings "true"/"false", and "false" is truthy in Ruby.
+    overwrite_screenshots = options.fetch(:overwrite_screenshots, true).to_s.downcase != "false"
     load_asc_api_key
     setup_ci
     # Register the watch app's App ID on the developer portal if it doesn't
@@ -139,10 +147,11 @@ platform :ios do
     )
     upload_to_app_store(
       skip_metadata: false,
-      skip_screenshots: false,
+      # When overwrite_screenshots is false, don't touch ASC screenshots at all.
+      skip_screenshots: !overwrite_screenshots,
       # Delete ALL screenshots on App Store Connect before uploading, so ASC
       # exactly mirrors fastlane/screenshots/ (otherwise deliver only appends).
-      overwrite_screenshots: true,
+      overwrite_screenshots: overwrite_screenshots,
       # Alternative — upload only changed screenshots — but it is a fastlane
       # BETA that needs FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS=1 and has
       # flaked on ASC processing; mutually exclusive with overwrite_screenshots:


### PR DESCRIPTION
The release lane hardcoded overwrite_screenshots: true, always deleting and re-uploading every App Store screenshot. Expose it as a single lane option (default true) and a matching workflow_dispatch boolean input so a release can leave ASC screenshots untouched.

When false, the lane sets skip_screenshots: true — overwrite_screenshots: false alone would still append. The value is coerced to a real boolean because CLI args and GitHub inputs arrive as the strings "true"/"false".