### PR TITLE
Answer-shaped SEO content: six guides, FAQ schema, llms.txt

### DIFF
--- a/website/__tests__/page.test.tsx
+++ b/website/__tests__/page.test.tsx
@@ -62,6 +62,27 @@ describe('Home page', () => {
     expect(screen.getByText('Shoot')).toBeInTheDocument();
   });
 
+  it('renders the about section', () => {
+    render(<Home />);
+    expect(screen.getByText('What is Remote Shutter?')).toBeInTheDocument();
+    expect(
+      screen.getByText('group photo at the beach').closest('a')
+    ).toHaveAttribute('href', '/blog/group-photos-everyone-in-the-shot');
+  });
+
+  it('renders the FAQ section', () => {
+    render(<Home />);
+    expect(
+      screen.getByText('Frequently asked questions')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Does Remote Shutter need Wi-Fi or an internet connection?')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Is Remote Shutter free? Is there a subscription?')
+    ).toBeInTheDocument();
+  });
+
   it('links to the gear and blog pages', () => {
     render(<Home />);
     expect(screen.getByText('Field kit').closest('a')).toHaveAttribute(

--- a/website/posts/apple-watch-camera-remote.md
+++ b/website/posts/apple-watch-camera-remote.md
@@ -1,0 +1,41 @@
+---
+title: "Apple Watch as a Camera Remote: What Works and What Doesn't"
+date: "2026-08-10"
+author: "Dario Lencina"
+description: "Apple's built-in Camera Remote is genuinely useful — and genuinely limited. What the Watch can do for your iPhone camera, and when you need a real second device."
+faq:
+  - q: "Does Apple Watch have a built-in camera remote?"
+    a: "Yes — the Camera Remote app ships on every Apple Watch. It shows a small live preview of your paired iPhone's camera and can fire the shutter or start a 3-second timer."
+  - q: "Can Apple Watch control a camera on someone else's iPhone?"
+    a: "Not with the built-in app — it only controls the iPhone it is paired to. To control a different device's camera, you need an app on both ends, like Remote Shutter."
+  - q: "Can the Watch start video recording remotely?"
+    a: "The built-in Camera Remote is photo-first. Remote Shutter's Watch app works alongside the iPhone remote to trigger capture on the separate camera device."
+  - q: "What's the range of the Watch as a camera remote?"
+    a: "The Watch talks to its iPhone over Bluetooth/Wi-Fi and comfortably covers a room — similar to the ~50-foot line-of-sight range of a phone-to-phone setup."
+---
+
+Short version: the Apple Watch is a *good* camera remote with two hard limits — it can only control **its own paired iPhone**, and the preview is the size of a postage stamp. Knowing when those limits matter tells you whether your wrist is enough or whether you want a second device running [Remote Shutter](https://apps.apple.com/us/app/remote-shutter/id633274861).
+
+## What the built-in Camera Remote does well
+
+Every Apple Watch ships with Apple's Camera Remote app. Open it and your paired iPhone's Camera app launches automatically; the Watch face shows a live (tiny) preview, and you can fire the shutter immediately or on a 3-second timer. You can also pick flash, HDR, and which lens from the Watch's ⋯ menu.
+
+It shines for exactly one job: **you propped your own iPhone somewhere, and you're in the shot.** Family photo on a beach, solo hiking portrait, checking your form at the gym — prop the phone, glance at your wrist to confirm you're in frame, tap. Zero extra hardware, and it's already on your wrist.
+
+## Where it runs out of road
+
+- **One paired phone only.** The Watch can't be a remote for your partner's iPhone, your old spare phone, or an iPad. Whoever owns the Watch must also supply the camera.
+- **Preview size.** Confirming "I'm roughly in frame" works; judging a composition, checking corners, or noticing a blink doesn't.
+- **Photo-first.** It's built around stills and quick timer shots, not directing a video take.
+
+## The two-device alternative
+
+Remote Shutter pairs **any two Apple devices**: one is the camera, the other is a remote with a full-screen live preview and complete camera controls — photo, video start/stop, lens switching, flash, front/back. The camera can be a spare iPhone while your main phone is the remote, or your iPhone can be the camera while an iPad or Mac gives you a big monitor ([that setup here](/blog/iphone-as-second-camera-mac-monitor)). There's a Remote Shutter Watch app too, so your wrist can trigger the separate camera device — something the built-in app can't reach.
+
+## Which should you use?
+
+Use the **built-in Watch remote** when it's your own iPhone, a quick still, and rough framing is fine. It's free and instant.
+
+Use **Remote Shutter** when any of these is true: the camera is a *different* device than your paired iPhone; you're shooting video; or you need to actually see the frame at full size before you commit. (Full three-way comparison, including Bluetooth clickers: [here](/blog/camera-remote-comparison).)
+
+Both apps are free to try, and they're not rivals so much as different tools — plenty of people prop the phone with Remote Shutter for the framing and keep the Watch as a wrist-mounted shutter button.

--- a/website/posts/camera-remote-comparison.md
+++ b/website/posts/camera-remote-comparison.md
@@ -1,0 +1,51 @@
+---
+title: "iPhone Camera Remotes Compared: App vs. Bluetooth Button vs. Apple Watch"
+date: "2026-08-10"
+author: "Dario Lencina"
+description: "An honest comparison of the three ways to trigger your iPhone camera remotely — what each costs, what each shows you, and which fits which job."
+faq:
+  - q: "What is the best camera remote for iPhone?"
+    a: "It depends on whether you need to see the frame. For selfie-stick range, a $10 Bluetooth button is fine. For quick solo shots with your own phone, the Apple Watch's built-in remote is enough. When the phone is mounted away from you and framing matters — group photos, overhead video, wildlife — a two-device app like Remote Shutter with a full live preview is the strongest option."
+  - q: "Do camera remote apps need internet?"
+    a: "Remote Shutter doesn't — the two devices connect directly over peer-to-peer Wi-Fi, with no router, cellular signal, or account. It works in airplane-mode territory: beaches, trails, basements."
+  - q: "Can any of these record video remotely?"
+    a: "Bluetooth buttons and the built-in Watch remote are photo-centric. Remote Shutter starts and stops video recording from the remote device with a live preview throughout."
+  - q: "Is Remote Shutter free?"
+    a: "The download is free with no account and no subscription; live preview and remote photo capture work out of the box, and one-time purchases unlock video recording and the full feature set."
+---
+
+There are exactly three ways to fire your iPhone's camera without touching it: a Bluetooth clicker, the Apple Watch's built-in Camera Remote, or an app that turns a second Apple device into the remote. Each is the right answer for a different job. Here's the honest breakdown.
+
+## Bluetooth shutter button (~$10)
+
+**What it is:** a coin-cell keychain button that pairs as a Bluetooth keyboard and sends a volume-press to snap the shutter.
+
+**Strengths:** cheapest option, tiny, clips to a selfie stick, no second device needed.
+
+**Weaknesses:** it shows you *nothing* — no preview, no framing, no focus check; you shoot blind and walk over to inspect. Range is nominal 10 m and degrades through walls. Pairing is flaky after iOS updates, and the battery is dead precisely when you finally need it.
+
+**Right job:** selfie sticks and arm's-length shots where you can already see the screen.
+
+## Apple Watch Camera Remote (built in, free)
+
+**What it is:** the stock Watch app that previews and triggers **your own paired iPhone's** camera.
+
+**Strengths:** already on your wrist, zero setup, small live preview, 3-second timer, can pick lens and flash.
+
+**Weaknesses:** only controls the iPhone it's paired to — never a spare phone, a family member's phone, or an iPad. The preview is wrist-sized: fine for "am I in frame," useless for real composition. Photo-first, not a video director's tool. ([Deeper dive on the Watch remote.](/blog/apple-watch-camera-remote))
+
+**Right job:** quick solo/family stills with your own propped-up iPhone.
+
+## Second-device app: Remote Shutter (free download)
+
+**What it is:** [Remote Shutter](https://apps.apple.com/us/app/remote-shutter/id633274861) runs on both devices — one becomes the camera, the other a full remote: live full-screen preview, photo capture, video start/stop, lens switching, front/back flip, flash and torch.
+
+**Strengths:** the only option where you *see the actual frame at full size* before shooting. Works between any two Apple devices — iPhone, iPad, Apple Watch, Apple-silicon Mac — so a spare phone becomes a wireless camera and an iPad becomes a director's monitor. Connects peer-to-peer with no Wi-Fi network, no account, ~50 ft line-of-sight range (or your whole Wi-Fi network's coverage). Nothing uploads anywhere.
+
+**Weaknesses:** you need a second Apple device with the app installed, and a mounted camera phone should be on power for long sessions. Advanced features (video recording, the full control set) are one-time paid unlocks — free covers preview and photo capture.
+
+**Right job:** everything where the camera is *away from you* — group photos with everyone in the shot, overhead/product video rigs, wildlife watching, form-check recordings, old-phone-as-remote-camera setups.
+
+## The one-line decision rule
+
+**Can you already see the phone's screen when you shoot?** Then a button or the Watch is enough. **Is the phone somewhere you can't see it from?** Then the preview is the feature, and a two-device app is the tool. Most people end up combining them: Remote Shutter for the framing, and the Watch as a convenient extra trigger.

--- a/website/posts/group-photos-everyone-in-the-shot.md
+++ b/website/posts/group-photos-everyone-in-the-shot.md
@@ -1,0 +1,42 @@
+---
+title: "How to Take Group Photos With Everyone in the Shot (iPhone)"
+date: "2026-08-10"
+author: "Dario Lencina"
+description: "The self-timer sprint, the stranger's crooked photo — there's a better way. Use a second Apple device as a live-preview remote for your iPhone camera."
+faq:
+  - q: "Can I see the photo before I take it?"
+    a: "Yes — that's the point. The remote device shows a live preview of exactly what the camera sees, so you check everyone's in frame and nobody's blinking before you press the shutter."
+  - q: "Do both devices need to be iPhones?"
+    a: "No. The camera should be an iPhone or iPad, but the remote can be an iPhone, iPad, Apple Watch, or Apple-silicon Mac. Borrow a family member's iPhone for the remote — the app is a free download on both ends."
+  - q: "Does it work outdoors with no Wi-Fi, like at a park or a wedding venue?"
+    a: "Yes. The devices connect directly to each other over peer-to-peer Wi-Fi, so no network or cellular signal is needed. Range is about 50 feet line of sight."
+  - q: "Can it record group videos too?"
+    a: "Yes. With the video upgrade you can start and stop video recording from the remote, with the same live preview."
+---
+
+Every big group photo ends one of three ways: someone's missing because they took the picture, everyone holds a frozen smile through the 10-second-timer sprint, or a stranger takes one blurry photo and hands the phone back. Here's the fourth way: put your iPhone on a ledge or tripod, stand with your group, and take the photo from a second device **while watching a live preview** of the shot.
+
+## The setup
+
+1. **Install [Remote Shutter](https://apps.apple.com/us/app/remote-shutter/id633274861) on two Apple devices.** Your iPhone is the camera; the remote can be a friend's iPhone, an iPad, an Apple Watch, or a Mac.
+2. **Prop or mount the camera phone.** A pocket tripod is ideal, but a ledge, a fence post, or a books-and-water-glass rig works.
+3. **Connect and pick roles.** The devices find each other directly — no Wi-Fi network needed, so this works at the beach, at a trailhead, or in a wedding garden with zero bars.
+4. **Join your group and frame from the remote.** The live preview shows exactly what the camera sees. Wave people left, fix the framing, then shoot. Take ten — they're free.
+
+## Why this beats the alternatives
+
+**Versus the self-timer:** no sprint, no guessing. You see the frame at the moment you shoot, so heads aren't cropped and eyes are open. And you can take many shots without jogging back to the phone after each one.
+
+**Versus handing your phone to a stranger:** you keep your phone, you do the framing, and you get as many takes as you want.
+
+**Versus a Bluetooth clicker:** a $10 Bluetooth button fires the shutter but shows you nothing — you still can't tell if everyone's in frame. The live preview is the difference between hoping and knowing. (More on that in [our Bluetooth remote comparison](/blog/iphone-camera-remote-without-bluetooth).)
+
+**Versus Apple Watch's built-in Camera Remote:** genuinely good for quick shots, and worth using if you have a Watch — the preview is just small, and the camera has to be your own paired iPhone. With Remote Shutter any two Apple devices pair up, so the person with the best camera phone doesn't have to be the photographer.
+
+## Three tricks for better group shots
+
+- **Shoot a burst of moments, not one pose.** Because you're not rationing timer runs, capture the laugh after the posed shot — it's usually the keeper.
+- **Go wide and high.** Set the camera phone slightly above eye level and use the wide lens for rows of people; you can switch lenses from the remote.
+- **Check the corners.** On the preview, glance at the frame edges for photobombers and cut-off elbows before you press the button.
+
+Remote Shutter is a free download with no account and no subscription — install it on both devices and you're shooting in about two minutes.

--- a/website/posts/iphone-as-second-camera-mac-monitor.md
+++ b/website/posts/iphone-as-second-camera-mac-monitor.md
@@ -1,0 +1,42 @@
+---
+title: "Use Your iPhone as a Second Camera With a Live Monitor on iPad or Mac"
+date: "2026-08-10"
+author: "Dario Lencina"
+description: "Product shots, overhead cooking videos, workbench tutorials: put the iPhone where the shot is and watch the frame on a big iPad or Mac screen."
+faq:
+  - q: "Can I use my Mac as a monitor for my iPhone camera?"
+    a: "Yes. Run Remote Shutter on an Apple-silicon Mac as the remote and on the iPhone as the camera — the Mac shows the live preview and controls the shutter and video recording."
+  - q: "Is this like Continuity Camera?"
+    a: "Different direction. Continuity Camera makes your iPhone a webcam for Mac video calls. Remote Shutter makes the Mac (or iPad) a monitor and remote for the iPhone's own camera app — the photos and videos are captured on the iPhone at full quality."
+  - q: "Does it need Wi-Fi?"
+    a: "No network is required — the devices connect directly, peer to peer. If both are on the same Wi-Fi network, that works too."
+  - q: "Can I record video with the phone mounted overhead?"
+    a: "Yes. Start and stop video recording from the monitor device, with the live preview showing the exact overhead frame the whole time."
+---
+
+The iPhone in your pocket is the best camera you own — but its screen is glued to its back. The moment you mount the phone overhead for a cooking video, clamp it over a workbench, or point it at a product table, you can't see what it sees. The fix: make an iPad or Mac the monitor. Install [Remote Shutter](https://apps.apple.com/us/app/remote-shutter/id633274861) on both, and the iPhone becomes a positionable camera while the big screen in front of you shows the live frame and holds the shutter button.
+
+## Setups this unlocks
+
+**Overhead / top-down video.** Clamp the iPhone above the cutting board, desk, or sketchpad, facing straight down. On the iPad beside you, watch the live preview and start/stop recording without touching (and shaking) the rig. This is the classic cooking-channel and unboxing setup, minus the dedicated camera gear.
+
+**Product photography.** Phone on a small tripod pointed at the product; you sit at the Mac, framing on a screen large enough to actually judge composition, reflections, and focus. Adjust the product with one hand, shoot with the other, and never bump the camera.
+
+**Workbench and repair tutorials.** The phone hangs over the soldering iron or engine bay; the monitor sits safely to the side. Your hands stay in frame; your face stays out of the fumes.
+
+**Talks and demos.** Point the iPhone at the stage or whiteboard from a fixed spot and control it from your seat.
+
+## How to set it up
+
+1. **Install Remote Shutter on the iPhone and on the monitor device** — iPad or Apple-silicon Mac (running the iPhone/iPad app).
+2. **Mount the iPhone** where the shot needs to be. Rigid mounting matters more than expensive mounting; a $15 clamp arm beats a $100 wobbling tripod. Our picks are in the [field kit](/gear).
+3. **Open the app on both devices and pick roles** — iPhone as camera, iPad/Mac as remote. They connect directly; no Wi-Fi network or account needed.
+4. **Frame on the big screen, then shoot.** Photos and video capture on the iPhone at full camera quality; the monitor controls lenses, flash, front/back, shutter, and recording.
+
+## Tips
+
+- **Lock your framing first.** Tape marks on the workbench for where props go beat re-rigging the camera between takes.
+- **Power the phone for long shoots.** Live preview plus recording is battery-hungry; run a cable to the mounted phone.
+- **Use the lens switch remotely.** Overhead rigs usually want the wide lens; product tables usually want the standard one — you can flip between them from the monitor without touching the rig.
+
+No subscription, no account, nothing uploaded anywhere — the video never leaves your two devices until you export it.

--- a/website/posts/iphone-camera-remote-without-bluetooth.md
+++ b/website/posts/iphone-camera-remote-without-bluetooth.md
@@ -1,0 +1,43 @@
+---
+title: "iPhone Camera Remote Without a Bluetooth Button"
+date: "2026-08-10"
+author: "Dario Lencina"
+description: "Bluetooth clicker not pairing, out of battery, or just not showing you the shot? Use a second Apple device as a full camera remote with live preview instead."
+faq:
+  - q: "Can I use my iPhone as a camera remote for another iPhone?"
+    a: "Yes. Install Remote Shutter on both iPhones; one becomes the camera, the other becomes the remote with a live preview, shutter, video, flash, and lens controls."
+  - q: "Why isn't my Bluetooth camera remote working with my iPhone?"
+    a: "Most cheap shutter buttons act as a Bluetooth keyboard sending a volume-up press, and they routinely fail after iOS updates, refuse to re-pair, or arrive with a dead coin cell. An app-based remote over peer-to-peer Wi-Fi avoids the pairing dance entirely."
+  - q: "Does an app-based remote work with no internet?"
+    a: "Yes. Remote Shutter connects the two devices directly over peer-to-peer Wi-Fi — no router, no cellular, no account. It works at the beach or on a mountain."
+  - q: "Is the range better than Bluetooth?"
+    a: "Comparable or better in practice: about 50 feet (15 m) line of sight device-to-device, and unlimited within your Wi-Fi network's coverage when both devices are on it — Bluetooth clickers are typically rated 10 m and drop off fast through walls."
+---
+
+Those $10 Bluetooth shutter buttons have three well-known problems: they pair like it's 2012 (and un-pair after iOS updates), the coin-cell battery is dead exactly when you need it, and — the big one — **they can't show you the shot**. You press the button blind and walk over to check.
+
+If you have any second Apple device, you can skip the clicker entirely: [Remote Shutter](https://apps.apple.com/us/app/remote-shutter/id633274861) turns an iPhone, iPad, Apple Watch, or Apple-silicon Mac into a full camera remote for your iPhone — with a live preview of the frame.
+
+## What "full remote" means
+
+A Bluetooth button gives you one thing: a shutter press. A second-device remote gives you the whole camera:
+
+- **Live preview** — see exactly what the camera sees before you shoot
+- **Photo and video** — start and stop recording remotely, not just snap
+- **Camera controls** — switch lenses, flip front/back, toggle flash and torch, all from the remote
+- **No pairing ritual** — the devices discover each other directly; there's nothing to put in pairing mode
+
+## Setting it up
+
+1. Install Remote Shutter on both devices (free download, no account).
+2. Open the app on both. They connect directly over peer-to-peer Wi-Fi — no network required.
+3. Pick which device is the camera and which is the remote.
+4. Frame on the preview, then shoot photos or roll video from wherever you're standing.
+
+## When a Bluetooth button is still the right tool
+
+Honesty department: a clicker is smaller than a second phone, costs $10, and clips to a selfie stick. If all you need is "fire the shutter while holding the phone at arm's length," a button is fine. The app approach wins when the phone is *away from you* — on a tripod, across the room, up on a shelf — because then you need to see the frame, not just trigger it. Full comparison: [Remote Shutter vs. Bluetooth remotes vs. Apple Watch](/blog/camera-remote-comparison).
+
+## No second device handy?
+
+Two built-in fallbacks worth knowing: the iPhone self-timer (Camera → arrow → timer — no preview at shot time, but reliable), and if you have an Apple Watch, Apple's built-in Camera Remote app gives you a small preview of your own paired iPhone. Both are fine for quick shots; the two-device setup is what you graduate to when you care about framing.

--- a/website/posts/use-old-iphone-as-remote-camera.md
+++ b/website/posts/use-old-iphone-as-remote-camera.md
@@ -1,0 +1,52 @@
+---
+title: "How to Use an Old iPhone as a Remote Camera"
+date: "2026-08-10"
+author: "Dario Lencina"
+description: "Turn a spare iPhone into a wireless remote camera for wildlife, home check-ins, and hard-to-reach angles — no network, no account, no monthly fee."
+faq:
+  - q: "Does the old iPhone need a SIM card or internet connection?"
+    a: "No. Remote Shutter connects the two devices directly over peer-to-peer Wi-Fi, so the camera phone needs no SIM, no cellular plan, and no Wi-Fi network. It works in places with no coverage at all."
+  - q: "How far away can the remote be from the camera?"
+    a: "Roughly 50 feet (15 m) with a clear line of sight when the devices connect directly. On the same Wi-Fi network, range is whatever your network covers."
+  - q: "How long does the battery last while streaming the live preview?"
+    a: "A few hours of continuous preview on most iPhones. For long sessions, plug the camera phone into a power bank or wall charger — it charges while it shoots."
+  - q: "What's the oldest iPhone that works?"
+    a: "Any iPhone that runs a recent version of iOS can be the camera. Older phones with tired batteries work fine when plugged in — the camera role doesn't need much horsepower."
+---
+
+If you have an old iPhone in a drawer, you already own a wireless remote camera. Install [Remote Shutter](https://apps.apple.com/us/app/remote-shutter/id633274861) on the old phone and on the phone you carry, and the old one becomes a camera you can see through and trigger from up to 50 feet away — no Wi-Fi network, no account, and no monthly fee.
+
+## What you need
+
+- Your everyday iPhone (or an iPad, Apple Watch, or Apple-silicon Mac) as the **remote**
+- A spare iPhone as the **camera**
+- Remote Shutter installed on both — the devices find each other and connect directly, peer to peer
+
+That last part matters: because the connection is device-to-device, this works in a forest, a garage, or a basement with zero bars and zero Wi-Fi.
+
+## Set it up in two minutes
+
+1. **Install Remote Shutter on both devices.** Same app on each — you pick the role when they connect.
+2. **Open the app on both phones.** They discover each other automatically over peer-to-peer Wi-Fi or your local network.
+3. **Make the old phone the camera.** Choose the camera role on the spare phone and the remote role on yours.
+4. **Position the camera phone and walk away.** From the remote you get a live preview of exactly what the camera sees, and you can switch lenses, flip between front and back cameras, toggle the flash, and capture photos or video.
+
+Photos and videos save on the camera phone, so you can AirDrop them to your main phone when you're done.
+
+## Things people actually do with this
+
+**Backyard wildlife.** Set the camera phone near a feeder or trail, then watch the live preview from inside the house and fire the shutter when something shows up. Unlike a motion-triggered trail cam, you frame the shot and choose the moment.
+
+**Check on a room.** Point the spare phone at the front door, a workbench print job, or a sleeping pet, and glance at the live view from the couch. Everything stays on your devices — nothing is uploaded anywhere.
+
+**Impossible angles.** Clamp the old phone above a basketball hoop, inside a bookshelf, or at ground level in the garden. Angles you'd never hold a phone at become easy when the phone doesn't need you behind it.
+
+**Self-recording.** Film your golf swing, deadlift form, or guitar take with the camera across the room and the preview in your hand — no more walking back and forth to check framing.
+
+## Tips for longer sessions
+
+- **Power the camera phone.** The live preview uses more battery than the remote side; a small power bank keeps an old phone shooting all afternoon.
+- **Mount it.** Any cheap phone tripod or clamp works — see the [field kit we shoot with](/gear) for what we use.
+- **Old batteries are fine.** A phone with 70% battery health that dies in an hour on its own runs indefinitely on a charger.
+
+Remote Shutter is free to download, and the basics — live preview, remote photo capture — work without paying anything. One-time upgrades unlock video recording and the full feature set. There's no subscription.

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,0 +1,25 @@
+# Remote Shutter
+
+> Remote Shutter is an iOS app that turns any two Apple devices into a wireless camera system: one device (iPhone or iPad) is the camera, the other (iPhone, iPad, Apple Watch, or Apple-silicon Mac) is the remote control with a full live preview. The devices connect directly over peer-to-peer Wi-Fi — no internet, no Wi-Fi network, no account, no subscription. Range is about 50 feet (15 m) line of sight, or the whole network when both devices share Wi-Fi. Free download with one-time paid upgrades (no subscription). Photos and videos stay on the devices; nothing is uploaded to any server.
+
+Key facts:
+- App Store: https://apps.apple.com/us/app/remote-shutter/id633274861 (iOS, Photography)
+- Remote controls: shutter, video start/stop, lens switching, front/back camera, flash, torch
+- Common uses: group photos with everyone in the shot, using a spare/old iPhone as a wireless camera (wildlife, home check-ins), overhead or product video rigs monitored from an iPad or Mac, Apple Watch as a trigger
+- Developer: Dario Lencina (Black Fire Apps), https://github.com/security-union/remote-shutter
+
+## Guides
+
+- [How to use an old iPhone as a remote camera](https://remoteshutter.app/blog/use-old-iphone-as-remote-camera): spare phone as wireless camera for wildlife, check-ins, hard angles
+- [Group photos with everyone in the shot](https://remoteshutter.app/blog/group-photos-everyone-in-the-shot): live-preview remote vs self-timer, strangers, and clickers
+- [iPhone camera remote without a Bluetooth button](https://remoteshutter.app/blog/iphone-camera-remote-without-bluetooth): app-based remote vs Bluetooth shutter buttons
+- [iPhone as a second camera with an iPad/Mac monitor](https://remoteshutter.app/blog/iphone-as-second-camera-mac-monitor): overhead video, product shots, workbench tutorials
+- [Apple Watch as a camera remote](https://remoteshutter.app/blog/apple-watch-camera-remote): what the built-in Watch remote can and cannot do
+- [Camera remotes compared: app vs Bluetooth button vs Apple Watch](https://remoteshutter.app/blog/camera-remote-comparison): honest three-way comparison
+
+## Site
+
+- [Home](https://remoteshutter.app/): features, how it works, FAQ
+- [Recommended gear](https://remoteshutter.app/gear): tripods, mounts, and lenses for remote shooting
+- [Blog](https://remoteshutter.app/blog): all posts
+- [Privacy policy](https://remoteshutter.app/privacy): no accounts, no tracking of photo content

--- a/website/src/app/blog/[slug]/page.tsx
+++ b/website/src/app/blog/[slug]/page.tsx
@@ -71,6 +71,22 @@ export default async function BlogPost({ params }: Props) {
     image: `${SITE_URL}/og-image.jpg`,
   };
 
+  const faqSchema =
+    post.faq.length > 0
+      ? {
+          '@context': 'https://schema.org',
+          '@type': 'FAQPage',
+          mainEntity: post.faq.map((f) => ({
+            '@type': 'Question',
+            name: f.q,
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: f.a,
+            },
+          })),
+        }
+      : null;
+
   const breadcrumbSchema = {
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
@@ -99,6 +115,7 @@ export default async function BlogPost({ params }: Props) {
     <>
       <JsonLd data={articleSchema} />
       <JsonLd data={breadcrumbSchema} />
+      {faqSchema && <JsonLd data={faqSchema} />}
       <Header />
       <main className={styles.main}>
         <nav className={styles.breadcrumb} aria-label="Breadcrumb">
@@ -122,6 +139,17 @@ export default async function BlogPost({ params }: Props) {
             className={styles.content}
             dangerouslySetInnerHTML={{ __html: post.contentHtml }}
           />
+          {post.faq.length > 0 && (
+            <section className={styles.content} aria-label="Frequently asked questions">
+              <h2>Frequently asked questions</h2>
+              {post.faq.map((f) => (
+                <div key={f.q}>
+                  <h3>{f.q}</h3>
+                  <p>{f.a}</p>
+                </div>
+              ))}
+            </section>
+          )}
         </article>
       </main>
       <Footer />

--- a/website/src/app/page.module.css
+++ b/website/src/app/page.module.css
@@ -111,6 +111,48 @@
   flex: none;
 }
 
+.about {
+  padding: 2.5rem 0 0;
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.about p {
+  color: var(--muted);
+  line-height: 1.65;
+  margin-bottom: 1rem;
+}
+
+.about a {
+  color: var(--accent);
+}
+
+.faq {
+  padding: 2.5rem 0 0;
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.faqItem {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--card-bg);
+  padding: 1rem 1.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.faqItem h3 {
+  font-size: 1rem;
+  color: var(--accent);
+  margin-bottom: 0.35rem;
+}
+
+.faqItem p {
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
 .more {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -31,11 +31,81 @@ const appSchema = {
   },
 };
 
+const FAQ = [
+  {
+    q: 'Does Remote Shutter need Wi-Fi or an internet connection?',
+    a: 'No. The two devices connect directly to each other over peer-to-peer Wi-Fi — no router, no cellular signal, no account. It works at a beach, on a trail, or in a basement with zero bars. If both devices are on the same Wi-Fi network, that works too.',
+  },
+  {
+    q: 'Which devices can I use?',
+    a: 'Any two Apple devices: iPhone, iPad, Apple Watch, or an Apple-silicon Mac. One acts as the camera (iPhone or iPad), the other as the remote with a live preview — a spare iPhone becomes a wireless camera, or an iPad or Mac becomes a big director’s monitor.',
+  },
+  {
+    q: 'How far away does the remote work?',
+    a: 'About 50 feet (15 m) with line of sight when the devices connect directly. On a shared Wi-Fi network, range is whatever the network covers.',
+  },
+  {
+    q: 'Can I record video remotely, not just photos?',
+    a: 'Yes. You can start and stop video recording from the remote device, watching the live preview the whole time.',
+  },
+  {
+    q: 'Is Remote Shutter free? Is there a subscription?',
+    a: 'The app is a free download with no account and no subscription. Live preview and remote photo capture work for free; one-time purchases unlock video recording and the full feature set.',
+  },
+  {
+    q: 'Where do my photos and videos go?',
+    a: 'They save to the camera device’s photo library and never leave your devices. Nothing is uploaded to any server.',
+  },
+];
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: FAQ.map((f) => ({
+    '@type': 'Question',
+    name: f.q,
+    acceptedAnswer: { '@type': 'Answer', text: f.a },
+  })),
+};
+
+const howToSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'How to use one iPhone as a remote camera for another',
+  description:
+    'Turn two Apple devices into a wireless camera system with a live-preview remote.',
+  tool: [{ '@type': 'HowToTool', name: 'Two Apple devices with Remote Shutter installed' }],
+  step: [
+    {
+      '@type': 'HowToStep',
+      name: 'Install on both devices',
+      text: 'Install Remote Shutter on both Apple devices — the camera and the remote.',
+    },
+    {
+      '@type': 'HowToStep',
+      name: 'Connect',
+      text: 'Open the app on both devices; they discover each other and connect directly, peer to peer.',
+    },
+    {
+      '@type': 'HowToStep',
+      name: 'Pick camera & remote',
+      text: 'Choose which device is the camera and which is the remote with live preview.',
+    },
+    {
+      '@type': 'HowToStep',
+      name: 'Shoot',
+      text: 'Frame the shot on the live preview, then capture photos or record video from the remote.',
+    },
+  ],
+};
+
 export default function Home() {
   return (
     <>
       <JsonLd data={websiteSchema} />
       <JsonLd data={appSchema} />
+      <JsonLd data={faqSchema} />
+      <JsonLd data={howToSchema} />
       <Header />
       <main className={styles.main}>
         <section className={styles.hero}>
@@ -115,6 +185,46 @@ export default function Home() {
               Shoot
             </li>
           </ol>
+        </section>
+
+        <section className={styles.about} id="about">
+          <h2 className={styles.sectionTitle}>What is Remote Shutter?</h2>
+          <p>
+            Remote Shutter turns any two Apple devices into a wireless camera
+            system. One device — an iPhone or iPad — is the camera. The other —
+            an iPhone, iPad, Apple Watch, or Apple-silicon Mac — is the remote,
+            with a full live preview of what the camera sees plus controls for
+            the shutter, video recording, lenses, flash, and front or back
+            camera.
+          </p>
+          <p>
+            The devices connect directly to each other, peer to peer: no Wi-Fi
+            network, no cellular signal, no account, and nothing uploaded to any
+            server. That makes it work anywhere — a{' '}
+            <Link href="/blog/group-photos-everyone-in-the-shot">
+              group photo at the beach
+            </Link>
+            , a{' '}
+            <Link href="/blog/use-old-iphone-as-remote-camera">
+              spare iPhone watching the backyard
+            </Link>
+            , or an{' '}
+            <Link href="/blog/iphone-as-second-camera-mac-monitor">
+              overhead video rig monitored from an iPad or Mac
+            </Link>
+            . Range is about 50 feet line of sight, or your whole network when
+            both devices share Wi-Fi.
+          </p>
+        </section>
+
+        <section className={styles.faq} id="faq">
+          <h2 className={styles.sectionTitle}>Frequently asked questions</h2>
+          {FAQ.map((f) => (
+            <div key={f.q} className={styles.faqItem}>
+              <h3>{f.q}</h3>
+              <p>{f.a}</p>
+            </div>
+          ))}
         </section>
 
         <section className={styles.more}>

--- a/website/src/lib/blog.ts
+++ b/website/src/lib/blog.ts
@@ -14,8 +14,14 @@ export interface PostMeta {
   description: string;
 }
 
+export interface PostFaqEntry {
+  q: string;
+  a: string;
+}
+
 export interface Post extends PostMeta {
   contentHtml: string;
+  faq: PostFaqEntry[];
 }
 
 export function getAllPostSlugs(): string[] {
@@ -53,6 +59,14 @@ export async function getPost(slug: string): Promise<Post> {
 
   const processed = await remark().use(html).process(content);
 
+  const faq: PostFaqEntry[] = Array.isArray(data.faq)
+    ? data.faq
+        .filter((f: unknown): f is { q: unknown; a: unknown } =>
+          typeof f === 'object' && f !== null && 'q' in f && 'a' in f
+        )
+        .map((f) => ({ q: String(f.q), a: String(f.a) }))
+    : [];
+
   return {
     slug,
     title: data.title ?? slug,
@@ -60,5 +74,6 @@ export async function getPost(slug: string): Promise<Post> {
     author: data.author ?? 'Dario Lencina',
     description: data.description ?? '',
     contentHtml: processed.toString(),
+    faq,
   };
 }


### PR DESCRIPTION
## Why

App Store analytics now attribute real installs to AI assistants: **ChatGPT (com.openai.chat) is our top named first-time-download referrer**, with Gemini and Bing showing up too. But assistants retrieve *passages*, and remoteshutter.app had almost nothing to retrieve — a 123-word homepage and a single welcome post. When ChatGPT recommends us today it links the App Store page; content on our own domain closes the citation loop.

## What

**Six new guides in `website/posts/`** — one per question people actually ask assistants, each opening with a direct answer, steps, and a FAQ:

- `use-old-iphone-as-remote-camera` — spare phone as wireless camera (wildlife, check-ins, hard angles)
- `group-photos-everyone-in-the-shot` — vs self-timer / strangers / clickers
- `iphone-camera-remote-without-bluetooth` — vs Bluetooth shutter buttons
- `iphone-as-second-camera-mac-monitor` — overhead/product rigs with iPad or Mac as monitor
- `apple-watch-camera-remote` — honest take on the built-in Watch remote
- `camera-remote-comparison` — three-way comparison, includes the "when a $10 clicker is the right tool" case

**FAQ pipeline:** posts can declare `faq:` entries in frontmatter; `blog.ts` parses them and the post page renders a visible FAQ section plus `FAQPage` JSON-LD.

**Homepage:** new "What is Remote Shutter?" prose section (quotable facts: P2P, no account, 50 ft, nothing uploaded), six-question FAQ with `FAQPage` schema, `HowTo` schema on the existing steps. Existing design/copy untouched.

**`public/llms.txt`:** markdown site map for AI crawlers (emerging standard; GPTBot and ClaudeBot already crawl us cleanly).

Deliberately **not** included: `aggregateRating` schema — worldwide average is 3.32★ right now; add it after the review-prompt play lifts it.

## Verification

- `npx jest`: 12/12 pass (2 new tests for the homepage sections)
- `npm run build`: clean static export, all 7 posts prerendered, FAQPage/HowTo schema and llms.txt confirmed in `out/`
- `npx eslint .`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)