### PR TITLE
Add overwrite_screenshots toggle to the Mac release lane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
         description: "Delete all App Store screenshots and re-upload (iOS lane). Uncheck to leave ASC screenshots untouched."
         type: boolean
         default: true
+      overwrite_screenshots_mac:
+        description: "Delete all App Store screenshots and re-upload (Mac lane). Uncheck to leave ASC screenshots untouched."
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -51,7 +55,7 @@ jobs:
       - name: Build and upload Mac to App Store
         if: ${{ inputs.platform != 'ios' }}
         timeout-minutes: 30
-        run: bundle exec fastlane release_mac
+        run: bundle exec fastlane release_mac overwrite_screenshots:${{ inputs.overwrite_screenshots_mac }}
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -163,7 +163,15 @@ platform :ios do
   end
 
   desc "Build the Mac Catalyst app and upload to App Store Connect (macOS platform)"
-  lane :release_mac do
+  desc "Options:"
+  desc "  overwrite_screenshots — when true (default) delete ALL Mac screenshots"
+  desc "    on ASC and re-upload fastlane/screenshots_mac/; when false, leave ASC"
+  desc "    screenshots untouched (skip them entirely). e.g."
+  desc "    fastlane release_mac overwrite_screenshots:false"
+  lane :release_mac do |options|
+    # Coerce to a real boolean: CLI args and GitHub workflow_dispatch inputs
+    # both arrive as the strings "true"/"false", and "false" is truthy in Ruby.
+    overwrite_screenshots = options.fetch(:overwrite_screenshots, true).to_s.downcase != "false"
     load_asc_api_key
     setup_ci
     # Catalyst distribution signs with a Mac Catalyst provisioning profile
@@ -211,13 +219,14 @@ platform :ios do
     upload_to_app_store(
       platform: "osx",
       skip_metadata: false,
-      skip_screenshots: false,
+      # When overwrite_screenshots is false, don't touch ASC screenshots at all.
+      skip_screenshots: !overwrite_screenshots,
       # Mac screenshots live in their own tree: deliver uploads files in
       # screenshots_path to the run's platform, and APP_DESKTOP display types
       # are invalid on the iOS version (run 29181223484) — and vice versa.
       screenshots_path: "./fastlane/screenshots_mac",
       # Delete ALL Mac screenshots on ASC before uploading (mirror the local set).
-      overwrite_screenshots: true,
+      overwrite_screenshots: overwrite_screenshots,
       # Beta alternative (upload only changed) — needs
       # FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS=1, mutually exclusive:
       # sync_screenshots: true,


### PR DESCRIPTION
PR #178 added the `overwrite_screenshots` toggle to the iOS `release` lane only; `release_mac` still hardcoded `overwrite_screenshots: true`, always deleting and re-uploading every Mac screenshot on ASC.

This mirrors the same pattern for the Mac lane:
- `release_mac` now takes an `overwrite_screenshots` option (default true). When false, the lane sets `skip_screenshots: true` so ASC screenshots are left untouched — `overwrite_screenshots: false` alone would still append. Coerced to a real boolean because CLI args and GitHub inputs arrive as the strings "true"/"false".
- The release workflow gets a second checkbox, `overwrite_screenshots_mac` (default true), wired to the Mac step — one checkbox per platform, independent of the existing iOS one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)