### PR TITLE
Localize the reconnect overlay in all 15 locales; reword to "disconnected"

### DIFF
--- a/RemoteCam/PeerLinkStatus.swift
+++ b/RemoteCam/PeerLinkStatus.swift
@@ -75,13 +75,22 @@ struct PeerLinkOverlay: View {
 
                     Text(String(
                         format: NSLocalizedString(
-                            "PeerBackgroundedReconnecting",
-                            value: "%@ is in the background — reconnecting…",
-                            comment: "Shown while waiting for a backgrounded peer to return"),
+                            "PeerDisconnectedReconnecting",
+                            value: "%@ disconnected — reconnecting…",
+                            comment: "Shown while waiting for a lost peer to return"),
                         peerName))
                         .font(.headline)
                         .multilineTextAlignment(.center)
                         .foregroundColor(.white)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Text(NSLocalizedString(
+                        "PeerReconnectHint",
+                        value: "Make sure Remote Shutter is still open on that device.",
+                        comment: "Hint under the reconnecting message"))
+                        .font(.footnote)
+                        .multilineTextAlignment(.center)
+                        .foregroundColor(.white.opacity(0.7))
                         .fixedSize(horizontal: false, vertical: true)
 
                     Button(NSLocalizedString("Cancel", comment: "")) {

--- a/RemoteCam/da.lproj/Localizable.strings
+++ b/RemoteCam/da.lproj/Localizable.strings
@@ -217,3 +217,8 @@
 "ConnectingHint" = "Dette kan tage op til 20 sekunder, hvis enhederne ikke er på samme Wi-Fi-netværk.";
 "ConnectionFailedStatus" = "KUNNE IKKE FORBINDE — FLYT ENHEDERNE TÆTTERE SAMMEN OG PRØV IGEN";
 "connect_cancel" = "Annuller";
+
+/* Peer-backgrounded reconnect overlay */
+"Cancel" = "Annuller";
+"PeerDisconnectedReconnecting" = "%@ blev afbrudt — genopretter forbindelsen…";
+"PeerReconnectHint" = "Sørg for, at Remote Shutter stadig er åben på den anden enhed.";

--- a/RemoteCam/de-DE.lproj/Localizable.strings
+++ b/RemoteCam/de-DE.lproj/Localizable.strings
@@ -338,3 +338,8 @@
 "ConnectingHint" = "Dies kann bis zu 20 Sekunden dauern, wenn die Geräte nicht im selben WLAN sind.";
 "ConnectionFailedStatus" = "VERBINDUNG FEHLGESCHLAGEN — GERÄTE NÄHER ZUSAMMENBRINGEN UND ERNEUT VERSUCHEN";
 "connect_cancel" = "Abbrechen";
+
+/* Peer-backgrounded reconnect overlay */
+"Cancel" = "Abbrechen";
+"PeerDisconnectedReconnecting" = "%@ wurde getrennt — Verbindung wird wiederhergestellt…";
+"PeerReconnectHint" = "Remote Shutter muss auf dem anderen Gerät weiterhin geöffnet sein.";

--- a/RemoteCam/en.lproj/Localizable.strings
+++ b/RemoteCam/en.lproj/Localizable.strings
@@ -338,3 +338,8 @@
 "ConnectingHint" = "This can take up to 20 seconds when the devices aren't on the same Wi-Fi network.";
 "ConnectionFailedStatus" = "COULDN'T CONNECT — MOVE THE DEVICES CLOSER AND TRY AGAIN";
 "connect_cancel" = "Cancel";
+
+/* Peer-backgrounded reconnect overlay */
+"Cancel" = "Cancel";
+"PeerDisconnectedReconnecting" = "%@ disconnected — reconnecting…";
+"PeerReconnectHint" = "Make sure Remote Shutter is still open on that device.";

--- a/RemoteCam/es-MX.lproj/Localizable.strings
+++ b/RemoteCam/es-MX.lproj/Localizable.strings
@@ -233,3 +233,7 @@
 "ConnectingHint" = "Esto puede tardar hasta 20 segundos cuando los dispositivos no están en la misma red Wi-Fi.";
 "ConnectionFailedStatus" = "NO SE PUDO CONECTAR — ACERCA LOS DISPOSITIVOS E INTENTA DE NUEVO";
 "connect_cancel" = "Cancelar";
+
+/* Peer-backgrounded reconnect overlay */
+"PeerDisconnectedReconnecting" = "%@ se desconectó — reconectando…";
+"PeerReconnectHint" = "Asegúrate de que Remote Shutter siga abierto en ese dispositivo.";

--- a/RemoteCam/fr-FR.lproj/Localizable.strings
+++ b/RemoteCam/fr-FR.lproj/Localizable.strings
@@ -233,3 +233,7 @@
 "ConnectingHint" = "Cela peut prendre jusqu'à 20 secondes si les appareils ne sont pas sur le même réseau Wi-Fi.";
 "ConnectionFailedStatus" = "CONNEXION IMPOSSIBLE — RAPPROCHEZ LES APPAREILS ET RÉESSAYEZ";
 "connect_cancel" = "Annuler";
+
+/* Peer-backgrounded reconnect overlay */
+"PeerDisconnectedReconnecting" = "%@ s'est déconnecté — reconnexion…";
+"PeerReconnectHint" = "Vérifiez que Remote Shutter est toujours ouvert sur cet appareil.";

--- a/RemoteCam/hi.lproj/Localizable.strings
+++ b/RemoteCam/hi.lproj/Localizable.strings
@@ -338,3 +338,8 @@
 "ConnectingHint" = "यदि डिवाइस एक ही Wi-Fi नेटवर्क पर नहीं हैं, तो इसमें 20 सेकंड तक लग सकते हैं।";
 "ConnectionFailedStatus" = "कनेक्ट नहीं हो सका — डिवाइस को पास लाकर फिर से प्रयास करें";
 "connect_cancel" = "रद्द करें";
+
+/* Peer-backgrounded reconnect overlay */
+"Cancel" = "रद्द करें";
+"PeerDisconnectedReconnecting" = "%@ डिस्कनेक्ट हो गया — फिर से कनेक्ट किया जा रहा है…";
+"PeerReconnectHint" = "सुनिश्चित करें कि उस डिवाइस पर Remote Shutter अभी भी खुला है।";

--- a/RemoteCam/it.lproj/Localizable.strings
+++ b/RemoteCam/it.lproj/Localizable.strings
@@ -217,3 +217,8 @@
 "ConnectingHint" = "Questa operazione può richiedere fino a 20 secondi se i dispositivi non sono sulla stessa rete Wi-Fi.";
 "ConnectionFailedStatus" = "CONNESSIONE NON RIUSCITA — AVVICINA I DISPOSITIVI E RIPROVA";
 "connect_cancel" = "Annulla";
+
+/* Peer-backgrounded reconnect overlay */
+"Cancel" = "Annulla";
+"PeerDisconnectedReconnecting" = "%@ si è disconnesso — riconnessione in corso…";
+"PeerReconnectHint" = "Assicurati che Remote Shutter sia ancora aperto sull'altro dispositivo.";

--- a/RemoteCam/ja.lproj/Localizable.strings
+++ b/RemoteCam/ja.lproj/Localizable.strings
@@ -338,3 +338,8 @@
 "ConnectingHint" = "デバイスが同じWi-Fiネットワークにない場合、最大20秒かかることがあります。";
 "ConnectionFailedStatus" = "接続できませんでした — デバイスを近づけてもう一度お試しください";
 "connect_cancel" = "キャンセル";
+
+/* Peer-backgrounded reconnect overlay */
+"Cancel" = "キャンセル";
+"PeerDisconnectedReconnecting" = "%@との接続が切断されました — 再接続中…";
+"PeerReconnectHint" = "そのデバイスでRemote Shutterが起動したままになっていることを確認してください。";

--- a/RemoteCam/ko.lproj/Localizable.strings
+++ b/RemoteCam/ko.lproj/Localizable.strings
@@ -338,3 +338,8 @@
 "ConnectingHint" = "기기가 같은 Wi-Fi 네트워크에 없으면 최대 20초가 걸릴 수 있습니다.";
 "ConnectionFailedStatus" = "연결하지 못했습니다 — 기기를 더 가까이 두고 다시 시도하세요";
 "connect_cancel" = "취소";
+
+/* Peer-backgrounded reconnect overlay */
+"Cancel" = "취소";
+"PeerDisconnectedReconnecting" = "%@ 연결이 끊어졌습니다 — 다시 연결하는 중…";
+"PeerReconnectHint" = "해당 기기에서 Remote Shutter가 계속 실행 중인지 확인하세요.";

--- a/RemoteCam/ms.lproj/Localizable.strings
+++ b/RemoteCam/ms.lproj/Localizable.strings
@@ -338,3 +338,8 @@
 "ConnectingHint" = "Ini boleh mengambil masa sehingga 20 saat jika peranti tidak berada pada rangkaian Wi-Fi yang sama.";
 "ConnectionFailedStatus" = "TIDAK DAPAT MENYAMBUNG — DEKATKAN PERANTI DAN CUBA LAGI";
 "connect_cancel" = "Batal";
+
+/* Peer-backgrounded reconnect overlay */
+"Cancel" = "Batal";
+"PeerDisconnectedReconnecting" = "%@ terputus — menyambung semula…";
+"PeerReconnectHint" = "Pastikan Remote Shutter masih terbuka pada peranti itu.";

--- a/RemoteCam/pt-BR.lproj/Localizable.strings
+++ b/RemoteCam/pt-BR.lproj/Localizable.strings
@@ -338,3 +338,8 @@
 "ConnectingHint" = "Isso pode levar até 20 segundos quando os dispositivos não estão na mesma rede Wi-Fi.";
 "ConnectionFailedStatus" = "NÃO FOI POSSÍVEL CONECTAR — APROXIME OS DISPOSITIVOS E TENTE NOVAMENTE";
 "connect_cancel" = "Cancelar";
+
+/* Peer-backgrounded reconnect overlay */
+"Cancel" = "Cancelar";
+"PeerDisconnectedReconnecting" = "%@ se desconectou — reconectando…";
+"PeerReconnectHint" = "Verifique se o Remote Shutter ainda está aberto no outro dispositivo.";

--- a/RemoteCam/ru.lproj/Localizable.strings
+++ b/RemoteCam/ru.lproj/Localizable.strings
@@ -338,3 +338,8 @@
 "ConnectingHint" = "Это может занять до 20 секунд, если устройства не в одной сети Wi-Fi.";
 "ConnectionFailedStatus" = "НЕ УДАЛОСЬ ПОДКЛЮЧИТЬСЯ — ПОДНЕСИТЕ УСТРОЙСТВА БЛИЖЕ И ПОВТОРИТЕ ПОПЫТКУ";
 "connect_cancel" = "Отменить";
+
+/* Peer-backgrounded reconnect overlay */
+"Cancel" = "Отмена";
+"PeerDisconnectedReconnecting" = "Соединение с %@ потеряно — повторное подключение…";
+"PeerReconnectHint" = "Убедитесь, что приложение Remote Shutter по-прежнему открыто на другом устройстве.";

--- a/RemoteCam/tr.lproj/Localizable.strings
+++ b/RemoteCam/tr.lproj/Localizable.strings
@@ -338,3 +338,8 @@
 "ConnectingHint" = "Cihazlar aynı Wi-Fi ağında değilse bu işlem 20 saniye kadar sürebilir.";
 "ConnectionFailedStatus" = "BAĞLANILAMADI — CİHAZLARI YAKLAŞTIRIP TEKRAR DENEYİN";
 "connect_cancel" = "İptal";
+
+/* Peer-backgrounded reconnect overlay */
+"Cancel" = "İptal";
+"PeerDisconnectedReconnecting" = "%@ bağlantısı kesildi — yeniden bağlanılıyor…";
+"PeerReconnectHint" = "Remote Shutter'ın o cihazda hâlâ açık olduğundan emin olun.";

--- a/RemoteCam/vi.lproj/Localizable.strings
+++ b/RemoteCam/vi.lproj/Localizable.strings
@@ -338,3 +338,8 @@
 "ConnectingHint" = "Quá trình này có thể mất tới 20 giây nếu các thiết bị không cùng mạng Wi-Fi.";
 "ConnectionFailedStatus" = "KHÔNG THỂ KẾT NỐI — ĐƯA CÁC THIẾT BỊ LẠI GẦN NHAU VÀ THỬ LẠI";
 "connect_cancel" = "Hủy";
+
+/* Peer-backgrounded reconnect overlay */
+"Cancel" = "Hủy";
+"PeerDisconnectedReconnecting" = "%@ đã ngắt kết nối — đang kết nối lại…";
+"PeerReconnectHint" = "Hãy đảm bảo Remote Shutter vẫn đang mở trên thiết bị đó.";

--- a/RemoteCam/zh-Hans.lproj/Localizable.strings
+++ b/RemoteCam/zh-Hans.lproj/Localizable.strings
@@ -338,3 +338,8 @@
 "ConnectingHint" = "如果设备不在同一 Wi-Fi 网络中，连接可能需要最多 20 秒。";
 "ConnectionFailedStatus" = "无法连接 — 请将设备靠近后重试";
 "connect_cancel" = "取消";
+
+/* Peer-backgrounded reconnect overlay */
+"Cancel" = "取消";
+"PeerDisconnectedReconnecting" = "%@ 已断开连接 — 正在重新连接…";
+"PeerReconnectHint" = "请确保该设备上的 Remote Shutter 仍在运行。";

--- a/RemoteShutter.xcodeproj/project.pbxproj
+++ b/RemoteShutter.xcodeproj/project.pbxproj
@@ -1375,7 +1375,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = J5A8XNQSV9;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -1389,7 +1389,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 9.0.1;
+				MARKETING_VERSION = 9.0.2;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.blackfireapps.remotecamera;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1416,7 +1416,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = J5A8XNQSV9;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -1430,7 +1430,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 9.0.1;
+				MARKETING_VERSION = 9.0.2;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.blackfireapps.remotecamera;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## Summary
- The reconnect overlay introduced with the Stormo migration (#183) had no entries in any `Localizable.strings` file — every non-English locale showed the inline English fallback.
- Its copy claimed the peer "is in the background", which is only one of the overlay's two triggers (backgrounding announcement *or* a dropped link). Reworded to **"%@ disconnected — reconnecting…"**, which is honest in both cases, under a new key `PeerDisconnectedReconnecting` so no stale "background" translation can survive.
- Added a dimmed footnote hint below the headline: **"Make sure Remote Shutter is still open on that device."** (`PeerReconnectHint`), plus the overlay's bare `Cancel` key, translated in all 15 locales.

## Verification
- Native-reviewer pass over all locales; two fixes applied: Russian dialog-convention "Отмена" (not "Отменить") and Malay stative "terbuka" (not passive "dibuka").
- All 15 `.strings` files pass `plutil -lint`; each key appears exactly once per file.
- Simulator build succeeds (`BUILD SUCCEEDED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)