### PR TITLE
ASO: move 'selfie remote' (en) and 'disparador remoto' (es) into subtitles

### DIFF
--- a/fastlane/metadata/en-GB/keywords.txt
+++ b/fastlane/metadata/en-GB/keywords.txt
@@ -1,1 +1,1 @@
-remote camera,wireless shutter,selfie remote,group photo,tripod,photo timer,webcam,mac camera
+wireless,group photo,tripod,webcam,mac,photobooth,bluetooth,video,watch,control,photography

--- a/fastlane/metadata/en-GB/subtitle.txt
+++ b/fastlane/metadata/en-GB/subtitle.txt
@@ -1,1 +1,1 @@
-Turn 2 devices into 1 camera
+Selfie remote & camera timer

--- a/fastlane/metadata/en-US/keywords.txt
+++ b/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-remote camera,wireless shutter,selfie remote,group photo,tripod,photo timer,webcam,mac camera
+wireless,group photo,tripod,webcam,mac,photobooth,bluetooth,video,watch,control,photography

--- a/fastlane/metadata/en-US/subtitle.txt
+++ b/fastlane/metadata/en-US/subtitle.txt
@@ -1,1 +1,1 @@
-Turn 2 devices into 1 camera
+Selfie remote & camera timer

--- a/fastlane/metadata/es-ES/keywords.txt
+++ b/fastlane/metadata/es-ES/keywords.txt
@@ -1,1 +1,1 @@
-disparador remoto,obturador,selfie,foto grupal,trípode,fotomatón,temporizador,remota,inalámbrica
+control remoto,obturador,selfie,foto grupal,trípode,fotomatón,temporizador,remota,inalámbrica

--- a/fastlane/metadata/es-ES/subtitle.txt
+++ b/fastlane/metadata/es-ES/subtitle.txt
@@ -1,1 +1,1 @@
-Control remoto para tu cámara
+Disparador remoto de cámara

--- a/fastlane/metadata/es-MX/keywords.txt
+++ b/fastlane/metadata/es-MX/keywords.txt
@@ -1,1 +1,1 @@
-disparador remoto,obturador,selfie,foto grupal,trípode,fotomatón,temporizador,remota,inalámbrica
+control remoto,obturador,selfie,foto grupal,trípode,fotomatón,temporizador,remota,inalámbrica

--- a/fastlane/metadata/es-MX/subtitle.txt
+++ b/fastlane/metadata/es-MX/subtitle.txt
@@ -1,1 +1,1 @@
-Control remoto para tu cámara
+Disparador remoto de cámara


### PR DESCRIPTION
## What

Metadata-only change, 4 locales (en-US, en-GB, es-ES, es-MX). Titles untouched.

| Locale | Subtitle before | Subtitle after |
|---|---|---|
| en-US / en-GB | Turn 2 devices into 1 camera | **Selfie remote & camera timer** |
| es-ES / es-MX | Control remoto para tu cámara | **Disparador remoto de cámara** |

Keyword fields reworked to drop words now covered by title+subtitle (Apple ignores cross-field duplicates) and spend the freed bytes on new terms: `photobooth, bluetooth, video, watch, control, photography` (en); `control remoto` moves from subtitle into keywords (es) so no term is lost.

## Why

- **en:** We fell out of the US top 50 for "selfie remote" (was #25 on Jul 11) despite the phrase sitting in the keyword field. The apps that rank on that SERP carry the word in visible metadata — including a one-rating 1.0★ app at #2 purely on title match. The current subtitle contains zero searchable terms.
- **es:** PR #140 (keyword-field fix, Jul 11) took "disparador remoto" from unranked to **#1 in AR/CO/PE** within 3 weeks — but only #15 ES / #21 MX. Subtitle weight targets the two biggest Spanish markets, where the traffic actually is (MX: ~61 search impressions/day vs AR: ~40/week).

## Verification

After this ships in the next release, `rank_tracker.py` in the growth repo gives the readout:
- ✅ "selfie remote" re-enters US top 50
- ✅ "disparador remoto" climbs from #15 (ES) / #21 (MX)
- 🛡️ Guardrail: "remote shutter" stays #1 in the US — titles are untouched, so risk is low; revert is a one-file change if it slips.

Conversion tradeoff acknowledged: the "2 devices" hook moves out of the subtitle. Store-funnel page-view→download rate is the tripwire for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)