### PR TITLE
Multicam: real countdown cancel + reactive rig-settings intersection

### DIFF
--- a/Docs/multicam.md
+++ b/Docs/multicam.md
@@ -80,11 +80,15 @@ MulticamLaneInfo (Sendable value)
 CameraLane (@Published)  →  SwiftUI tile
 ```
 
-Mutations never publish by hand. The controller mutates a `CameraLink` and marks
-the lanes dirty; a single coalescing step turns the current links into
-`[MulticamLaneInfo]` and hands them to the main actor once per pump message. A
-state change can never be "forgotten" on the way to the screen, because
-publishing is a consequence of mutation, not a separate call.
+Mutations never publish by hand. After every pump message the controller
+re-derives each UI snapshot (lanes, shutter state, rig settings, available
+peers) from its state and publishes only the ones whose value changed — one
+coalesced hop to main per message. A state change can never be "forgotten" on
+the way to the screen, because publishing is a diff of derived state, not a
+per-handler call. The rig-settings snapshot in particular is recomputed from
+the live lane set every time, so the tray is always the intersection of the
+cameras actually in the rig — a camera joining, dropping, or being refused
+recomputes it on the same pump turn.
 
 ## Live preview — five hops, four domains
 

--- a/Docs/multicam.md
+++ b/Docs/multicam.md
@@ -150,6 +150,57 @@ start and stop anchor and the lengths match. Photos come back inline in
 `TakePicResp`; video clips transfer as resources afterward (see
 [Known debts](#known-debts)).
 
+### Broadcast is locked-target; recording is all-or-nothing
+
+Two rules keep a rig shot deterministic:
+
+- **The target set is locked when the shot is armed.** The shutter tap
+  computes the ready lanes once; the countdown ticks and the scheduled
+  command go to exactly that set — the cameras that count down are the
+  cameras that shoot. Nothing arms on an empty set; a target dropping
+  mid-countdown shrinks the set, and an emptied set cancels the countdown.
+- **A recording take exists only if every target commits.** The director
+  holds `.startingRecording` (shutter shows in-flight, not REC) while start
+  acks collect; REC — and the classic recording timer, counting from the
+  shared fire instant — appear only when the last target has acked. One
+  refusal, silence past the 3 s deadline, or a target dropping voids the
+  whole take.
+
+```mermaid
+sequenceDiagram
+    participant UI as Director shutter
+    participant MC as MulticamController
+    participant A as Camera A
+    participant B as Camera B
+
+    UI->>MC: record tap
+    Note over MC: lock targets = ready lanes
+    MC->>A: ScheduledStartRecording fireAt+offsetA, id
+    MC->>B: ScheduledStartRecording fireAt+offsetB, id
+    Note over MC: .startingRecording, shutter in-flight<br/>3 s ack timeout
+
+    alt every target acks success
+        A-->>MC: Ack ok
+        B-->>MC: Ack ok
+        Note over MC: .recording, recordingStartTime = fireAt
+        MC-->>UI: REC + RecordingTimer
+        Note over A,B: both fire at the shared instant
+    else B nacks, or silent, or disconnects
+        A-->>MC: Ack ok
+        B-->>MC: nack, or nothing
+        MC->>A: ScheduledStopRecording id
+        MC->>B: ScheduledStopRecording id
+        Note over MC: stop to EVERY target, covers an<br/>ok-ack still in flight
+        Note over MC: B badged failed, .monitoring<br/>shutter back to idle
+        Note over A: short clip finalizes, auto-collects
+    end
+```
+
+Photos keep per-lane settling (`.capturingPhoto` until every ack or the
+timeout; a fired photo can't be untaken, so the badges name the failures
+instead of voiding the shot). Stop with zero rolling lanes resets to
+`.monitoring` rather than wedging. Stale acks are dropped by capture id.
+
 ## Resilient camera — a drop mid-recording
 
 The one behavior a camera changes in a director session: if the director drops

--- a/Docs/multicam.md
+++ b/Docs/multicam.md
@@ -190,7 +190,10 @@ These are the invariants worth preserving through future changes.
 - **Framing belongs to a camera; the shot belongs to the rig.** Per-camera
   controls (zoom, focus, flash, torch, lens, camera flip) address the *focused*
   camera only. Rig controls (shutter, record, timer, quality/HDR) fan out to
-  all. Nothing per-camera ever broadcasts.
+  all. Nothing per-camera ever broadcasts. The viewfinder gestures (tap to
+  focus, double-tap flip, pinch zoom) live in the shared
+  `ViewfinderGestureLayer` — the same component the 1:1 monitor uses — with the
+  director supplying focused-camera routing through its callbacks.
 - **Rendering isolation per lane.** One decoder and one published image per
   camera; a frame from one camera can only touch its own tile.
 - **Additive, gated wire.** Every multicam action (`ClockSyncPing`,

--- a/Docs/multicam.md
+++ b/Docs/multicam.md
@@ -200,6 +200,10 @@ Photos keep per-lane settling (`.capturingPhoto` until every ack or the
 timeout; a fired photo can't be untaken, so the badges name the failures
 instead of voiding the shot). Stop with zero rolling lanes resets to
 `.monitoring` rather than wedging. Stale acks are dropped by capture id.
+A camera the director knows is gone is never waited on: a dead rolling
+lane settles at stop time (the stop is still sent, so its clip ends on
+reconnect), and a lane dying inside any ack window settles on the spot
+instead of running out the timeout.
 
 ## Resilient camera — a drop mid-recording
 

--- a/RemoteCam/CameraLink.swift
+++ b/RemoteCam/CameraLink.swift
@@ -119,6 +119,7 @@ final class CameraLink {
             canFlipCamera: capabilities.map {
                 $0.frontCamera != nil && $0.backCamera != nil
             } ?? false,
+            supportsFocusPoint: capabilities?.supportsFocusPoint ?? false,
             zoomFactor: zoomFactor,
             maxZoomFactor: maxZoomFactor,
             zoomStops: zoomStops,

--- a/RemoteCam/MonitorView.swift
+++ b/RemoteCam/MonitorView.swift
@@ -121,8 +121,8 @@ struct MonitorView: View {
             // so a tap on a control is never stolen as a focus tap.
             ViewfinderGestureLayer(
                 cameraImage: { viewModel.frames.cameraImage },
-                zoomScale: viewModel.zoomScale,
-                currentZoomFactor: viewModel.currentZoomFactor,
+                zoomScale: { viewModel.zoomScale },
+                currentZoomFactor: { viewModel.currentZoomFactor },
                 focusEnabled: true,
                 onFocusTap: onFocusTap,
                 onDoubleTap: onToggleCamera,

--- a/RemoteCam/MonitorView.swift
+++ b/RemoteCam/MonitorView.swift
@@ -12,7 +12,6 @@ import Combine
 /// whichever edge the screen's *shape* makes cheap — see `MonitorChromeLayout`.
 struct MonitorView: View {
     @ObservedObject var viewModel: MonitorViewModel
-    @State private var zoomAtGestureStart: CGFloat?
     /// Peer-link state; the reconnect overlay is a function of it.
     @ObservedObject var peerLink: PeerLinkStatus = .shared
 
@@ -38,11 +37,6 @@ struct MonitorView: View {
     /// Toggles the connected camera's local-preview mode (on ⇄ standby).
     let onToggleCameraStandby: () -> Void
 
-    /// The live focus reticle (view-space position + identity to re-trigger the
-    /// animation on each tap). Local UI only — no round-trip to the camera.
-    @State private var focusReticle: FocusReticle?
-    /// The preview area's measured size, for tap → normalized-image mapping.
-    @State private var previewSize: CGSize = .zero
     @State private var isTrayOpen = false
 
     var body: some View {
@@ -75,7 +69,6 @@ struct MonitorView: View {
         // already draw their own shape. Not .plain — that also drops the
         // style's hit region, leaving material fills unclickable.
         .buttonStyle(.borderless)
-        .onPreferenceChange(PreviewSizePreferenceKey.self) { previewSize = $0 }
         .statusBarHidden()
     }
 
@@ -123,61 +116,21 @@ struct MonitorView: View {
                 .opacity(viewModel.isPreviewStale ? 0.65 : 1)
                 .animation(.easeInOut(duration: 0.25), value: viewModel.isPreviewStale)
 
-            // Preview gestures sit BELOW the interactive chrome, so a tap on a
-            // control is never stolen as a focus tap. Double tap toggles the
-            // camera; a single tap focuses (simultaneous so the reticle is
-            // instant — an exclusive gesture would stall it for the double-tap
-            // window); pinch zooms. The translation guard keeps drags and
-            // pinches from focusing.
-            Color.clear
-                .contentShape(Rectangle())
-                .onTapGesture(count: 2) {
-                    onToggleCamera()
-                }
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 0)
-                        .onEnded { value in
-                            if abs(value.translation.width) < 10, abs(value.translation.height) < 10 {
-                                handleFocusTap(at: value.location)
-                            }
-                        }
-                )
-                .simultaneousGesture(
-                    MagnificationGesture()
-                        .onChanged { value in
-                            if zoomAtGestureStart == nil {
-                                zoomAtGestureStart = viewModel.currentZoomFactor
-                            }
-                            let start = zoomAtGestureStart!
-                            onZoomChange(viewModel.zoomScale.pinched(from: start, magnification: value))
-                        }
-                        .onEnded { _ in
-                            zoomAtGestureStart = nil
-                        }
-                )
-
-            focusReticleOverlay
+            // Gestures (focus tap, double-tap flip, pinch zoom) + reticle, in
+            // the preview's own coordinate space, BELOW the interactive chrome
+            // so a tap on a control is never stolen as a focus tap.
+            ViewfinderGestureLayer(
+                cameraImage: { viewModel.frames.cameraImage },
+                zoomScale: viewModel.zoomScale,
+                currentZoomFactor: viewModel.currentZoomFactor,
+                focusEnabled: true,
+                onFocusTap: onFocusTap,
+                onDoubleTap: onToggleCamera,
+                onZoomChange: onZoomChange)
 
             countdownOverlay
         }
-        .background(
-            GeometryReader { geo in
-                Color.clear.preference(key: PreviewSizePreferenceKey.self, value: geo.size)
-            }
-        )
         .ignoresSafeArea(edges: Self.previewBleedEdges)
-    }
-
-    /// The focus reticle, drawn in the preview's coordinate space. Non-interactive
-    /// so it never eats a subsequent tap.
-    @ViewBuilder
-    private var focusReticleOverlay: some View {
-        if let reticle = focusReticle {
-            FocusReticleView()
-                .id(reticle.id)
-                .position(reticle.point)
-                .allowsHitTesting(false)
-        }
     }
 
     /// The self-timer, centered and large. The capture happens across the room:
@@ -198,25 +151,6 @@ struct MonitorView: View {
                 .id(viewModel.timerValue)
                 .transition(.scale(scale: 1.15).combined(with: .opacity))
                 .allowsHitTesting(false)
-        }
-    }
-
-    /// Maps a preview tap into a normalized image point and, if it landed on the
-    /// image (not the letterbox), shows the reticle and forwards it to the camera.
-    private func handleFocusTap(at location: CGPoint) {
-        guard let image = viewModel.frames.cameraImage,
-              let normalized = FocusPointMapping.normalizedImagePoint(
-                tap: location, viewSize: previewSize, imageSize: image.size)
-        else { return }
-        showFocusReticle(at: location)
-        onFocusTap(normalized)
-    }
-
-    private func showFocusReticle(at point: CGPoint) {
-        let reticle = FocusReticle(point: point)
-        focusReticle = reticle
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-            if focusReticle?.id == reticle.id { focusReticle = nil }
         }
     }
 
@@ -883,49 +817,6 @@ struct LiveFrameView: View {
                         .foregroundColor(.white.opacity(0.5))
                 )
         }
-    }
-}
-
-// MARK: - Tap to Focus
-
-/// One tap-to-focus reticle: its view-space position plus an identity so a new
-/// tap re-instantiates `FocusReticleView` and replays its animation.
-struct FocusReticle: Equatable {
-    let id = UUID()
-    let point: CGPoint
-}
-
-/// Measures the preview area's size so a tap can be mapped to a normalized image
-/// point. A preference key avoids mutating `@State` during layout.
-private struct PreviewSizePreferenceKey: PreferenceKey {
-    static var defaultValue: CGSize = .zero
-    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
-        let next = nextValue()
-        if next != .zero { value = next }
-    }
-}
-
-/// The animated focus square: a yellow reticle that pulses in and fades. Purely
-/// local tap feedback — the focus command travels separately.
-struct FocusReticleView: View {
-    @State private var scale: CGFloat = 1.25
-    @State private var opacity: Double = 0
-
-    var body: some View {
-        RoundedRectangle(cornerRadius: 6)
-            .stroke(Color.yellow, lineWidth: 1.5)
-            .frame(width: 78, height: 78)
-            .scaleEffect(scale)
-            .opacity(opacity)
-            .onAppear {
-                withAnimation(.easeOut(duration: 0.12)) {
-                    scale = 1.0
-                    opacity = 1
-                }
-                withAnimation(.easeIn(duration: 0.2).delay(0.35)) {
-                    opacity = 0
-                }
-            }
     }
 }
 

--- a/RemoteCam/MulticamController.swift
+++ b/RemoteCam/MulticamController.swift
@@ -558,15 +558,32 @@ public actor MulticamController {
         laneLeftShot(peer)
     }
 
-    /// A lane in play for a shot went away. During the start-ack window the
-    /// take is all-or-nothing, so the whole take aborts; during a countdown
-    /// the locked set shrinks, and an emptied set cancels the countdown.
-    /// (An established `.recording` is untouched — the rest of the rig keeps
+    /// A lane in play for a shot went away. A dead camera is never waited on:
+    /// during the start-ack window the take is all-or-nothing, so the whole
+    /// take aborts; during a photo or stop ack window the lane settles
+    /// immediately instead of running out its timeout; during a countdown the
+    /// locked set shrinks, and an emptied set cancels the countdown. (An
+    /// established `.recording` is untouched — the rest of the rig keeps
     /// rolling, and the camera itself keeps recording through the drop.)
     private func laneLeftShot(_ peer: MCPeerID) {
-        if case .startingRecording = state, takeTargets.contains(peer) {
-            links[peer]?.captureOutcome = .failed
-            abortRecordingStart()
+        switch state {
+        case .startingRecording:
+            if takeTargets.contains(peer) {
+                links[peer]?.captureOutcome = .failed
+                abortRecordingStart()
+            }
+        case .capturingPhoto:
+            if capturingLanes.contains(peer) {
+                links[peer]?.captureOutcome = .failed
+                finishLane(peer)
+            }
+        case .stoppingRecording:
+            if capturingLanes.contains(peer) {
+                links[peer]?.isRecording = false
+                finishLane(peer)
+            }
+        case .recording, .monitoring:
+            break
         }
         if var armed = armedTargets, armed.remove(peer) != nil {
             armedTargets = armed
@@ -938,8 +955,20 @@ public actor MulticamController {
             fallback: { _ in RemoteCmd.StopRecordingVideo(sender: nil, sendMediaToPeer: false) },
             lanes: rolling)
 
-        state = .stoppingRecording(captureId: fan.captureID, acksRemaining: capturingLanes.count)
-        armAckTimeout(fan.captureID)
+        // A lane we can't hear will never ack — settle it now instead of
+        // holding the rig on its timeout. The stop was still sent above, so
+        // the camera ends its clip the moment it can hear us again.
+        for link in rolling where link.status != .linked {
+            link.isRecording = false
+            capturingLanes.remove(link.peerID)
+        }
+        if capturingLanes.isEmpty {
+            clearRecordingTake()
+            state = .monitoring(mode: .photo)
+        } else {
+            state = .stoppingRecording(captureId: fan.captureID, acksRemaining: capturingLanes.count)
+            armAckTimeout(fan.captureID)
+        }
     }
 
     // MARK: - Rig-wide quality ("the shot belongs to the rig")

--- a/RemoteCam/MulticamController.swift
+++ b/RemoteCam/MulticamController.swift
@@ -411,11 +411,11 @@ public actor MulticamController {
             storePong(measured.pong, t3: measured.t3, from: measured.peer)
 
         // --- UI commands (single-entry inbox) ---
-        case is MCToggleFocusedCamera: handleToggleFocusedCamera()
-        case let m as MCFocusAtPoint: handleFocusAtPoint(x: m.x, y: m.y)
-        case is MCToggleTorch: handleToggleTorch()
-        case is MCToggleFlash: handleToggleFlash()
-        case let z as MCSetZoom: handleSetZoom(z.factor)
+        case let m as MCFlipCamera: handleFlipCamera(target: m.target)
+        case let m as MCFocusAtPoint: handleFocusAtPoint(x: m.x, y: m.y, target: m.target)
+        case let m as MCToggleTorch: handleToggleTorch(target: m.target)
+        case let m as MCToggleFlash: handleToggleFlash(target: m.target)
+        case let z as MCSetZoom: handleSetZoom(z.factor, target: z.target)
         case is MCCapturePhoto: handleCapturePhoto()
         case is MCStartRecording: handleStartRecording()
         case is MCStopRecording: handleStopRecording()
@@ -643,28 +643,36 @@ public actor MulticamController {
         sendTo(frame.peerId, RemoteCmd.RequestFrame(sender: nil))
     }
 
-    // MARK: - Per-camera controls (focused peer only)
+    // MARK: - Per-camera controls (target carried by the command)
 
-    /// Framing controls address the focused camera. Each is a message on the
-    /// single inbox, like every other UI intent.
-    public nonisolated func setZoom(_ factor: CGFloat) { tell(MCSetZoom(factor)) }
-    public nonisolated func toggleTorch() { tell(MCToggleTorch()) }
-    public nonisolated func toggleFlash() { tell(MCToggleFlash()) }
+    /// Framing controls are pure functions of their arguments: the UI names
+    /// the camera it rendered the control for, and the command carries that
+    /// target all the way to the wire. No routing register to go stale —
+    /// `focusedPeer` is presentation state (tile size, stream tier), never
+    /// command routing.
+    public nonisolated func setZoom(_ factor: CGFloat, on peer: MCPeerID) {
+        tell(MCSetZoom(factor, target: peer))
+    }
+    public nonisolated func toggleTorch(on peer: MCPeerID) { tell(MCToggleTorch(target: peer)) }
+    public nonisolated func toggleFlash(on peer: MCPeerID) { tell(MCToggleFlash(target: peer)) }
 
-    private func handleSetZoom(_ factor: CGFloat) { focusedSend(RemoteCmd.SetZoom(zoomFactor: factor)) }
+    private func handleSetZoom(_ factor: CGFloat, target: MCPeerID) {
+        guard links[target] != nil else { return }
+        sendTo(target, RemoteCmd.SetZoom(zoomFactor: factor))
+    }
 
-    private func handleToggleTorch() {
-        guard let peer = focusedPeer, let link = links[peer] else { return }
+    private func handleToggleTorch(target: MCPeerID) {
+        guard let link = links[target] else { return }
         // Optimistic: reflect the tap immediately so the glyph tints like the
         // 1:1 monitor's; the camera is the source of truth for whether it took.
         link.torchOn.toggle()
-        sendTo(peer, RemoteCmd.ToggleTorch())
+        sendTo(target, RemoteCmd.ToggleTorch())
     }
 
-    private func handleToggleFlash() {
-        guard let peer = focusedPeer, let link = links[peer] else { return }
+    private func handleToggleFlash(target: MCPeerID) {
+        guard let link = links[target] else { return }
         link.flashOn.toggle()
-        sendTo(peer, RemoteCmd.ToggleFlash())
+        sendTo(target, RemoteCmd.ToggleFlash())
     }
 
     /// Disconnect one camera from the rig: a purposeful goodbye (`EndSession`)
@@ -682,33 +690,32 @@ public actor MulticamController {
         }
     }
 
-    /// Flip the focused camera between front and back. Framing is per-camera,
-    /// so only the focused peer flips; `ToggleCameraResp` carries its refreshed
-    /// capabilities back to that lane.
-    public nonisolated func toggleFocusedCamera() { tell(MCToggleFocusedCamera()) }
+    /// Flip one camera between front and back. The camera decides whether a
+    /// flip does anything, exactly as in the 1:1 monitor; `ToggleCameraResp`
+    /// carries its refreshed capabilities back to that lane.
+    public nonisolated func flipCamera(_ peer: MCPeerID) { tell(MCFlipCamera(target: peer)) }
 
-    private func handleToggleFocusedCamera() {
-        // Sent whenever a camera is focused and linked — the camera decides
-        // whether a flip does anything, exactly as in the 1:1 monitor. Never
-        // gated on advertised positions (the payload doesn't reliably carry
-        // both), which was why the button read as disabled on device.
-        guard let peer = focusedPeer, links[peer]?.status == .linked else { return }
-        sendTo(peer, RemoteCmd.ToggleCamera())
+    private func handleFlipCamera(target: MCPeerID) {
+        guard links[target]?.status == .linked else { return }
+        sendTo(target, RemoteCmd.ToggleCamera())
     }
 
-    /// Tap-to-focus targets the focused camera only. The IAP gate lives on the
-    /// view controller (mirrors the 1:1); here we drop the command if the
-    /// focused peer never advertised focus support.
-    public nonisolated func focusFocusedCamera(x: Float, y: Float) {
-        tell(MCFocusAtPoint(x: x, y: y))
+    /// Tap-to-focus on one camera. The IAP gate lives on the view controller
+    /// (mirrors the 1:1); here the command is dropped if that camera never
+    /// advertised focus support.
+    public nonisolated func focusCamera(_ peer: MCPeerID, x: Float, y: Float) {
+        tell(MCFocusAtPoint(x: x, y: y, target: peer))
     }
 
-    private func handleFocusAtPoint(x: Float, y: Float) {
-        guard let peer = focusedPeer, links[peer]?.capabilities?.supportsFocusPoint == true else { return }
-        sendTo(peer, RemoteCmd.FocusAtPoint(x: x, y: y))
+    private func handleFocusAtPoint(x: Float, y: Float, target: MCPeerID) {
+        guard links[target]?.capabilities?.supportsFocusPoint == true else { return }
+        sendTo(target, RemoteCmd.FocusAtPoint(x: x, y: y))
     }
 
-    func switchLens(_ lens: CameraLensType) { focusedSend(RemoteCmd.SwitchLens(lensType: lens)) }
+    func switchLens(_ lens: CameraLensType, on peer: MCPeerID) {
+        guard links[peer] != nil else { return }
+        sendTo(peer, RemoteCmd.SwitchLens(lensType: lens))
+    }
 
     public nonisolated func setFocusedPeer(_ peer: MCPeerID) { tell(MCPeerCommand(.focus, peer)) }
 
@@ -753,11 +760,6 @@ public actor MulticamController {
         frameSinks[peer] = nil
         order.removeAll { $0 == peer }
         if focusedPeer == peer { focusedPeer = order.first; syncFocusFlags() }
-    }
-
-    private func focusedSend(_ msg: Message) {
-        guard let peer = focusedPeer else { return }
-        sendTo(peer, msg)
     }
 
     /// Seed a lane's zoom scale from a capabilities exchange via the shared
@@ -1576,11 +1578,18 @@ final class ResourceTransferFinished: Message, @unchecked Sendable {
 enum MulticamTimedAction { case photo, record }
 
 final class MCCapturePhoto: Message, @unchecked Sendable {}
-final class MCToggleFocusedCamera: Message, @unchecked Sendable {}
+final class MCFlipCamera: Message, @unchecked Sendable {
+    let target: MCPeerID
+    init(target: MCPeerID) { self.target = target; super.init(sender: nil) }
+}
 final class MCFocusAtPoint: Message, @unchecked Sendable {
     let x: Float
     let y: Float
-    init(x: Float, y: Float) { self.x = x; self.y = y }
+    let target: MCPeerID
+    init(x: Float, y: Float, target: MCPeerID) {
+        self.x = x; self.y = y; self.target = target
+        super.init(sender: nil)
+    }
 }
 final class MCStartRecording: Message, @unchecked Sendable {}
 final class MCStopRecording: Message, @unchecked Sendable {}
@@ -1605,11 +1614,21 @@ final class MCPeerCommand: Message, @unchecked Sendable {
     init(_ kind: Kind, _ peer: MCPeerID) { self.kind = kind; self.peer = peer; super.init(sender: nil) }
 }
 
-final class MCToggleTorch: Message, @unchecked Sendable {}
-final class MCToggleFlash: Message, @unchecked Sendable {}
+final class MCToggleTorch: Message, @unchecked Sendable {
+    let target: MCPeerID
+    init(target: MCPeerID) { self.target = target; super.init(sender: nil) }
+}
+final class MCToggleFlash: Message, @unchecked Sendable {
+    let target: MCPeerID
+    init(target: MCPeerID) { self.target = target; super.init(sender: nil) }
+}
 final class MCSetZoom: Message, @unchecked Sendable {
     let factor: CGFloat
-    init(_ factor: CGFloat) { self.factor = factor; super.init(sender: nil) }
+    let target: MCPeerID
+    init(_ factor: CGFloat, target: MCPeerID) {
+        self.factor = factor; self.target = target
+        super.init(sender: nil)
+    }
 }
 
 final class MCSetVideoQuality: Message, @unchecked Sendable {

--- a/RemoteCam/MulticamController.swift
+++ b/RemoteCam/MulticamController.swift
@@ -20,8 +20,12 @@ enum MulticamState: Equatable {
     /// A synced photo is in flight: `acksRemaining` cameras have yet to accept
     /// or refuse `captureId`. Returns to `.monitoring` when it reaches zero.
     case capturingPhoto(captureId: String, acksRemaining: Int)
-    /// The rig is recording (or still collecting start acks). `acksRemaining`
-    /// counts cameras that have yet to confirm the scheduled start.
+    /// A synced recording start is collecting acks — all-or-nothing: the
+    /// shutter shows in-flight (not REC) until every target camera accepts;
+    /// one refusal, silence past the deadline, or a target dropping aborts
+    /// the whole take.
+    case startingRecording(captureId: String, acksRemaining: Int)
+    /// Every target camera accepted the synced start — the rig is rolling.
     case recording(captureId: String, acksRemaining: Int)
     /// A synced stop is in flight; returns to `.monitoring` when every camera
     /// has confirmed (or timed out).
@@ -86,9 +90,11 @@ typealias MulticamFrameSink = @Sendable (RemoteCmd.OnFrame) -> Void
 /// frame from camera B never re-renders camera A.
 protocol MulticamDisplay: AnyObject {
     func applyLanes(_ lanes: [MulticamLaneInfo])
-    /// Aggregate shutter state: `capturing` = a synced photo is in flight
-    /// (activity ring); `recording` = the rig is rolling (record/stop button).
-    func applyShutterState(capturing: Bool, recording: Bool)
+    /// Aggregate shutter state: `capturing` = a synced photo or recording
+    /// start is in flight (activity ring); `recording` = every target camera
+    /// committed and the rig is rolling (record/stop button + timer counting
+    /// from `recordingStartTime`, nil unless recording).
+    func applyShutterState(capturing: Bool, recording: Bool, recordingStartTime: Date?)
     /// Cameras the browser has found that aren't in the rig — the add-camera
     /// sheet's list.
     func applyAvailablePeers(_ peers: [MCPeerID])
@@ -173,10 +179,22 @@ public actor MulticamController {
 
     /// One id per director session, part of every capture's filename group.
     private let sessionID = UUID().uuidString
-    /// Cameras that have yet to answer the in-flight synced capture. Empty
-    /// unless `state` is `.capturingPhoto`.
+    /// Cameras that have yet to answer the in-flight synced capture/start/stop.
     private var capturingLanes: Set<MCPeerID> = []
     private var currentCaptureID: String?
+    /// The camera set locked when a countdown arms a shot: the ticks and the
+    /// capture address exactly this set, so the cameras that count down are
+    /// the cameras that shoot. Nil when no countdown is armed.
+    private var armedTargets: Set<MCPeerID>?
+    /// The in-flight recording take: its locked targets, which wire path the
+    /// start went out on (scheduled vs plain fallback — the abort must stop
+    /// through the same path), and the shared fire instant.
+    private var takeTargets: [MCPeerID] = []
+    private var takeScheduled = false
+    private var takeAnchorMillis: UInt64?
+    /// When the rig actually started rolling (every start ack in) — feeds the
+    /// classic recording timer on the director.
+    private var recordingStartedAt: Date?
     /// The most recent photo/video capture id, used to name auto-collected
     /// footage on the director under the shared `RS_<sess>_<cap>_cam<k>` group.
     private var lastCaptureID: String?
@@ -309,6 +327,7 @@ public actor MulticamController {
     private struct ShutterSnapshot: Equatable {
         let capturing: Bool
         let recording: Bool
+        let recordingStartTime: Date?
     }
 
     func handle(_ msg: Message) async {
@@ -336,7 +355,8 @@ public actor MulticamController {
         OperationQueue.main.addOperation {
             if lanesChanged { display?.applyLanes(lanes) }
             if shutterChanged {
-                display?.applyShutterState(capturing: shutter.capturing, recording: shutter.recording)
+                display?.applyShutterState(capturing: shutter.capturing, recording: shutter.recording,
+                                           recordingStartTime: shutter.recordingStartTime)
             }
             if rigChanged { display?.applyRigSettings(rig) }
             if availableChanged { display?.applyAvailablePeers(availablePeers) }
@@ -344,13 +364,20 @@ public actor MulticamController {
     }
 
     private func shutterSnapshot() -> ShutterSnapshot {
+        // A photo in flight and a start-ack window both read as "working, not
+        // yet done" on the shutter; REC (and its timer) appear only once every
+        // target camera has committed.
         let capturing: Bool
-        if case .capturingPhoto = state { capturing = true } else { capturing = false }
+        switch state {
+        case .capturingPhoto, .startingRecording: capturing = true
+        default: capturing = false
+        }
         switch state {
         case .recording, .stoppingRecording:
-            return ShutterSnapshot(capturing: capturing, recording: true)
+            return ShutterSnapshot(capturing: capturing, recording: true,
+                                   recordingStartTime: recordingStartedAt)
         default:
-            return ShutterSnapshot(capturing: capturing, recording: false)
+            return ShutterSnapshot(capturing: capturing, recording: false, recordingStartTime: nil)
         }
     }
 
@@ -470,15 +497,15 @@ public actor MulticamController {
             }
 
         case let ack as RemoteCmd.ScheduledCaptureAck:
-            resolvePhotoAck(from: peer, success: ack.error == nil)
+            resolvePhotoAck(from: peer, captureId: ack.captureId, success: ack.error == nil)
 
         case is RemoteCmd.TakePicAck:
-            // The fallback (plain TakePic) path's positive ack.
-            resolvePhotoAck(from: peer, success: true)
+            // The fallback (plain TakePic) path's positive ack (carries no id).
+            resolvePhotoAck(from: peer, captureId: nil, success: true)
 
         case let resp as RemoteCmd.TakePicResp:
             if resp.error != nil {
-                resolvePhotoAck(from: peer, success: false)
+                resolvePhotoAck(from: peer, captureId: nil, success: false)
             } else if let pic = resp.pic {
                 // Auto-collect: the camera returned its (EXIF-stamped) still.
                 // Save it to the director's library under the shared RS_ name.
@@ -486,11 +513,12 @@ public actor MulticamController {
             }
 
         case let ack as RemoteCmd.ScheduledRecordingAck:
-            resolveRecordingAck(from: peer, isStop: ack.isStop, success: ack.error == nil)
+            resolveRecordingAck(from: peer, captureId: ack.captureId, isStop: ack.isStop,
+                                success: ack.error == nil)
 
         case let ack as RemoteCmd.StartRecordingVideoAck:
-            // The fallback (plain StartRecordingVideo) path's positive ack.
-            if ack.error == nil { resolveRecordingAck(from: peer, isStop: false, success: true) }
+            // The fallback (plain StartRecordingVideo) path's ack (no id).
+            resolveRecordingAck(from: peer, captureId: nil, isStop: false, success: ack.error == nil)
 
         default:
             // Per-camera command responses (zoom/lens/flash/torch acks) update
@@ -527,6 +555,23 @@ public actor MulticamController {
         // controller stays browsing, so `browserDidFindPeer` re-invites.
         link.status = .reconnecting
         armReconnect(peer)
+        laneLeftShot(peer)
+    }
+
+    /// A lane in play for a shot went away. During the start-ack window the
+    /// take is all-or-nothing, so the whole take aborts; during a countdown
+    /// the locked set shrinks, and an emptied set cancels the countdown.
+    /// (An established `.recording` is untouched — the rest of the rig keeps
+    /// rolling, and the camera itself keeps recording through the drop.)
+    private func laneLeftShot(_ peer: MCPeerID) {
+        if case .startingRecording = state, takeTargets.contains(peer) {
+            links[peer]?.captureOutcome = .failed
+            abortRecordingStart()
+        }
+        if var armed = armedTargets, armed.remove(peer) != nil {
+            armedTargets = armed
+            if armed.isEmpty { cancelCountdown() }
+        }
     }
 
     private func handleBrowserFound(_ peer: MCPeerID) {
@@ -686,6 +731,7 @@ public actor MulticamController {
     public nonisolated func removeCamera(_ peer: MCPeerID) { tell(MCPeerCommand(.remove, peer)) }
 
     private func handleRemoveCamera(_ peer: MCPeerID) {
+        laneLeftShot(peer)
         links[peer] = nil
         frameSinks[peer] = nil
         order.removeAll { $0 == peer }
@@ -719,6 +765,11 @@ public actor MulticamController {
         if case .recording(let id, let remaining) = state { return (id, remaining) }
         return nil
     }
+    func startingStateForTesting() -> (id: String, remaining: Int)? {
+        if case .startingRecording(let id, let remaining) = state { return (id, remaining) }
+        return nil
+    }
+    func recordingStartTimeForTesting() -> Date? { recordingStartedAt }
     func stoppingStateForTesting() -> (id: String, remaining: Int)? {
         if case .stoppingRecording(let id, let remaining) = state { return (id, remaining) }
         return nil
@@ -751,14 +802,15 @@ public actor MulticamController {
         order.compactMap { links[$0] }.filter { $0.status == .linked && $0.supportsMulticam }
     }
 
-    /// Send a scheduled command to each ready camera at a shared instant, each
+    /// Send a scheduled command to each target camera at a shared instant, each
     /// translated into that camera's own clock by its offset. Returns the
-    /// captureID and the lanes addressed. `build` makes the per-lane message.
+    /// captureID, whether the scheduled path was used, and the shared instant.
+    /// `build` makes the per-lane message.
     private func fanOutScheduled(
         _ build: (_ fireAtCameraClock: UInt64, _ anchor: UInt64, _ captureID: String,
                   _ index: Int) -> Message,
         fallback: (CameraLink) -> Message,
-        lanes: [CameraLink]) -> String {
+        lanes: [CameraLink]) -> (captureID: String, scheduled: Bool, anchorMillis: UInt64?) {
         let captureID = UUID().uuidString
         capturingLanes = Set(lanes.map(\.peerID))
         currentCaptureID = captureID
@@ -772,12 +824,28 @@ public actor MulticamController {
                 let fireAtCameraClock = UInt64(Int64(fireAt) + offset)
                 sendTo(link.peerID, build(fireAtCameraClock, fireAt, captureID, index + 1))
             }
+            return (captureID, true, fireAt)
         } else {
             // A missing offset means we can't promise a sub-frame instant — fire
             // now on each camera, under the same shot id.
             for link in lanes { sendTo(link.peerID, fallback(link)) }
+            return (captureID, false, nil)
         }
-        return captureID
+    }
+
+    /// The lanes a firing shot addresses: the set the countdown locked (its
+    /// still-ready members), or the ready lanes right now for an un-timed shot.
+    private func shotLanes() -> [CameraLink] {
+        let ready = readyMulticamLanes()
+        guard let armed = armedTargets else { return ready }
+        return ready.filter { armed.contains($0.peerID) }
+    }
+
+    /// Arm a timed shot: lock the target set and start the countdown. The
+    /// ticks and the eventual capture address exactly this set.
+    private func armCountdown(_ action: MulticamTimedAction) {
+        armedTargets = Set(readyMulticamLanes().map(\.peerID))
+        beginCountdown(action)
     }
 
     /// Fire a synced photo on every ready multicam camera. If the rig timer is
@@ -788,53 +856,63 @@ public actor MulticamController {
 
     private func handleCapturePhoto() {
         if countdown != nil { cancelCountdown(); return }
+        // Nothing arms unless a camera is ready to shoot — a countdown must
+        // never play on cameras that won't be asked to fire.
+        guard case .monitoring = state, !readyMulticamLanes().isEmpty else { return }
         guard rigTimerSeconds > 0 else { performCapturePhoto(); return }
-        beginCountdown(.photo)
+        armCountdown(.photo)
     }
 
     private func performCapturePhoto() {
         guard case .monitoring = state else { return }
-        let ready = readyMulticamLanes()
-        guard !ready.isEmpty else { return }
-        for link in ready { link.captureOutcome = nil }
+        let targets = shotLanes()
+        guard !targets.isEmpty else { return }
+        for link in targets { link.captureOutcome = nil }
 
-        let captureID = fanOutScheduled(
+        let fan = fanOutScheduled(
             { fire, anchor, id, index in
                 RemoteCmd.ScheduledCapture(fireAtCameraClockMillis: fire, anchorMillis: anchor,
                                            captureId: id, sessionId: self.sessionID, cameraIndex: index)
             },
             fallback: { _ in RemoteCmd.TakePic(sender: nil, sendMediaToPeer: false) },
-            lanes: ready)
+            lanes: targets)
 
-        state = .capturingPhoto(captureId: captureID, acksRemaining: capturingLanes.count)
-        armAckTimeout(captureID)
+        state = .capturingPhoto(captureId: fan.captureID, acksRemaining: capturingLanes.count)
+        armAckTimeout(fan.captureID)
     }
 
     /// Start a synced recording on every ready multicam camera (timer-gated).
     public nonisolated func startRecording() { tell(MCStartRecording()) }
 
     private func handleStartRecording() {
+        // A second tap while acks are still being collected backs out of the
+        // take (the timeout would settle it anyway; don't make the user wait).
+        if case .startingRecording = state { abortRecordingStart(); return }
         if countdown != nil { cancelCountdown(); return }
+        guard case .monitoring = state, !readyMulticamLanes().isEmpty else { return }
         guard rigTimerSeconds > 0 else { performStartRecording(); return }
-        beginCountdown(.record)
+        armCountdown(.record)
     }
 
     private func performStartRecording() {
         guard case .monitoring = state else { return }
-        let ready = readyMulticamLanes()
-        guard !ready.isEmpty else { return }
-        for link in ready { link.captureOutcome = nil }
+        let targets = shotLanes()
+        guard !targets.isEmpty else { return }
+        for link in targets { link.captureOutcome = nil }
 
-        let captureID = fanOutScheduled(
+        let fan = fanOutScheduled(
             { fire, anchor, id, index in
                 RemoteCmd.ScheduledStartRecording(fireAtCameraClockMillis: fire, anchorMillis: anchor,
                                                   captureId: id, sessionId: self.sessionID, cameraIndex: index)
             },
             fallback: { _ in RemoteCmd.StartRecordingVideo(sender: nil) },
-            lanes: ready)
+            lanes: targets)
 
-        state = .recording(captureId: captureID, acksRemaining: capturingLanes.count)
-        armAckTimeout(captureID)
+        takeTargets = targets.map(\.peerID)
+        takeScheduled = fan.scheduled
+        takeAnchorMillis = fan.anchorMillis
+        state = .startingRecording(captureId: fan.captureID, acksRemaining: capturingLanes.count)
+        armAckTimeout(fan.captureID)
     }
 
     /// Stop the synced recording on every rolling camera, anchored so the clips
@@ -844,9 +922,15 @@ public actor MulticamController {
     private func handleStopRecording() {
         guard case .recording(_, _) = state else { return }
         let rolling = order.compactMap { links[$0] }.filter { $0.isRecording }
-        guard !rolling.isEmpty else { return }
+        guard !rolling.isEmpty else {
+            // Nothing is actually rolling (every rolling lane has dropped) —
+            // there is no take left to stop, only a state to put right.
+            clearRecordingTake()
+            state = .monitoring(mode: .photo)
+            return
+        }
 
-        let captureID = fanOutScheduled(
+        let fan = fanOutScheduled(
             { fire, anchor, id, index in
                 RemoteCmd.ScheduledStopRecording(fireAtCameraClockMillis: fire, anchorMillis: anchor,
                                                  captureId: id, sessionId: self.sessionID, cameraIndex: index)
@@ -854,8 +938,8 @@ public actor MulticamController {
             fallback: { _ in RemoteCmd.StopRecordingVideo(sender: nil, sendMediaToPeer: false) },
             lanes: rolling)
 
-        state = .stoppingRecording(captureId: captureID, acksRemaining: capturingLanes.count)
-        armAckTimeout(captureID)
+        state = .stoppingRecording(captureId: fan.captureID, acksRemaining: capturingLanes.count)
+        armAckTimeout(fan.captureID)
     }
 
     // MARK: - Rig-wide quality ("the shot belongs to the rig")
@@ -965,7 +1049,8 @@ public actor MulticamController {
         countdownGeneration += 1
         timerTask.value?.cancel()
         countdown = nil
-        for peer in order { sendTo(peer, RemoteCmd.TimerCountdown(value: -1)) }
+        for peer in countdownRecipients() { sendTo(peer, RemoteCmd.TimerCountdown(value: -1)) }
+        armedTargets = nil
     }
 
     /// Advance one tick (pump-driven). Fires the capture at zero. A stale
@@ -983,6 +1068,7 @@ public actor MulticamController {
             case .photo: performCapturePhoto()
             case .record: performStartRecording()
             }
+            armedTargets = nil // the locked set has served its shot
         }
     }
 
@@ -1000,7 +1086,14 @@ public actor MulticamController {
     }
 
     private func fanOutTimerTick(_ remaining: Int) {
-        for peer in order { sendTo(peer, RemoteCmd.TimerCountdown(value: remaining)) }
+        for peer in countdownRecipients() { sendTo(peer, RemoteCmd.TimerCountdown(value: remaining)) }
+    }
+
+    /// The countdown plays only on the cameras that will be asked to shoot —
+    /// never on a lane the locked target set doesn't contain.
+    private func countdownRecipients() -> [MCPeerID] {
+        guard let armed = armedTargets else { return order }
+        return order.filter { armed.contains($0) }
     }
 
     /// The tray's snapshot, derived on demand from the live lane set — never
@@ -1024,20 +1117,38 @@ public actor MulticamController {
 
     // MARK: Ack aggregation (shared across photo / start / stop)
 
-    private func resolvePhotoAck(from peer: MCPeerID, success: Bool) {
-        guard case .capturingPhoto = state, capturingLanes.contains(peer) else { return }
+    /// `captureId` nil = a fallback-path message that carries no id; a non-nil
+    /// id must match the in-flight shot or the ack is a stray from a dead one.
+    private func resolvePhotoAck(from peer: MCPeerID, captureId: String?, success: Bool) {
+        guard case .capturingPhoto(let id, _) = state, capturingLanes.contains(peer),
+              captureId == nil || captureId == id else { return }
         links[peer]?.captureOutcome = success ? .captured : .failed
         finishLane(peer)
     }
 
-    private func resolveRecordingAck(from peer: MCPeerID, isStop: Bool, success: Bool) {
+    private func resolveRecordingAck(from peer: MCPeerID, captureId: String?,
+                                     isStop: Bool, success: Bool) {
         switch state {
-        case .recording where !isStop:
-            guard capturingLanes.contains(peer) else { return }
-            if success { links[peer]?.isRecording = true } else { links[peer]?.captureOutcome = .failed }
-            finishLane(peer)
-        case .stoppingRecording where isStop:
-            guard capturingLanes.contains(peer) else { return }
+        case .startingRecording(let id, _) where !isStop:
+            guard capturingLanes.contains(peer), captureId == nil || captureId == id else { return }
+            guard success else {
+                // All-or-nothing: one refusal voids the whole take.
+                links[peer]?.captureOutcome = .failed
+                abortRecordingStart()
+                return
+            }
+            links[peer]?.isRecording = true
+            capturingLanes.remove(peer)
+            if capturingLanes.isEmpty {
+                // Every target committed — the rig is rolling, from the shared
+                // fire instant.
+                state = .recording(captureId: id, acksRemaining: 0)
+                recordingStartedAt = recordingStartDate()
+            } else {
+                state = .startingRecording(captureId: id, acksRemaining: capturingLanes.count)
+            }
+        case .stoppingRecording(let id, _) where isStop:
+            guard capturingLanes.contains(peer), captureId == nil || captureId == id else { return }
             links[peer]?.isRecording = false
             finishLane(peer)
         default:
@@ -1045,20 +1156,64 @@ public actor MulticamController {
         }
     }
 
+    /// The take's shared fire instant as a wall-clock date (scheduled path),
+    /// or now (fallback path) — so the recording timer counts from the moment
+    /// the cameras actually rolled, not from when the last ack arrived.
+    private func recordingStartDate() -> Date {
+        guard let anchor = takeAnchorMillis else { return Date() }
+        let deltaMillis = Int64(bitPattern: anchor &- SyncClock.nowMillis())
+        return Date().addingTimeInterval(Double(deltaMillis) / 1000)
+    }
+
+    /// All-or-nothing abort: the take is void unless every target accepted.
+    /// The stop goes to EVERY target — a camera whose ok-ack is still in
+    /// flight gets stopped too, and one that never started refuses the stop
+    /// harmlessly. Badging the lane that broke the take is the trigger site's
+    /// job (nack, timeout, and disconnect know who to blame; the rest didn't fail).
+    private func abortRecordingStart() {
+        guard case .startingRecording(let id, _) = state else { return }
+        for peer in takeTargets {
+            if takeScheduled {
+                let fireAt = SyncClock.nowMillis() + captureLeadMillis
+                let offset = links[peer]?.latestOffset?.offsetMillis ?? 0
+                sendTo(peer, RemoteCmd.ScheduledStopRecording(
+                    fireAtCameraClockMillis: UInt64(Int64(fireAt) + offset), anchorMillis: fireAt,
+                    captureId: id, sessionId: sessionID, cameraIndex: cameraIndex(of: peer)))
+            } else {
+                sendTo(peer, RemoteCmd.StopRecordingVideo(sender: nil, sendMediaToPeer: false))
+            }
+            links[peer]?.isRecording = false
+        }
+        clearRecordingTake()
+        state = .monitoring(mode: .photo)
+    }
+
+    private func clearRecordingTake() {
+        capturingLanes.removeAll()
+        currentCaptureID = nil
+        takeTargets = []
+        takeScheduled = false
+        takeAnchorMillis = nil
+        recordingStartedAt = nil
+    }
+
     /// Count one lane's answer and advance the aggregate. A photo or a stop
-    /// that empties the set returns to monitoring; a start that empties it
-    /// stays `.recording` (the rig is now rolling).
+    /// that empties the set returns to monitoring. (Recording start acks are
+    /// aggregated all-or-nothing in `resolveRecordingAck`, not here.)
     private func finishLane(_ peer: MCPeerID) {
         capturingLanes.remove(peer)
         let remaining = capturingLanes.count
         switch state {
         case .capturingPhoto(let id, _):
             state = remaining == 0 ? .monitoring(mode: .photo) : .capturingPhoto(captureId: id, acksRemaining: remaining)
-        case .recording(let id, _):
-            state = .recording(captureId: id, acksRemaining: remaining)
         case .stoppingRecording(let id, _):
-            state = remaining == 0 ? .monitoring(mode: .photo) : .stoppingRecording(captureId: id, acksRemaining: remaining)
-        case .monitoring:
+            if remaining == 0 {
+                clearRecordingTake()
+                state = .monitoring(mode: .photo)
+            } else {
+                state = .stoppingRecording(captureId: id, acksRemaining: remaining)
+            }
+        case .recording, .startingRecording, .monitoring:
             break
         }
     }
@@ -1072,33 +1227,35 @@ public actor MulticamController {
     }
 
     /// Any camera silent past the deadline is settled so the aggregate always
-    /// resolves: a silent photo lane failed; a silent start lane failed (not
-    /// rolling); a silent stop lane is forced stopped.
+    /// resolves: a silent photo lane failed; a silent recording-start lane
+    /// voids the whole take (all-or-nothing); a silent stop lane is forced
+    /// stopped.
     private func expireAcks(_ captureID: String) {
         let matches: Bool
         switch state {
-        case .capturingPhoto(let id, _), .recording(let id, _), .stoppingRecording(let id, _):
+        case .capturingPhoto(let id, _), .startingRecording(let id, _),
+             .recording(let id, _), .stoppingRecording(let id, _):
             matches = id == captureID
         case .monitoring:
             matches = false
         }
         guard matches else { return }
 
-        for peer in capturingLanes {
-            switch state {
-            case .capturingPhoto: links[peer]?.captureOutcome = .failed
-            case .recording: links[peer]?.captureOutcome = .failed
-            case .stoppingRecording: links[peer]?.isRecording = false
-            case .monitoring: break
-            }
-        }
-        capturingLanes.removeAll()
-        currentCaptureID = nil
         switch state {
-        case .recording(let id, _):
-            state = .recording(captureId: id, acksRemaining: 0) // rolling, start acks settled
-        default:
+        case .startingRecording:
+            for peer in capturingLanes { links[peer]?.captureOutcome = .failed }
+            abortRecordingStart()
+        case .capturingPhoto:
+            for peer in capturingLanes { links[peer]?.captureOutcome = .failed }
+            capturingLanes.removeAll()
+            currentCaptureID = nil
             state = .monitoring(mode: .photo)
+        case .stoppingRecording:
+            for peer in capturingLanes { links[peer]?.isRecording = false }
+            clearRecordingTake()
+            state = .monitoring(mode: .photo)
+        case .recording, .monitoring:
+            break // a rolling rig has no pending acks under all-or-nothing
         }
     }
 

--- a/RemoteCam/MulticamController.swift
+++ b/RemoteCam/MulticamController.swift
@@ -57,6 +57,9 @@ struct MulticamLaneInfo: Equatable {
     /// capabilities. Not the flip-button gate (that mirrors the 1:1 monitor and
     /// stays ungated); a projection of capabilities for diagnostics/tests.
     let canFlipCamera: Bool
+    /// This camera can focus at a point — gates the viewfinder's focus tap so
+    /// the user never gets a reticle (or a paywall) for a camera that can't.
+    let supportsFocusPoint: Bool
     /// Zoom state for the focused zoom pill (the same values the 1:1 monitor
     /// builds its `ZoomScale` from). `zoomFactor` is the live hardware factor.
     let zoomFactor: CGFloat

--- a/RemoteCam/MulticamController.swift
+++ b/RemoteCam/MulticamController.swift
@@ -197,6 +197,10 @@ public actor MulticamController {
     private var rigTimerSeconds: Int = 0
     /// The live countdown, or nil when not counting down.
     private var countdown: (remaining: Int, action: MulticamTimedAction)?
+    /// Bumped on every countdown begin/cancel; a tick carrying a stale
+    /// generation is ignored, so a cancelled countdown can never fire late and
+    /// a tick already in the inbox can never advance a newer countdown.
+    private var countdownGeneration = 0
     /// The countdown tick interval — injectable so tests don't wait real seconds.
     private var timerTickInterval: TimeInterval = 1
     private nonisolated let timerTask = Locked<Task<Void, Never>?>(nil)
@@ -220,11 +224,13 @@ public actor MulticamController {
 
     func setDisplay(_ display: MulticamDisplay) {
         self.display = display
-        // Pre-pump setup: replay the current state directly (no pump epilogue
-        // to flush a dirty flag). The display is wired after `install`, so the
-        // first snapshot emitted during install would otherwise reach no one.
-        publishRigSettingsNow()
-        publishLanesNow()
+        // A display may be wired after `install`: forget what was published so
+        // the new screen receives the complete current state, not just diffs.
+        publishedLanes = nil
+        publishedShutter = nil
+        publishedRig = nil
+        publishedAvailable = nil
+        publishChangedSnapshots()
     }
     func setReconnectRetryDelay(_ delay: TimeInterval) { reconnectRetryDelay = delay }
 
@@ -269,7 +275,7 @@ public actor MulticamController {
 
         for peer in order { beginHandshake(with: peer) }
         startClockSyncLoop()
-        publishLanesNow() // pre-pump setup
+        publishChangedSnapshots() // install runs outside the pump — publish directly
     }
 
     /// The initial per-camera handshake: announce the director role (carries
@@ -285,18 +291,64 @@ public actor MulticamController {
 
     // MARK: - Message handling
 
-    /// Derived publishing: handlers mark what changed instead of pushing to the
-    /// UI themselves, and the pump flushes at most one lanes-publish and one
-    /// rig-publish per message — so multiple mutations coalesce into one main hop.
-    private var lanesDirty = false
-    private var rigDirty = false
-    private func markLanesDirty() { lanesDirty = true }
-    private func markRigDirty() { rigDirty = true }
+    /// Derived publishing: handlers only mutate state. After every message the
+    /// pump rebuilds each UI snapshot from that state and publishes the ones
+    /// that changed (all snapshots are Equatable) — at most one main hop per
+    /// message, and no per-handler publish bookkeeping. The settings tray is
+    /// therefore always the intersection of the cameras actually in the rig:
+    /// a lane joining, dropping, or changing capabilities republishes it on
+    /// the same pump turn.
+    private var publishedLanes: [MulticamLaneInfo]?
+    private var publishedShutter: ShutterSnapshot?
+    private var publishedRig: RigSettingsSnapshot?
+    private var publishedAvailable: [MCPeerID]?
+
+    private struct ShutterSnapshot: Equatable {
+        let capturing: Bool
+        let recording: Bool
+    }
 
     func handle(_ msg: Message) async {
         await route(msg)
-        if lanesDirty { lanesDirty = false; publishLanesNow() }
-        if rigDirty { rigDirty = false; publishRigSettingsNow() }
+        publishChangedSnapshots()
+    }
+
+    private func publishChangedSnapshots() {
+        let lanes = laneSnapshot()
+        let shutter = shutterSnapshot()
+        let rig = rigSettingsSnapshot()
+        let availablePeers = available.peers
+
+        let lanesChanged = lanes != publishedLanes
+        let shutterChanged = shutter != publishedShutter
+        let rigChanged = rig != publishedRig
+        let availableChanged = availablePeers != publishedAvailable
+        guard lanesChanged || shutterChanged || rigChanged || availableChanged else { return }
+        publishedLanes = lanes
+        publishedShutter = shutter
+        publishedRig = rig
+        publishedAvailable = availablePeers
+
+        let display = display
+        OperationQueue.main.addOperation {
+            if lanesChanged { display?.applyLanes(lanes) }
+            if shutterChanged {
+                display?.applyShutterState(capturing: shutter.capturing, recording: shutter.recording)
+            }
+            if rigChanged { display?.applyRigSettings(rig) }
+            if availableChanged { display?.applyAvailablePeers(availablePeers) }
+        }
+    }
+
+    private func shutterSnapshot() -> ShutterSnapshot {
+        let capturing: Bool
+        if case .capturingPhoto = state { capturing = true } else { capturing = false }
+        switch state {
+        case .recording, .stoppingRecording:
+            return ShutterSnapshot(capturing: capturing, recording: true)
+        default:
+            return ShutterSnapshot(capturing: capturing, recording: false)
+        }
     }
 
     private func route(_ msg: Message) async {
@@ -311,9 +363,7 @@ public actor MulticamController {
             handleBrowserFound(found.peer)
 
         case let lost as UICmd.BrowserLostPeer:
-            if available.remove(lost.peer) {
-                publishAvailable()
-            }
+            _ = available.remove(lost.peer)
 
         case let routed as RoutedMessage:
             await handleRouted(routed.message, from: routed.peer)
@@ -341,7 +391,8 @@ public actor MulticamController {
         case is MCStopRecording: handleStopRecording()
         case is MCAutomaticVideoQuality: handleAutomaticVideoQuality()
         case is MCAutomaticPhotoQuality: handleAutomaticPhotoQuality()
-        case is MCTimerAdvance: advanceCountdown()
+        case let tick as MCTimerAdvance: advanceCountdown(generation: tick.generation)
+        case let expired as MCAckTimeout: expireAcks(expired.captureID)
         case let q as MCSetVideoQuality: handleSetVideoQuality(resolution: q.resolution, frameRate: q.frameRate)
         case let q as MCSetPhotoQuality: handleSetPhotoQuality(format: q.format, hdr: q.hdr)
         case let t as MCSetRigTimer: handleSetRigTimer(t.seconds)
@@ -379,7 +430,6 @@ public actor MulticamController {
             // fully drive.
             if !isPeerCompatible(became) {
                 link.status = .failed
-                markLanesDirty()
             }
 
         case let caps as RemoteCmd.CameraCapabilitiesResp:
@@ -390,8 +440,6 @@ public actor MulticamController {
             // tile badges + the tray offers re-match) rather than silently
             // changing the rig. Also refreshes the intersection menu.
             refreshRematchFlags()
-            markLanesDirty()
-            markRigDirty()
             // A multicam-capable camera gets an immediate clock probe so its
             // offset is ready well before the first synced capture (PR4), and
             // its preview tier (full if focused, else thumbnail).
@@ -409,8 +457,6 @@ public actor MulticamController {
                 seedZoom(link, from: caps)
             }
             refreshRematchFlags()
-            markLanesDirty()
-            markRigDirty()
 
         case let resp as RemoteCmd.SetZoomResp:
             // The focused camera settled on a zoom; reflect its factor and range
@@ -419,7 +465,6 @@ public actor MulticamController {
             if let maxZoom = resp.zoomRange?.maxZoom {
                 link.maxZoomFactor = ZoomScaleSeed.clampMaxZoom(maxZoom, wideAngle: link.wideAngleZoomFactor)
             }
-            markLanesDirty()
 
         case let ack as RemoteCmd.ScheduledCaptureAck:
             resolvePhotoAck(from: peer, success: ack.error == nil)
@@ -461,13 +506,10 @@ public actor MulticamController {
             links[peer] = CameraLink(peerID: peer)
         }
         // It's in the rig now, so it's no longer an "available" candidate.
-        if available.remove(peer) {
-            publishAvailable()
-        }
+        _ = available.remove(peer)
         focusedPeer = focusedPeer ?? peer
         syncFocusFlags()
         beginHandshake(with: peer)
-        markLanesDirty()
     }
 
     /// Mirror `focusedPeer` onto each lane's `isFocused` so `CameraLink.snapshot`
@@ -476,18 +518,11 @@ public actor MulticamController {
         for (peer, link) in links { link.isFocused = (peer == focusedPeer) }
     }
 
-    private func publishAvailable() {
-        let peers = available.peers
-        let display = display
-        OperationQueue.main.addOperation { display?.applyAvailablePeers(peers) }
-    }
-
     private func handlePeerDisconnected(_ peer: MCPeerID) {
         guard let link = links[peer] else { return }
         // Degrade the tile, keep the rest of the rig recording/monitoring. The
         // controller stays browsing, so `browserDidFindPeer` re-invites.
         link.status = .reconnecting
-        markLanesDirty()
         armReconnect(peer)
     }
 
@@ -503,7 +538,6 @@ public actor MulticamController {
         // resolved name rather than the hash placeholder.
         guard links[peer] == nil else { return }
         available.upsert(peer)
-        publishAvailable()
     }
 
     /// Invite a discovered camera into the rig (the "add camera" flow). The
@@ -560,14 +594,12 @@ public actor MulticamController {
         // 1:1 monitor's; the camera is the source of truth for whether it took.
         link.torchOn.toggle()
         sendTo(peer, RemoteCmd.ToggleTorch())
-        markLanesDirty()
     }
 
     private func handleToggleFlash() {
         guard let peer = focusedPeer, let link = links[peer] else { return }
         link.flashOn.toggle()
         sendTo(peer, RemoteCmd.ToggleFlash())
-        markLanesDirty()
     }
 
     /// Disconnect one camera from the rig: a purposeful goodbye (`EndSession`)
@@ -622,7 +654,6 @@ public actor MulticamController {
         // Retier previews: the newly focused camera goes full-size, the rest
         // (including the one that just lost focus) drop to thumbnail.
         for p in order { pushProfile(to: p) }
-        markLanesDirty()
     }
 
     /// The preview tier a camera should be on: full for the focused lane,
@@ -656,7 +687,6 @@ public actor MulticamController {
         frameSinks[peer] = nil
         order.removeAll { $0 == peer }
         if focusedPeer == peer { focusedPeer = order.first; syncFocusFlags() }
-        markLanesDirty()
     }
 
     private func focusedSend(_ msg: Message) {
@@ -694,6 +724,7 @@ public actor MulticamController {
     func isRecordingForTesting(_ peer: MCPeerID) -> Bool { links[peer]?.isRecording ?? false }
     func availablePeersForTesting() -> [MCPeerID] { available.peers }
     func cameraCountForTesting() -> Int { order.count }
+    func rigSettingsSnapshotForTesting() -> RigSettingsSnapshot { rigSettingsSnapshot() }
 
     /// Test seam: put a lane in the state a real handshake would — linked, with
     /// known multicam capability and (optionally) a known clock offset — so
@@ -753,6 +784,7 @@ public actor MulticamController {
     public nonisolated func capturePhoto() { tell(MCCapturePhoto()) }
 
     private func handleCapturePhoto() {
+        if countdown != nil { cancelCountdown(); return }
         guard rigTimerSeconds > 0 else { performCapturePhoto(); return }
         beginCountdown(.photo)
     }
@@ -772,7 +804,6 @@ public actor MulticamController {
             lanes: ready)
 
         state = .capturingPhoto(captureId: captureID, acksRemaining: capturingLanes.count)
-        markLanesDirty()
         armAckTimeout(captureID)
     }
 
@@ -780,6 +811,7 @@ public actor MulticamController {
     public nonisolated func startRecording() { tell(MCStartRecording()) }
 
     private func handleStartRecording() {
+        if countdown != nil { cancelCountdown(); return }
         guard rigTimerSeconds > 0 else { performStartRecording(); return }
         beginCountdown(.record)
     }
@@ -799,7 +831,6 @@ public actor MulticamController {
             lanes: ready)
 
         state = .recording(captureId: captureID, acksRemaining: capturingLanes.count)
-        markLanesDirty()
         armAckTimeout(captureID)
     }
 
@@ -821,7 +852,6 @@ public actor MulticamController {
             lanes: rolling)
 
         state = .stoppingRecording(captureId: captureID, acksRemaining: capturingLanes.count)
-        markLanesDirty()
         armAckTimeout(captureID)
     }
 
@@ -831,7 +861,8 @@ public actor MulticamController {
     func setTimerTickInterval(_ t: TimeInterval) { timerTickInterval = t }
     /// Advance the rig countdown one tick deterministically (production uses the
     /// one-shot Task; tests set a large interval and drive with this instead).
-    func advanceTimerForTesting() { advanceCountdown() }
+    /// Runs through `handle` so the publish epilogue fires like a real tick.
+    func advanceTimerForTesting() async { await handle(MCTimerAdvance(generation: countdownGeneration)) }
     func countdownRemainingForTesting() -> Int? { countdown?.remaining }
     func activeVideoQualityForTesting() -> (VideoResolution, VideoFrameRate)? {
         activeVideoQuality.map { ($0.resolution, $0.frameRate) }
@@ -862,7 +893,6 @@ public actor MulticamController {
             sendTo(peer, RemoteCmd.SetVideoQuality(resolution: resolution, frameRate: frameRate))
         }
         refreshRematchFlags()
-        markLanesDirty()
     }
 
     public nonisolated func setPhotoQuality(format: PhotoFormat, hdr: HDRMode) {
@@ -874,7 +904,6 @@ public actor MulticamController {
         for peer in order {
             sendTo(peer, RemoteCmd.SetPhotoQuality(format: format, hdrMode: hdr))
         }
-        markLanesDirty()
     }
 
     /// "Automatic" / re-match: recompute best-in-intersection and apply it.
@@ -912,7 +941,6 @@ public actor MulticamController {
 
     private func handleSetRigTimer(_ seconds: Int) {
         rigTimerSeconds = seconds
-        markRigDirty()
     }
 
     /// Begin a director-side countdown, fanned out to every camera so subjects
@@ -920,14 +948,27 @@ public actor MulticamController {
     /// the inbox (so it is ordered with everything else and visible to
     /// `waitForIdle`); the only Task is a one-shot sleep between ticks.
     private func beginCountdown(_ action: MulticamTimedAction) {
+        countdownGeneration += 1
         countdown = (remaining: rigTimerSeconds, action: action)
         fanOutTimerTick(rigTimerSeconds)
         scheduleNextTick()
     }
 
-    /// Advance one tick (pump-driven). Fires the capture at zero.
-    private func advanceCountdown() {
-        guard let c = countdown else { return }
+    /// Cancel the running countdown: the shutter, tapped again while the rig is
+    /// counting, is a cancel — the same gesture the 1:1 monitor honors. Every
+    /// camera is told (a negative tick renders the "cancelled" overlay and
+    /// restores its torch); nothing is captured.
+    private func cancelCountdown() {
+        countdownGeneration += 1
+        timerTask.value?.cancel()
+        countdown = nil
+        for peer in order { sendTo(peer, RemoteCmd.TimerCountdown(value: -1)) }
+    }
+
+    /// Advance one tick (pump-driven). Fires the capture at zero. A stale
+    /// generation is a tick from a countdown that no longer exists — dropped.
+    private func advanceCountdown(generation: Int) {
+        guard generation == countdownGeneration, let c = countdown else { return }
         let remaining = c.remaining - 1
         fanOutTimerTick(remaining)
         if remaining > 0 {
@@ -946,21 +987,24 @@ public actor MulticamController {
     /// only — tests drive `advanceCountdown` directly via `advanceTimerForTesting`.
     private func scheduleNextTick() {
         let interval = timerTickInterval
+        let generation = countdownGeneration
         timerTask.value?.cancel()
         timerTask.value = Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
-            self?.tell(MCTimerAdvance())
+            guard !Task.isCancelled else { return }
+            self?.tell(MCTimerAdvance(generation: generation))
         }
     }
 
     private func fanOutTimerTick(_ remaining: Int) {
         for peer in order { sendTo(peer, RemoteCmd.TimerCountdown(value: remaining)) }
-        markRigDirty() // the countdown value is read from `countdown` state at publish
     }
 
-    private func publishRigSettingsNow() {
+    /// The tray's snapshot, derived on demand from the live lane set — never
+    /// stored, so it cannot go stale when a camera joins or drops.
+    private func rigSettingsSnapshot() -> RigSettingsSnapshot {
         let menu = rigQualityMenu()
-        let snapshot = RigSettingsSnapshot(
+        return RigSettingsSnapshot(
             timerSeconds: rigTimerSeconds,
             countdown: countdown?.remaining,
             activeVideo: activeVideoQuality.map {
@@ -973,8 +1017,6 @@ public actor MulticamController {
             hdrBlockedBy: menu.lanesBlockingHDR(),
             activePhotoFormat: activePhotoQuality?.format,
             activeHDR: activePhotoQuality?.hdr)
-        let display = display
-        OperationQueue.main.addOperation { display?.applyRigSettings(snapshot) }
     }
 
     // MARK: Ack aggregation (shared across photo / start / stop)
@@ -1016,15 +1058,13 @@ public actor MulticamController {
         case .monitoring:
             break
         }
-        markLanesDirty()
     }
 
     private func armAckTimeout(_ captureID: String) {
         let timeout = captureAckTimeout
         Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
-            guard let self else { return }
-            await self.expireAcks(captureID)
+            self?.tell(MCAckTimeout(captureID: captureID))
         }
     }
 
@@ -1057,7 +1097,6 @@ public actor MulticamController {
         default:
             state = .monitoring(mode: .photo)
         }
-        markLanesDirty()
     }
 
     // MARK: - Auto-collect (footage back to the director)
@@ -1084,14 +1123,12 @@ public actor MulticamController {
         guard let link = links[peer] else { return }
         let name = rigMetadata(for: peer).photoFilename(isHEIC: Self.isHEIC(data))
         link.collection = .collected
-        markLanesDirty()
         Self.savePhotoToLibrary(data, originalFilename: name)
     }
 
     private func handleResourceStarted(_ started: ResourceTransferStarted) {
         guard let link = links[started.peer] else { return }
         link.collection = .transferring(0)
-        markLanesDirty()
     }
 
     private func handleResourceFinished(_ finished: ResourceTransferFinished) {
@@ -1106,11 +1143,9 @@ public actor MulticamController {
             // partial temp file is ours to clean up.
             finished.localURL.map(Self.discardTempFile)
             link.collection = .failed
-            markLanesDirty()
             return
         }
         link.collection = .collected
-        markLanesDirty()
         // The resource is named with the RS_ filename by the camera, so save it
         // under that; QuickTime sync metadata rides inside the .mov itself. The
         // controller owns `localURL` until `saveVideoToLibrary` either moves it
@@ -1131,7 +1166,6 @@ public actor MulticamController {
     private func handleRetryCollection(_ peer: MCPeerID) {
         guard let link = links[peer], link.collection == .failed else { return }
         link.collection = .transferring(0)
-        markLanesDirty()
         sendTo(peer, RemoteCmd.RequestVideoResend(captureId: lastCaptureID ?? ""))
     }
 
@@ -1227,22 +1261,6 @@ public actor MulticamController {
         order.compactMap { links[$0]?.snapshot }
     }
 
-    private func publishLanesNow() {
-        let snapshot = laneSnapshot()
-        let capturing: Bool
-        if case .capturingPhoto = state { capturing = true } else { capturing = false }
-        let recording: Bool
-        switch state {
-        case .recording, .stoppingRecording: recording = true
-        default: recording = false
-        }
-        let display = display
-        OperationQueue.main.addOperation {
-            display?.applyLanes(snapshot)
-            display?.applyShutterState(capturing: capturing, recording: recording)
-        }
-    }
-
     private func isPeerCompatible(_ became: RemoteCmd.RoleAnnouncement) -> Bool {
         PeerAppCompatibility.isCompatible(remoteShortVersion: became.shortVersion)
     }
@@ -1297,7 +1315,6 @@ extension MulticamController: MultipeerServiceDelegate {
             t0Millis: pong.echoT0Millis,
             cameraClockMillis: pong.cameraClockMillis,
             t3Millis: t3)
-        markLanesDirty()
     }
 
     public nonisolated func didReceiveFrameRequest(_ request: RemoteCmd.RequestFrame) {
@@ -1380,7 +1397,17 @@ final class MCStartRecording: Message, @unchecked Sendable {}
 final class MCStopRecording: Message, @unchecked Sendable {}
 final class MCAutomaticVideoQuality: Message, @unchecked Sendable {}
 final class MCAutomaticPhotoQuality: Message, @unchecked Sendable {}
-final class MCTimerAdvance: Message, @unchecked Sendable {}
+final class MCTimerAdvance: Message, @unchecked Sendable {
+    /// The countdown generation this tick belongs to (see `countdownGeneration`).
+    let generation: Int
+    init(generation: Int) { self.generation = generation; super.init(sender: nil) }
+}
+
+/// The capture-ack deadline for `captureID` passed — settle any silent lanes.
+final class MCAckTimeout: Message, @unchecked Sendable {
+    let captureID: String
+    init(captureID: String) { self.captureID = captureID; super.init(sender: nil) }
+}
 
 final class MCPeerCommand: Message, @unchecked Sendable {
     enum Kind { case focus, invite, remove, disconnect, retryCollection, nudgeFrame, requestKeyframe, reconnectTick }

--- a/RemoteCam/MulticamView.swift
+++ b/RemoteCam/MulticamView.swift
@@ -52,9 +52,6 @@ struct MulticamView: View {
     /// scanner re-arms and re-selects the still-connected cameras).
     let onBack: () -> Void
 
-    @State private var focusReticle: FocusReticle?
-    @State private var focusedPreviewSize: CGSize = .zero
-
     var body: some View {
         GeometryReader { geo in
             let dock = MonitorChromeLayout.dock(
@@ -332,30 +329,22 @@ struct MulticamView: View {
     @ViewBuilder
     private var focusedViewfinder: some View {
         if let focused = viewModel.focusedLane {
+            // One ZStack, one `ignoresSafeArea`: the frame, the gestures, and
+            // the reticle share a single coordinate space (the same contract as
+            // the 1:1 monitor's preview layer). Gestures address the focused
+            // camera; in grid mode a tile tap focuses the lane instead.
             ZStack {
                 LiveFrameView(frames: focused.frames, aspectRatio: .sixteenNine)
-                    .ignoresSafeArea()
-                    .background(GeometryReader { geo in
-                        Color.clear.preference(key: FocusedPreviewSizeKey.self, value: geo.size)
-                    })
-                    // Tap-to-focus, focus mode only (in grid a tap focuses the
-                    // tile). The translation guard keeps a drag from focusing,
-                    // matching the 1:1 preview.
-                    .simultaneousGesture(
-                        DragGesture(minimumDistance: 0).onEnded { value in
-                            if abs(value.translation.width) < 10, abs(value.translation.height) < 10 {
-                                handleFocusTap(at: value.location, lane: focused)
-                            }
-                        })
-
-                if let reticle = focusReticle {
-                    FocusReticleView()
-                        .id(reticle.id)
-                        .position(reticle.point)
-                        .allowsHitTesting(false)
-                }
+                ViewfinderGestureLayer(
+                    cameraImage: { focused.frames.cameraImage },
+                    zoomScale: focused.zoomScale,
+                    currentZoomFactor: focused.zoomFactor,
+                    focusEnabled: focused.supportsFocusPoint,
+                    onFocusTap: onFocusTap,
+                    onDoubleTap: onToggleFocusedCamera,
+                    onZoomChange: onZoomChange)
             }
-            .onPreferenceChange(FocusedPreviewSizeKey.self) { focusedPreviewSize = $0 }
+            .ignoresSafeArea()
         } else {
             // No camera focused yet (all reconnecting, or none linked).
             Rectangle()
@@ -366,22 +355,6 @@ struct MulticamView: View {
                         .foregroundColor(.white.opacity(0.5)))
                 .ignoresSafeArea()
         }
-    }
-
-    /// Maps a preview tap into a normalized upright image point and, if it
-    /// landed on the image (not the letterbox), shows the reticle and forwards
-    /// it. Same `FocusPointMapping` + reticle the 1:1 monitor uses.
-    private func handleFocusTap(at location: CGPoint, lane: CameraLane) {
-        guard let image = lane.frames.cameraImage,
-              let normalized = FocusPointMapping.normalizedImagePoint(
-                tap: location, viewSize: focusedPreviewSize, imageSize: image.size)
-        else { return }
-        let reticle = FocusReticle(point: location)
-        focusReticle = reticle
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-            if focusReticle?.id == reticle.id { focusReticle = nil }
-        }
-        onFocusTap(normalized)
     }
 
     /// The camera strip — multicam's one added element. Thumbnails of the other
@@ -690,11 +663,4 @@ struct RigTrayPanel: View {
             onAutomaticVideoQuality()
         }
     }
-}
-
-/// The focused viewfinder's rendered size, for mapping a tap into
-/// normalized image coordinates.
-private struct FocusedPreviewSizeKey: PreferenceKey {
-    static var defaultValue: CGSize = .zero
-    static func reduce(value: inout CGSize, nextValue: () -> CGSize) { value = nextValue() }
 }

--- a/RemoteCam/MulticamView.swift
+++ b/RemoteCam/MulticamView.swift
@@ -122,10 +122,20 @@ struct MulticamView: View {
         .padding(.bottom, 8)
     }
 
-    /// Back (leading) · focused link + camera chip · Spacer · flash/torch/tray.
-    /// The same slots as the monitor's `topBar`; the rig tray takes the
-    /// settings glyph's place.
+    /// Back (leading) · focused link + camera chip · Spacer · flash/torch/tray,
+    /// with the recording timecode centered over it all — the same slots as
+    /// the monitor's `topBar`; the rig tray takes the settings glyph's place.
     private var topBar: some View {
+        ZStack {
+            if viewModel.isRecording {
+                RecordingTimer(startTime: viewModel.recordingStartTime,
+                               isRecording: viewModel.isRecording)
+            }
+            topBarControls
+        }
+    }
+
+    private var topBarControls: some View {
         HStack(spacing: 0) {
             GlassCircleButton(systemImage: "chevron.backward",
                               size: 44, glyphSize: 22,

--- a/RemoteCam/MulticamView.swift
+++ b/RemoteCam/MulticamView.swift
@@ -337,8 +337,8 @@ struct MulticamView: View {
                 LiveFrameView(frames: focused.frames, aspectRatio: .sixteenNine)
                 ViewfinderGestureLayer(
                     cameraImage: { focused.frames.cameraImage },
-                    zoomScale: focused.zoomScale,
-                    currentZoomFactor: focused.zoomFactor,
+                    zoomScale: { focused.zoomScale },
+                    currentZoomFactor: { focused.zoomFactor },
                     focusEnabled: focused.supportsFocusPoint,
                     onFocusTap: onFocusTap,
                     onDoubleTap: onToggleFocusedCamera,

--- a/RemoteCam/MulticamView.swift
+++ b/RemoteCam/MulticamView.swift
@@ -37,17 +37,19 @@ struct MulticamView: View {
     /// Retry a lane's failed footage collection.
     let onRetryCollection: (CameraLane) -> Void
     /// Flip the focused camera front/back (per-camera framing).
-    let onToggleFocusedCamera: () -> Void
-    /// Torch / flash on the focused camera (per-camera framing).
-    let onToggleTorch: () -> Void
-    let onToggleFlash: () -> Void
+    /// Per-camera commands carry the lane they were rendered for — routing is
+    /// a parameter of the command, never a stored register.
+    let onFlipCamera: (CameraLane) -> Void
+    /// Torch / flash on the named camera (per-camera framing).
+    let onToggleTorch: (CameraLane) -> Void
+    let onToggleFlash: (CameraLane) -> Void
     /// Disconnect one camera from the rig (long-press → EndSession to it).
     let onDisconnectCamera: (CameraLane) -> Void
-    /// Zoom the focused camera (per-camera framing; throttled by the host).
-    let onZoomChange: (CGFloat) -> Void
-    /// Tap-to-focus on the focused camera (normalized upright coords; the host
+    /// Zoom the named camera (per-camera framing; throttled by the host).
+    let onZoomChange: (CameraLane, CGFloat) -> Void
+    /// Tap-to-focus on the named camera (normalized upright coords; the host
     /// gates on the IAP, the controller on the peer's advertised support).
-    let onFocusTap: (CGPoint) -> Void
+    let onFocusTap: (CameraLane, CGPoint) -> Void
     /// Leave the director screen, back to the scanner (links stay up; the
     /// scanner re-arms and re-selects the still-connected cameras).
     let onBack: () -> Void
@@ -153,8 +155,8 @@ struct MulticamView: View {
                            isTorchEnabled: viewModel.focusedTorchOn,
                            isTorchButtonEnabled: viewModel.focusedTorchEnabled,
                            isTrayOpen: viewModel.showingRigTray,
-                           onToggleFlash: onToggleFlash,
-                           onToggleTorch: onToggleTorch,
+                           onToggleFlash: withFocused(onToggleFlash),
+                           onToggleTorch: withFocused(onToggleTorch),
                            onToggleTray: { viewModel.showingRigTray = true })
                 .equatable()
         }
@@ -225,7 +227,7 @@ struct MulticamView: View {
             activeDeviceID: nil,
             isEnabled: viewModel.focusedCameraCanFlip,
             isSwitching: false,
-            onToggleCamera: onToggleFocusedCamera,
+            onToggleCamera: withFocused(onFlipCamera),
             onSelectCameraDevice: { _ in })
             .equatable()
 
@@ -245,11 +247,17 @@ struct MulticamView: View {
     /// 1:1 monitor does.
     @ViewBuilder
     private var focusedZoomPill: some View {
-        if viewModel.displayMode == .focus && viewModel.showsFocusedZoomPill {
+        if viewModel.displayMode == .focus && viewModel.showsFocusedZoomPill,
+           let focused = viewModel.focusedLane {
             ZoomPill(scale: viewModel.focusedZoomScale,
                      currentZoomFactor: viewModel.focusedZoomFactor,
-                     onZoomChange: onZoomChange)
+                     onZoomChange: { onZoomChange(focused, $0) })
         }
+    }
+
+    /// Bind a per-camera action to the lane the control was rendered for.
+    private func withFocused(_ action: @escaping (CameraLane) -> Void) -> () -> Void {
+        { if let focused = viewModel.focusedLane { action(focused) } }
     }
 
     /// The grid toggle occupies the monitor's gallery slot. Shown only with
@@ -350,9 +358,9 @@ struct MulticamView: View {
                     zoomScale: { focused.zoomScale },
                     currentZoomFactor: { focused.zoomFactor },
                     focusEnabled: focused.supportsFocusPoint,
-                    onFocusTap: onFocusTap,
-                    onDoubleTap: onToggleFocusedCamera,
-                    onZoomChange: onZoomChange)
+                    onFocusTap: { onFocusTap(focused, $0) },
+                    onDoubleTap: { onFlipCamera(focused) },
+                    onZoomChange: { onZoomChange(focused, $0) })
             }
             .ignoresSafeArea()
         } else {

--- a/RemoteCam/MulticamViewController.swift
+++ b/RemoteCam/MulticamViewController.swift
@@ -54,7 +54,10 @@ public final class MulticamViewController: UIViewController {
             onFocusLane: { [weak self] lane in self?.controller.setFocusedPeer(lane.peerID) },
             onShutter: { [weak self] in self?.triggerShutter() },
             onToggleMode: { [weak self] in
-                guard let self, !self.viewModel.isRecording else { return }
+                // The mode is frozen while a shot is in play — recording,
+                // collecting acks, or counting down. What you armed is what fires.
+                guard let self, !self.viewModel.isRecording, !self.viewModel.isCapturing,
+                      self.viewModel.rigSettings.countdown == nil else { return }
                 self.viewModel.mode = self.viewModel.mode == .photo ? .video : .photo
             },
             onAddCamera: { [weak self] in self?.handleAddCameraTapped() },
@@ -212,9 +215,10 @@ extension MulticamViewController: MulticamDisplay {
         for lane in created { wire(lane) }
     }
 
-    func applyShutterState(capturing: Bool, recording: Bool) {
+    func applyShutterState(capturing: Bool, recording: Bool, recordingStartTime: Date?) {
         viewModel.isCapturing = capturing
         viewModel.isRecording = recording
+        viewModel.recordingStartTime = recordingStartTime
     }
 
     func applyAvailablePeers(_ peers: [MCPeerID]) {

--- a/RemoteCam/MulticamViewController.swift
+++ b/RemoteCam/MulticamViewController.swift
@@ -81,12 +81,12 @@ public final class MulticamViewController: UIViewController {
                     hdr: on ? .on : .off)
             },
             onRetryCollection: { [weak self] lane in self?.controller.retryCollection(for: lane.peerID) },
-            onToggleFocusedCamera: { [weak self] in self?.controller.toggleFocusedCamera() },
-            onToggleTorch: { [weak self] in self?.controller.toggleTorch() },
-            onToggleFlash: { [weak self] in self?.controller.toggleFlash() },
+            onFlipCamera: { [weak self] lane in self?.controller.flipCamera(lane.peerID) },
+            onToggleTorch: { [weak self] lane in self?.controller.toggleTorch(on: lane.peerID) },
+            onToggleFlash: { [weak self] lane in self?.controller.toggleFlash(on: lane.peerID) },
             onDisconnectCamera: { [weak self] lane in self?.controller.disconnectCamera(lane.peerID) },
-            onZoomChange: { [weak self] factor in self?.handleZoomChange(factor) },
-            onFocusTap: { [weak self] point in self?.handleFocusTap(point) },
+            onZoomChange: { [weak self] lane, factor in self?.handleZoomChange(factor, on: lane.peerID) },
+            onFocusTap: { [weak self] lane, point in self?.handleFocusTap(point, on: lane.peerID) },
             onBack: { [weak self] in self?.navigationController?.popViewController(animated: true) })
         hosting = embedSwiftUIView(multicamView)
 
@@ -124,16 +124,16 @@ public final class MulticamViewController: UIViewController {
         }
     }
 
-    /// Tap-to-focus on the focused camera. Gated behind its own entitlement
-    /// (mirrors the 1:1); a locked user is routed to the paywall. The
-    /// controller additionally drops the command if the focused peer never
-    /// advertised focus support.
-    private func handleFocusTap(_ point: CGPoint) {
+    /// Tap-to-focus on the camera the tap was rendered over. Gated behind its
+    /// own entitlement (mirrors the 1:1); a locked user is routed to the
+    /// paywall. The controller additionally drops the command if that peer
+    /// never advertised focus support.
+    private func handleFocusTap(_ point: CGPoint, on peer: MCPeerID) {
         guard StoreManager.shared.hasTapToFocusFeature() else {
             showPaywall()
             return
         }
-        controller.focusFocusedCamera(x: Float(point.x), y: Float(point.y))
+        controller.focusCamera(peer, x: Float(point.x), y: Float(point.y))
     }
 
     /// Reuse the existing Settings/paywall sheet — no bespoke multicam paywall.
@@ -152,18 +152,20 @@ public final class MulticamViewController: UIViewController {
         }
     }
 
-    /// Throttled zoom to the focused camera, the same leading+trailing pattern
-    /// the 1:1 monitor uses so a drag never floods the wire.
-    private func handleZoomChange(_ factor: CGFloat) {
+    /// Throttled zoom, the same leading+trailing pattern the 1:1 monitor uses
+    /// so a drag never floods the wire. The target camera rides through the
+    /// throttle with the value — the trailing edge lands on the camera the
+    /// drag was on, whatever is focused by the time it fires.
+    private func handleZoomChange(_ factor: CGFloat, on peer: MCPeerID) {
         switch zoomThrottle.update(value: Double(factor), now: Date()) {
         case .sendNow:
-            controller.setZoom(factor)
+            controller.setZoom(factor, on: peer)
         case .scheduleTrailing:
             trailingZoomTimer?.invalidate()
             trailingZoomTimer = Timer.scheduledTimer(withTimeInterval: zoomThrottle.interval,
                                                      repeats: false) { [weak self] _ in
                 guard let self, let pending = self.zoomThrottle.fireTrailing(now: Date()) else { return }
-                self.controller.setZoom(CGFloat(pending))
+                self.controller.setZoom(CGFloat(pending), on: peer)
             }
         }
     }

--- a/RemoteCam/MulticamViewModel.swift
+++ b/RemoteCam/MulticamViewModel.swift
@@ -67,10 +67,15 @@ final class CameraLane: ObservableObject, Identifiable {
 final class MulticamViewModel: ObservableObject {
     @Published private(set) var lanes: [CameraLane] = []
     @Published var interfaceOrientation: UIInterfaceOrientation = .portrait
-    /// A synced photo is in flight — drives the shutter's activity ring.
+    /// A synced photo or recording start is in flight — the shutter's activity
+    /// ring, shown until every camera has answered.
     @Published var isCapturing: Bool = false
-    /// The rig is recording — the shutter becomes a stop button.
+    /// Every target camera committed and the rig is recording — the shutter
+    /// becomes a stop button and the timecode counts.
     @Published var isRecording: Bool = false
+    /// When the rig actually started rolling — drives the classic
+    /// `RecordingTimer` in the top bar. Nil unless recording.
+    @Published var recordingStartTime: Date?
     /// Photo vs video shutter mode.
     @Published var mode: MonitorMode = .photo
     /// Focus (viewfinder + strip) vs grid (monitor wall) layout.

--- a/RemoteCam/MulticamViewModel.swift
+++ b/RemoteCam/MulticamViewModel.swift
@@ -35,6 +35,7 @@ final class CameraLane: ObservableObject, Identifiable {
     var needsQualityRematch: Bool { info.needsQualityRematch }
     var collection: CameraLink.LaneCollectionState { info.collection }
     var canFlipCamera: Bool { info.canFlipCamera }
+    var supportsFocusPoint: Bool { info.supportsFocusPoint }
     var zoomFactor: CGFloat { info.zoomFactor }
     var zoomScale: ZoomScale {
         ZoomScale(stops: info.zoomStops,

--- a/RemoteCam/ViewfinderGestureLayer.swift
+++ b/RemoteCam/ViewfinderGestureLayer.swift
@@ -25,9 +25,11 @@ struct ViewfinderGestureLayer: View {
     /// Read at tap time: the live frame whose pixel size maps the tap into
     /// normalized image space (nil while no frame has arrived — taps ignored).
     let cameraImage: () -> UIImage?
-    /// The camera's zoom model, for pinch (same values the zoom pill uses).
-    let zoomScale: ZoomScale
-    let currentZoomFactor: CGFloat
+    /// Read at gesture time (not captured at render), so a pinch always starts
+    /// from the camera's current factor and scale — the same values the zoom
+    /// pill uses.
+    let zoomScale: () -> ZoomScale
+    let currentZoomFactor: () -> CGFloat
     /// Whether single-tap focus is offered at all. The director turns this off
     /// when the focused camera can't focus at a point, so the user gets no
     /// reticle promising something the camera won't do — and a free user isn't
@@ -66,10 +68,10 @@ struct ViewfinderGestureLayer: View {
                     MagnificationGesture()
                         .onChanged { value in
                             if zoomAtGestureStart == nil {
-                                zoomAtGestureStart = currentZoomFactor
+                                zoomAtGestureStart = currentZoomFactor()
                             }
                             let start = zoomAtGestureStart!
-                            onZoomChange(zoomScale.pinched(from: start, magnification: value))
+                            onZoomChange(zoomScale().pinched(from: start, magnification: value))
                         }
                         .onEnded { _ in
                             zoomAtGestureStart = nil

--- a/RemoteCam/ViewfinderGestureLayer.swift
+++ b/RemoteCam/ViewfinderGestureLayer.swift
@@ -1,0 +1,152 @@
+//
+//  ViewfinderGestureLayer.swift
+//  RemoteShutter
+//
+//  Copyright © 2026 Security Union LLC. All rights reserved.
+//
+
+import SwiftUI
+import UIKit
+
+/// The viewfinder's touch surface, shared by the 1:1 monitor and the multicam
+/// director: single tap focuses (mapped through `FocusPointMapping`, reticle
+/// under the finger), double tap flips the camera, pinch zooms. The screen
+/// supplies routing through callbacks — on the 1:1 monitor they address *the*
+/// camera, on the director the *focused* camera — while this layer owns the
+/// gesture mechanics, the tap→image mapping, and the reticle, so the two
+/// screens cannot drift apart.
+///
+/// Place it inside the ZStack that draws the live frame, and apply
+/// `ignoresSafeArea` to that ZStack as a whole: the gesture location, the
+/// measured size, and the reticle then share one coordinate space. Keep it
+/// BELOW the chrome so a tap on a control is never stolen as a focus tap.
+struct ViewfinderGestureLayer: View {
+
+    /// Read at tap time: the live frame whose pixel size maps the tap into
+    /// normalized image space (nil while no frame has arrived — taps ignored).
+    let cameraImage: () -> UIImage?
+    /// The camera's zoom model, for pinch (same values the zoom pill uses).
+    let zoomScale: ZoomScale
+    let currentZoomFactor: CGFloat
+    /// Whether single-tap focus is offered at all. The director turns this off
+    /// when the focused camera can't focus at a point, so the user gets no
+    /// reticle promising something the camera won't do — and a free user isn't
+    /// routed to the paywall for a feature that can't work here.
+    let focusEnabled: Bool
+    /// A tap landed on the image (not the letterbox), in normalized upright
+    /// image coordinates, origin top-left.
+    let onFocusTap: (CGPoint) -> Void
+    let onDoubleTap: () -> Void
+    let onZoomChange: (CGFloat) -> Void
+
+    @State private var viewSize: CGSize = .zero
+    @State private var focusReticle: FocusReticle?
+    @State private var zoomAtGestureStart: CGFloat?
+
+    var body: some View {
+        ZStack {
+            // Double tap toggles the camera; a single tap focuses (simultaneous
+            // so the reticle is instant — an exclusive gesture would stall it
+            // for the double-tap window); pinch zooms. The translation guard
+            // keeps drags and pinches from focusing.
+            Color.clear
+                .contentShape(Rectangle())
+                .onTapGesture(count: 2) {
+                    onDoubleTap()
+                }
+                .simultaneousGesture(
+                    DragGesture(minimumDistance: 0)
+                        .onEnded { value in
+                            if abs(value.translation.width) < 10, abs(value.translation.height) < 10 {
+                                handleFocusTap(at: value.location)
+                            }
+                        }
+                )
+                .simultaneousGesture(
+                    MagnificationGesture()
+                        .onChanged { value in
+                            if zoomAtGestureStart == nil {
+                                zoomAtGestureStart = currentZoomFactor
+                            }
+                            let start = zoomAtGestureStart!
+                            onZoomChange(zoomScale.pinched(from: start, magnification: value))
+                        }
+                        .onEnded { _ in
+                            zoomAtGestureStart = nil
+                        }
+                )
+
+            // Drawn in the same coordinate space the tap was measured in.
+            // Non-interactive so it never eats a subsequent tap.
+            if let reticle = focusReticle {
+                FocusReticleView()
+                    .id(reticle.id)
+                    .position(reticle.point)
+                    .allowsHitTesting(false)
+            }
+        }
+        .background(
+            GeometryReader { geo in
+                Color.clear.preference(key: ViewfinderSizeKey.self, value: geo.size)
+            }
+        )
+        .onPreferenceChange(ViewfinderSizeKey.self) { viewSize = $0 }
+    }
+
+    /// Maps a tap into a normalized image point and, if it landed on the image
+    /// (not the letterbox), shows the reticle and forwards it to the screen.
+    private func handleFocusTap(at location: CGPoint) {
+        guard focusEnabled,
+              let image = cameraImage(),
+              let normalized = FocusPointMapping.normalizedImagePoint(
+                tap: location, viewSize: viewSize, imageSize: image.size)
+        else { return }
+        let reticle = FocusReticle(point: location)
+        focusReticle = reticle
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            if focusReticle?.id == reticle.id { focusReticle = nil }
+        }
+        onFocusTap(normalized)
+    }
+}
+
+/// One tap-to-focus reticle: its view-space position plus an identity so a new
+/// tap re-instantiates `FocusReticleView` and replays its animation.
+struct FocusReticle: Equatable {
+    let id = UUID()
+    let point: CGPoint
+}
+
+/// Measures the viewfinder's size so a tap can be mapped to a normalized image
+/// point. A preference key avoids mutating `@State` during layout.
+private struct ViewfinderSizeKey: PreferenceKey {
+    static var defaultValue: CGSize = .zero
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+        let next = nextValue()
+        if next != .zero { value = next }
+    }
+}
+
+/// The animated focus square: a yellow reticle that pulses in and fades. Purely
+/// local tap feedback — the focus command travels separately.
+struct FocusReticleView: View {
+    @State private var scale: CGFloat = 1.25
+    @State private var opacity: Double = 0
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 6)
+            .stroke(Color.yellow, lineWidth: 1.5)
+            .frame(width: 78, height: 78)
+            .scaleEffect(scale)
+            .opacity(opacity)
+            .onAppear {
+                withAnimation(.easeOut(duration: 0.12)) {
+                    scale = 1.0
+                    opacity = 1
+                }
+                withAnimation(.easeIn(duration: 0.2).delay(0.35)) {
+                    opacity = 0
+                }
+            }
+    }
+}

--- a/RemoteCamTests/MulticamControllerTests.swift
+++ b/RemoteCamTests/MulticamControllerTests.swift
@@ -634,6 +634,92 @@ final class MulticamControllerTests: XCTestCase {
         XCTAssertEqual(Set(stops.flatMap(\.peers)), [camA, camB])
     }
 
+    /// Stopping never waits on a camera the director already knows is gone:
+    /// the dead lane settles at stop time and the rig resolves on the live
+    /// lanes' acks alone — no 3s timeout ride.
+    func testStopDoesNotWaitForADeadCamerasAck() async {
+        let (controller, transport, _) = await makeController(peers: [camA, camB])
+        await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)
+        await controller.seedLaneForTesting(camB, supportsMulticam: true, offsetMillis: 0)
+
+        controller.startRecording()
+        await controller.waitForIdle()
+        let recID = await controller.startingStateForTesting()!.id
+        controller.didReceiveMessage(
+            RemoteCmd.ScheduledRecordingAck(captureId: recID, isStop: false), from: camA)
+        controller.didReceiveMessage(
+            RemoteCmd.ScheduledRecordingAck(captureId: recID, isStop: false), from: camB)
+        await controller.waitForIdle()
+
+        controller.peerDidDisconnect(camB)
+        await controller.waitForIdle()
+        transport.sentMessages.removeAll()
+
+        controller.stopRecording()
+        await controller.waitForIdle()
+        // The stop still goes to the dead lane (its camera ends the clip the
+        // moment it reconnects), but only the live lane is awaited.
+        let stops = sent(transport, RemoteCmd.ScheduledStopRecording.self)
+        XCTAssertEqual(Set(stops.flatMap(\.peers)), [camA, camB])
+        let stopping = await controller.stoppingStateForTesting()
+        XCTAssertEqual(stopping?.remaining, 1, "only the live camera is awaited")
+
+        controller.didReceiveMessage(
+            RemoteCmd.ScheduledRecordingAck(captureId: stopping!.id, isStop: true), from: camA)
+        await controller.waitForIdle()
+        let after = await controller.stoppingStateForTesting()
+        XCTAssertNil(after, "resolved on the live ack alone — no timeout ride")
+    }
+
+    /// A camera dying inside the stop-ack window settles immediately too.
+    func testCameraDyingDuringStopWindowSettlesImmediately() async {
+        let (controller, _, _) = await makeController(peers: [camA, camB])
+        await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)
+        await controller.seedLaneForTesting(camB, supportsMulticam: true, offsetMillis: 0)
+
+        controller.startRecording()
+        await controller.waitForIdle()
+        let recID = await controller.startingStateForTesting()!.id
+        controller.didReceiveMessage(
+            RemoteCmd.ScheduledRecordingAck(captureId: recID, isStop: false), from: camA)
+        controller.didReceiveMessage(
+            RemoteCmd.ScheduledRecordingAck(captureId: recID, isStop: false), from: camB)
+        await controller.waitForIdle()
+
+        controller.stopRecording()
+        await controller.waitForIdle()
+        let stopID = await controller.stoppingStateForTesting()!.id
+        controller.didReceiveMessage(
+            RemoteCmd.ScheduledRecordingAck(captureId: stopID, isStop: true), from: camA)
+        controller.peerDidDisconnect(camB) // dies inside the window
+        await controller.waitForIdle()
+
+        let stopping = await controller.stoppingStateForTesting()
+        let recording = await controller.recordingStateForTesting()
+        XCTAssertNil(stopping)
+        XCTAssertNil(recording, "back to monitoring without waiting out the timeout")
+    }
+
+    /// Same smartness for photos: a lane dying in the ack window is settled as
+    /// failed on the spot, not waited on.
+    func testCameraDyingDuringPhotoWindowSettlesImmediately() async {
+        let (controller, _, _) = await makeController(peers: [camA, camB])
+        await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)
+        await controller.seedLaneForTesting(camB, supportsMulticam: true, offsetMillis: 0)
+
+        controller.capturePhoto()
+        await controller.waitForIdle()
+        let captureID = await controller.captureStateForTesting()!.id
+        controller.didReceiveMessage(RemoteCmd.ScheduledCaptureAck(captureId: captureID), from: camA)
+        controller.peerDidDisconnect(camB)
+        await controller.waitForIdle()
+
+        let capture = await controller.captureStateForTesting()
+        XCTAssertNil(capture, "the shot settles on the live ack + the dead lane")
+        let outB = await controller.captureOutcomeForTesting(camB)
+        XCTAssertEqual(outB, .failed)
+    }
+
     func testStopUnsticksWhenNothingIsRolling() async {
         let (controller, _, _) = await makeController(peers: [camA, camB])
         await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)

--- a/RemoteCamTests/MulticamControllerTests.swift
+++ b/RemoteCamTests/MulticamControllerTests.swift
@@ -978,6 +978,19 @@ final class MulticamControllerTests: XCTestCase {
             supportsFocusPoint: supportsFocus, supportsMulticam: true, error: nil)
     }
 
+    /// The lane snapshot projects `supportsFocusPoint`, so the viewfinder can
+    /// withhold the focus tap (no reticle, no paywall) for a camera that can't.
+    func testLaneProjectsSupportsFocusPoint() async {
+        let (controller, _, _) = await makeController(peers: [camA, camB])
+        controller.didReceiveMessage(focusCaps(supportsFocus: true), from: camA)
+        controller.didReceiveMessage(focusCaps(supportsFocus: false), from: camB)
+        await controller.waitForIdle()
+
+        let lanes = await controller.lanesForTesting()
+        XCTAssertEqual(lanes.first { $0.peerID == camA }?.supportsFocusPoint, true)
+        XCTAssertEqual(lanes.first { $0.peerID == camB }?.supportsFocusPoint, false)
+    }
+
     func testFocusGoesOnlyToTheFocusedCameraWithMappedCoords() async {
         let (controller, transport, _) = await makeController(peers: [camA, camB])
         controller.didReceiveMessage(focusCaps(supportsFocus: true), from: camA)

--- a/RemoteCamTests/MulticamControllerTests.swift
+++ b/RemoteCamTests/MulticamControllerTests.swift
@@ -15,14 +15,16 @@ private final class FakeMulticamDisplay: MulticamDisplay, @unchecked Sendable {
     var lastLanes: [MulticamLaneInfo] = []
     var capturing = false
     var recording = false
+    var recordingStartTime: Date?
     var availablePeers: [MCPeerID] = []
     var rigSettings: RigSettingsSnapshot?
     var didExit = false
 
     func applyLanes(_ lanes: [MulticamLaneInfo]) { lastLanes = lanes }
-    func applyShutterState(capturing: Bool, recording: Bool) {
+    func applyShutterState(capturing: Bool, recording: Bool, recordingStartTime: Date?) {
         self.capturing = capturing
         self.recording = recording
+        self.recordingStartTime = recordingStartTime
     }
     func applyAvailablePeers(_ peers: [MCPeerID]) { availablePeers = peers }
     func applyRigSettings(_ settings: RigSettingsSnapshot) { rigSettings = settings }
@@ -417,7 +419,7 @@ final class MulticamControllerTests: XCTestCase {
         }
 
         // Mark both rolling so stopRecording targets them.
-        let recID = await controller.recordingStateForTesting()?.id
+        let recID = await controller.startingStateForTesting()?.id
         controller.didReceiveMessage(RemoteCmd.ScheduledRecordingAck(captureId: recID!, isStop: false), from: camA)
         controller.didReceiveMessage(RemoteCmd.ScheduledRecordingAck(captureId: recID!, isStop: false), from: camB)
         await controller.waitForIdle()
@@ -448,10 +450,17 @@ final class MulticamControllerTests: XCTestCase {
 
         controller.startRecording()
         await controller.waitForIdle()
-        let recID = await controller.recordingStateForTesting()?.id
+        // All-or-nothing: collecting acks is not recording yet.
+        let recID = await controller.startingStateForTesting()?.id
         XCTAssertNotNil(recID)
+        var recording = await controller.recordingStateForTesting()
+        XCTAssertNil(recording, "no REC until every target has acked")
 
         controller.didReceiveMessage(RemoteCmd.ScheduledRecordingAck(captureId: recID!, isStop: false), from: camA)
+        await controller.waitForIdle()
+        recording = await controller.recordingStateForTesting()
+        XCTAssertNil(recording, "one ack of two is still in-flight")
+
         controller.didReceiveMessage(RemoteCmd.ScheduledRecordingAck(captureId: recID!, isStop: false), from: camB)
         await controller.waitForIdle()
 
@@ -459,9 +468,11 @@ final class MulticamControllerTests: XCTestCase {
         let recB = await controller.isRecordingForTesting(camB)
         XCTAssertTrue(recA)
         XCTAssertTrue(recB)
-        // Still recording (all start acks in, remaining 0).
+        // Every target committed: the rig is rolling, with a start time.
         let stillRecording = await controller.recordingStateForTesting()
         XCTAssertEqual(stillRecording?.remaining, 0)
+        let startTime = await controller.recordingStartTimeForTesting()
+        XCTAssertNotNil(startTime)
 
         // Stop resolves back to monitoring.
         controller.stopRecording()
@@ -476,6 +487,241 @@ final class MulticamControllerTests: XCTestCase {
         XCTAssertNil(stoppingAfter, "back to monitoring")
         let recAafter = await controller.isRecordingForTesting(camA)
         XCTAssertFalse(recAafter)
+    }
+
+    // MARK: - All-or-nothing recording protocol
+
+    /// One refusal voids the whole take: stop goes to EVERY target (even the
+    /// one whose ok-ack is already in), and the rig returns to monitoring.
+    func testStartNackAbortsTheWholeTake() async {
+        let (controller, transport, _) = await makeController(peers: [camA, camB])
+        await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)
+        await controller.seedLaneForTesting(camB, supportsMulticam: true, offsetMillis: 0)
+
+        controller.startRecording()
+        await controller.waitForIdle()
+        let recID = await controller.startingStateForTesting()!.id
+        transport.sentMessages.removeAll()
+
+        controller.didReceiveMessage(
+            RemoteCmd.ScheduledRecordingAck(captureId: recID, isStop: false), from: camA)
+        controller.didReceiveMessage(
+            RemoteCmd.ScheduledRecordingAck(captureId: recID, isStop: false,
+                                            error: NSError(domain: "late", code: 1)), from: camB)
+        await controller.waitForIdle()
+
+        let stops = sent(transport, RemoteCmd.ScheduledStopRecording.self)
+        XCTAssertEqual(Set(stops.flatMap(\.peers)), [camA, camB],
+                       "the abort stops every target, not just the acked ones")
+        let starting = await controller.startingStateForTesting()
+        let recording = await controller.recordingStateForTesting()
+        XCTAssertNil(starting)
+        XCTAssertNil(recording, "the take is void — back to monitoring")
+        let outB = await controller.captureOutcomeForTesting(camB)
+        XCTAssertEqual(outB, .failed, "the lane that broke the take is badged")
+        let recA = await controller.isRecordingForTesting(camA)
+        XCTAssertFalse(recA)
+        let startTime = await controller.recordingStartTimeForTesting()
+        XCTAssertNil(startTime)
+    }
+
+    func testStartAckTimeoutAbortsTheTake() async {
+        let (controller, transport, _) = await makeController(peers: [camA, camB])
+        await controller.setCaptureAckTimeout(0.1)
+        await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)
+        await controller.seedLaneForTesting(camB, supportsMulticam: true, offsetMillis: 0)
+
+        controller.startRecording()
+        await controller.waitForIdle()
+        let recID = await controller.startingStateForTesting()!.id
+        controller.didReceiveMessage(
+            RemoteCmd.ScheduledRecordingAck(captureId: recID, isStop: false), from: camA)
+        await controller.waitForIdle()
+        transport.sentMessages.removeAll()
+
+        try? await Task.sleep(nanoseconds: 300_000_000) // camB stays silent
+        await controller.waitForIdle()
+
+        let stops = sent(transport, RemoteCmd.ScheduledStopRecording.self)
+        XCTAssertEqual(Set(stops.flatMap(\.peers)), [camA, camB])
+        let recording = await controller.recordingStateForTesting()
+        XCTAssertNil(recording, "silence past the deadline voids the take")
+        let outB = await controller.captureOutcomeForTesting(camB)
+        XCTAssertEqual(outB, .failed)
+    }
+
+    func testTargetDisconnectDuringStartAborts() async {
+        let (controller, transport, _) = await makeController(peers: [camA, camB])
+        await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)
+        await controller.seedLaneForTesting(camB, supportsMulticam: true, offsetMillis: 0)
+
+        controller.startRecording()
+        await controller.waitForIdle()
+        transport.sentMessages.removeAll()
+
+        controller.peerDidDisconnect(camB)
+        await controller.waitForIdle()
+
+        let starting = await controller.startingStateForTesting()
+        XCTAssertNil(starting, "losing a target during the ack window aborts")
+        XCTAssertFalse(sent(transport, RemoteCmd.ScheduledStopRecording.self).isEmpty)
+        let outB = await controller.captureOutcomeForTesting(camB)
+        XCTAssertEqual(outB, .failed)
+    }
+
+    /// A stale ack from an aborted take must not leak into a newer one.
+    func testStaleStartAckFromAbortedTakeIsIgnored() async {
+        let (controller, _, _) = await makeController(peers: [camA, camB])
+        await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)
+        await controller.seedLaneForTesting(camB, supportsMulticam: true, offsetMillis: 0)
+
+        controller.startRecording()
+        await controller.waitForIdle()
+        let firstID = await controller.startingStateForTesting()!.id
+        controller.startRecording() // second tap = back out of the take
+        await controller.waitForIdle()
+        controller.startRecording() // arm a fresh take
+        await controller.waitForIdle()
+
+        controller.didReceiveMessage(
+            RemoteCmd.ScheduledRecordingAck(captureId: firstID, isStop: false), from: camA)
+        controller.didReceiveMessage(
+            RemoteCmd.ScheduledRecordingAck(captureId: firstID, isStop: false), from: camB)
+        await controller.waitForIdle()
+
+        let starting = await controller.startingStateForTesting()
+        let recording = await controller.recordingStateForTesting()
+        XCTAssertEqual(starting?.remaining, 2, "old take's acks count for nothing")
+        XCTAssertNil(recording)
+    }
+
+    func testStopUnsticksWhenNothingIsRolling() async {
+        let (controller, _, _) = await makeController(peers: [camA, camB])
+        await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)
+        await controller.seedLaneForTesting(camB, supportsMulticam: true, offsetMillis: 0)
+
+        controller.startRecording()
+        await controller.waitForIdle()
+        let recID = await controller.startingStateForTesting()!.id
+        controller.didReceiveMessage(
+            RemoteCmd.ScheduledRecordingAck(captureId: recID, isStop: false), from: camA)
+        controller.didReceiveMessage(
+            RemoteCmd.ScheduledRecordingAck(captureId: recID, isStop: false), from: camB)
+        await controller.waitForIdle()
+
+        // Both rolling lanes get torn out from under the take.
+        controller.removeCamera(camA)
+        controller.removeCamera(camB)
+        await controller.waitForIdle()
+
+        controller.stopRecording()
+        await controller.waitForIdle()
+        let recording = await controller.recordingStateForTesting()
+        XCTAssertNil(recording, "stop with nothing rolling resets to monitoring")
+    }
+
+    // MARK: - Locked countdown targets
+
+    /// The countdown plays only on the cameras that will shoot: a lane that
+    /// isn't ready gets neither ticks nor the capture.
+    func testCountdownTicksOnlyToArmedTargets() async {
+        let (controller, transport, _) = await makeController(peers: [camA, camB])
+        await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)
+        await controller.seedLaneForTesting(camB, supportsMulticam: false, offsetMillis: nil)
+        await controller.setTimerTickInterval(1000)
+        controller.setRigTimer(2)
+        await controller.waitForIdle()
+        transport.sentMessages.removeAll()
+
+        controller.capturePhoto()
+        await controller.waitForIdle()
+        for _ in 0..<2 {
+            await controller.advanceTimerForTesting()
+            await controller.waitForIdle()
+        }
+
+        let ticks = sent(transport, RemoteCmd.TimerCountdown.self)
+        XCTAssertEqual(Set(ticks.flatMap(\.peers)), [camA],
+                       "the non-ready camera never sees a countdown it won't shoot")
+        let captures = sent(transport, RemoteCmd.ScheduledCapture.self)
+        XCTAssertEqual(Set(captures.flatMap(\.peers)), [camA])
+    }
+
+    /// A camera that becomes ready mid-countdown is NOT pulled into the armed
+    /// shot — the set was locked when the countdown started.
+    func testLateReadyCameraIsExcludedFromArmedShot() async {
+        let (controller, transport, _) = await makeController(peers: [camA, camB])
+        await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)
+        await controller.setTimerTickInterval(1000)
+        controller.setRigTimer(2)
+        await controller.waitForIdle()
+        transport.sentMessages.removeAll()
+
+        controller.capturePhoto()
+        await controller.waitForIdle()
+        // camB's capabilities arrive while the rig is counting down.
+        controller.didReceiveMessage(capsWith(full4K), from: camB)
+        await controller.waitForIdle()
+        for _ in 0..<2 {
+            await controller.advanceTimerForTesting()
+            await controller.waitForIdle()
+        }
+
+        let captures = sent(transport, RemoteCmd.ScheduledCapture.self)
+        XCTAssertEqual(Set(captures.flatMap(\.peers)), [camA],
+                       "the shot fires on the set that was armed, nothing else")
+    }
+
+    func testNothingArmsWithoutAReadyCamera() async {
+        let (controller, transport, _) = await makeController(peers: [camA, camB])
+        controller.setRigTimer(3)
+        await controller.waitForIdle()
+        transport.sentMessages.removeAll()
+
+        controller.capturePhoto() // no lane is ready — no countdown, no ticks
+        await controller.waitForIdle()
+
+        let remaining = await controller.countdownRemainingForTesting()
+        XCTAssertNil(remaining)
+        XCTAssertTrue(sent(transport, RemoteCmd.TimerCountdown.self).isEmpty)
+    }
+
+    /// A target dropping mid-countdown shrinks the set; the shot still fires
+    /// on the rest.
+    func testArmedTargetDropShrinksTheShot() async {
+        let (controller, transport, _) = await makeController(peers: [camA, camB])
+        await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)
+        await controller.seedLaneForTesting(camB, supportsMulticam: true, offsetMillis: 0)
+        await controller.setTimerTickInterval(1000)
+        controller.setRigTimer(2)
+        await controller.waitForIdle()
+
+        controller.capturePhoto()
+        await controller.waitForIdle()
+        controller.peerDidDisconnect(camB)
+        await controller.waitForIdle()
+        transport.sentMessages.removeAll()
+        for _ in 0..<2 {
+            await controller.advanceTimerForTesting()
+            await controller.waitForIdle()
+        }
+
+        let captures = sent(transport, RemoteCmd.ScheduledCapture.self)
+        XCTAssertEqual(Set(captures.flatMap(\.peers)), [camA])
+
+        // Settle the shot, then re-arm: the last armed camera dropping cancels
+        // the countdown outright.
+        let captureID = await controller.captureStateForTesting()!.id
+        controller.didReceiveMessage(RemoteCmd.ScheduledCaptureAck(captureId: captureID), from: camA)
+        await controller.waitForIdle()
+        controller.capturePhoto()
+        await controller.waitForIdle()
+        let armed = await controller.countdownRemainingForTesting()
+        XCTAssertNotNil(armed)
+        controller.peerDidDisconnect(camA)
+        await controller.waitForIdle()
+        let remaining = await controller.countdownRemainingForTesting()
+        XCTAssertNil(remaining, "an emptied target set cancels the countdown")
     }
 
     // MARK: - Removal

--- a/RemoteCamTests/MulticamControllerTests.swift
+++ b/RemoteCamTests/MulticamControllerTests.swift
@@ -124,19 +124,61 @@ final class MulticamControllerTests: XCTestCase {
                        "the frame ack must address only the camera that sent the frame")
     }
 
-    // MARK: - Focused-camera commands
+    // MARK: - Per-camera commands (target carried by the command)
 
-    func testPerCameraCommandTargetsOnlyTheFocusedPeer() async {
+    /// Routing is the parameter, not the focus register: a command aimed at
+    /// camB lands on camB even while camA is the focused camera.
+    func testPerCameraCommandTargetsItsParameterNotTheFocusRegister() async {
         let (controller, transport, _) = await makeController(peers: [camA, camB])
-        controller.setFocusedPeer(camB)
+        controller.setFocusedPeer(camA)
         await controller.waitForIdle()
         transport.sentMessages.removeAll()
 
-        await controller.setZoom(2.0)
+        controller.setZoom(2.0, on: camB)
         await controller.waitForIdle()
 
         let zooms = sent(transport, RemoteCmd.SetZoom.self)
         XCTAssertEqual(zooms.map(\.peers), [[camB]])
+    }
+
+    /// Dario's repro: zooming one camera must not unroute the broadcast — a
+    /// following photo AND recording still fan to every ready camera.
+    func testZoomingOneCameraNeverUnroutesTheBroadcast() async {
+        let (controller, transport, _) = await makeController(peers: [camA, camB])
+        await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)
+        await controller.seedLaneForTesting(camB, supportsMulticam: true, offsetMillis: 0)
+        controller.setFocusedPeer(camA)
+        await controller.waitForIdle()
+
+        // A pinch burst on camera A, with its responses coming back.
+        for factor in [2.0, 2.5, 3.0, 3.5] {
+            controller.setZoom(CGFloat(factor), on: camA)
+        }
+        controller.didReceiveMessage(
+            RemoteCmd.SetZoomResp(zoomFactor: 3.5, currentLens: .wideAngle,
+                                  zoomRange: RemoteCmd.ZoomRange(minZoom: 1, maxZoom: 8), error: nil),
+            from: camA)
+        await controller.waitForIdle()
+        transport.sentMessages.removeAll()
+
+        controller.capturePhoto()
+        await controller.waitForIdle()
+        let captures = sent(transport, RemoteCmd.ScheduledCapture.self)
+        XCTAssertEqual(Set(captures.flatMap(\.peers)), [camA, camB],
+                       "the photo still fans to every ready camera after zooming one")
+
+        // Settle the photo, then the same for a recording start.
+        let captureID = await controller.captureStateForTesting()!.id
+        controller.didReceiveMessage(RemoteCmd.ScheduledCaptureAck(captureId: captureID), from: camA)
+        controller.didReceiveMessage(RemoteCmd.ScheduledCaptureAck(captureId: captureID), from: camB)
+        await controller.waitForIdle()
+        transport.sentMessages.removeAll()
+
+        controller.startRecording()
+        await controller.waitForIdle()
+        let starts = sent(transport, RemoteCmd.ScheduledStartRecording.self)
+        XCTAssertEqual(Set(starts.flatMap(\.peers)), [camA, camB],
+                       "the recording start still fans to every ready camera")
     }
 
     // MARK: - Disconnect / reconnect
@@ -1221,7 +1263,7 @@ final class MulticamControllerTests: XCTestCase {
         await controller.waitForIdle()
         transport.sentMessages.removeAll()
 
-        controller.toggleFocusedCamera()
+        controller.flipCamera(camA)
         await controller.waitForIdle()
 
         let flips = sent(transport, RemoteCmd.ToggleCamera.self)
@@ -1259,7 +1301,7 @@ final class MulticamControllerTests: XCTestCase {
         await controller.waitForIdle()
         transport.sentMessages.removeAll()
 
-        controller.toggleFocusedCamera()
+        controller.flipCamera(camA)
         await controller.waitForIdle()
 
         XCTAssertEqual(sent(transport, RemoteCmd.ToggleCamera.self).map(\.peers), [[camA]],
@@ -1275,7 +1317,7 @@ final class MulticamControllerTests: XCTestCase {
         await controller.waitForIdle()
         transport.sentMessages.removeAll()
 
-        controller.toggleFocusedCamera()
+        controller.flipCamera(camA)
         await controller.waitForIdle()
 
         XCTAssertTrue(sent(transport, RemoteCmd.ToggleCamera.self).isEmpty,
@@ -1307,7 +1349,7 @@ final class MulticamControllerTests: XCTestCase {
         await controller.waitForIdle()
         transport.sentMessages.removeAll()
 
-        controller.setZoom(3.0)
+        controller.setZoom(3.0, on: camA)
         await controller.waitForIdle()
 
         let zooms = sent(transport, RemoteCmd.SetZoom.self)
@@ -1370,7 +1412,7 @@ final class MulticamControllerTests: XCTestCase {
         await controller.waitForIdle()
         transport.sentMessages.removeAll()
 
-        controller.focusFocusedCamera(x: 0.25, y: 0.75)
+        controller.focusCamera(camA, x: 0.25, y: 0.75)
         await controller.waitForIdle()
 
         let focuses = sent(transport, RemoteCmd.FocusAtPoint.self)
@@ -1388,7 +1430,7 @@ final class MulticamControllerTests: XCTestCase {
         await controller.waitForIdle()
         transport.sentMessages.removeAll()
 
-        controller.focusFocusedCamera(x: 0.5, y: 0.5)
+        controller.focusCamera(camA, x: 0.5, y: 0.5)
         await controller.waitForIdle()
 
         XCTAssertTrue(sent(transport, RemoteCmd.FocusAtPoint.self).isEmpty,
@@ -1403,7 +1445,7 @@ final class MulticamControllerTests: XCTestCase {
         await controller.waitForIdle()
         transport.sentMessages.removeAll()
 
-        controller.toggleTorch()
+        controller.toggleTorch(on: camA)
         await controller.waitForIdle()
 
         XCTAssertEqual(sent(transport, RemoteCmd.ToggleTorch.self).map(\.peers), [[camA]],

--- a/RemoteCamTests/MulticamControllerTests.swift
+++ b/RemoteCamTests/MulticamControllerTests.swift
@@ -595,6 +595,45 @@ final class MulticamControllerTests: XCTestCase {
         XCTAssertNil(recording)
     }
 
+    /// All-or-nothing governs FORMING a take, never a rolling one: once every
+    /// target has committed, a camera dropping degrades its own lane and
+    /// nothing else — the rig keeps recording, and the eventual stop still
+    /// addresses the missing lane so its clip ends properly on reconnect.
+    func testEstablishedRecordingSurvivesACameraDrop() async {
+        let (controller, transport, _) = await makeController(peers: [camA, camB])
+        await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)
+        await controller.seedLaneForTesting(camB, supportsMulticam: true, offsetMillis: 0)
+
+        controller.startRecording()
+        await controller.waitForIdle()
+        let recID = await controller.startingStateForTesting()!.id
+        controller.didReceiveMessage(
+            RemoteCmd.ScheduledRecordingAck(captureId: recID, isStop: false), from: camA)
+        controller.didReceiveMessage(
+            RemoteCmd.ScheduledRecordingAck(captureId: recID, isStop: false), from: camB)
+        await controller.waitForIdle()
+        transport.sentMessages.removeAll()
+
+        controller.peerDidDisconnect(camB)
+        await controller.waitForIdle()
+
+        let recording = await controller.recordingStateForTesting()
+        XCTAssertNotNil(recording, "the rig keeps rolling through a lane drop")
+        XCTAssertTrue(sent(transport, RemoteCmd.ScheduledStopRecording.self).isEmpty,
+                      "no abort — nothing is stopped")
+        let statusB = await controller.statusForTesting(camB)
+        XCTAssertEqual(statusB, .reconnecting)
+        let recB = await controller.isRecordingForTesting(camB)
+        XCTAssertTrue(recB, "the dropped camera is still rolling on its own")
+
+        // Stop still addresses BOTH rolling lanes, present or not, so the
+        // missing camera's clip is ended the moment it can hear us.
+        controller.stopRecording()
+        await controller.waitForIdle()
+        let stops = sent(transport, RemoteCmd.ScheduledStopRecording.self)
+        XCTAssertEqual(Set(stops.flatMap(\.peers)), [camA, camB])
+    }
+
     func testStopUnsticksWhenNothingIsRolling() async {
         let (controller, _, _) = await makeController(peers: [camA, camB])
         await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)

--- a/RemoteCamTests/MulticamControllerTests.swift
+++ b/RemoteCamTests/MulticamControllerTests.swift
@@ -586,6 +586,63 @@ final class MulticamControllerTests: XCTestCase {
         XCTAssertFalse(camAstillOK)
     }
 
+    /// The tray is the live intersection of the cameras actually in the rig:
+    /// when the camera that was blocking an option leaves, the option unblocks
+    /// on the same pump turn — no manual refresh, no stale copy anywhere.
+    func testCameraDropRecomputesQualityIntersection() async {
+        let (controller, _, display) = await makeController(peers: [camA, camB])
+        controller.didReceiveMessage(capsWith(full4K), from: camA)
+        controller.didReceiveMessage(capsWith(only1080, heif: false, hdr: false), from: camB)
+        await controller.waitForIdle()
+
+        var rig = await controller.rigSettingsSnapshotForTesting()
+        XCTAssertEqual(rig.videoOptions.first { $0.resolution == .uhd4k && $0.frameRate == .fps30 }?.enabled,
+                       false, "camB (1080-only) blocks 4K30")
+        XCTAssertFalse(rig.heifAvailable)
+        XCTAssertFalse(rig.hdrAvailable)
+
+        controller.disconnectCamera(camB)
+        await controller.waitForIdle()
+
+        rig = await controller.rigSettingsSnapshotForTesting()
+        XCTAssertEqual(rig.videoOptions.first { $0.resolution == .uhd4k && $0.frameRate == .fps30 }?.enabled,
+                       true, "with camB gone the intersection is camA alone — 4K30 unblocks")
+        XCTAssertTrue(rig.heifAvailable)
+        XCTAssertTrue(rig.hdrAvailable)
+
+        // And the recomputed snapshot is published to the screen, not just
+        // computable on demand.
+        await MainActor.run { RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.02)) }
+        XCTAssertEqual(display.rigSettings?.videoOptions
+            .first { $0.resolution == .uhd4k && $0.frameRate == .fps30 }?.enabled, true)
+    }
+
+    /// A camera whose version handshake is refused is out of the rig's
+    /// intersection too — its constraints must not linger in the tray.
+    func testVersionRefusedCameraLeavesTheIntersection() async {
+        let (controller, _, _) = await makeController(peers: [camA, camB])
+        controller.didReceiveMessage(capsWith(full4K), from: camA)
+        controller.didReceiveMessage(capsWith(only1080), from: camB)
+        await controller.waitForIdle()
+        var rig = await controller.rigSettingsSnapshotForTesting()
+        XCTAssertEqual(rig.videoOptions.first { $0.resolution == .uhd4k && $0.frameRate == .fps30 }?.enabled, false)
+
+        // camB announces an incompatible app major → refused (status .failed).
+        guard let local = PeerAppCompatibility.localVersion else {
+            return XCTFail("the test host must carry a parseable CFBundleShortVersionString")
+        }
+        controller.didReceiveMessage(
+            RemoteCmd.PeerBecameCamera(bundleVersion: 1,
+                                       shortVersion: "\(local.major + 1).0.0",
+                                       platform: "iPhone"),
+            from: camB)
+        await controller.waitForIdle()
+
+        rig = await controller.rigSettingsSnapshotForTesting()
+        XCTAssertEqual(rig.videoOptions.first { $0.resolution == .uhd4k && $0.frameRate == .fps30 }?.enabled,
+                       true, "a refused camera no longer constrains the rig")
+    }
+
     func testRigTimerCountsDownFansOutAndFiresCapture() async {
         let (controller, transport, _) = await makeController(peers: [camA, camB])
         // Seed offsets so the fired capture takes the scheduled path.
@@ -616,6 +673,84 @@ final class MulticamControllerTests: XCTestCase {
         XCTAssertTrue(ticks.contains { $0.value == 0 })
         XCTAssertFalse(sent(transport, RemoteCmd.ScheduledCapture.self).isEmpty,
                        "expiry fired the synced capture")
+    }
+
+    // MARK: - Countdown cancel (Dario's repro: cancel raced the timer to zero
+    // and the picture fired anyway)
+
+    /// Tapping the shutter while the rig is counting down cancels the countdown
+    /// — the 1:1 monitor's gesture — instead of restarting it or firing.
+    func testShutterTapDuringCountdownCancelsInsteadOfCapturing() async {
+        let (controller, transport, _) = await makeController(peers: [camA, camB])
+        await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)
+        await controller.seedLaneForTesting(camB, supportsMulticam: true, offsetMillis: 0)
+        await controller.setTimerTickInterval(1000)
+        controller.setRigTimer(3)
+        controller.capturePhoto()
+        await controller.waitForIdle()
+        var remaining = await controller.countdownRemainingForTesting()
+        XCTAssertEqual(remaining, 3)
+        transport.sentMessages.removeAll()
+
+        controller.capturePhoto() // second tap = cancel
+        await controller.waitForIdle()
+
+        remaining = await controller.countdownRemainingForTesting()
+        XCTAssertNil(remaining, "the countdown is cancelled, not restarted")
+        // Every camera is told the countdown is off (negative tick clears its
+        // overlay and restores its torch)…
+        let cancels = sent(transport, RemoteCmd.TimerCountdown.self)
+            .compactMap { $0.msg as? RemoteCmd.TimerCountdown }
+            .filter { $0.value < 0 }
+        XCTAssertEqual(cancels.count, 2)
+        // …and nothing is captured, by either the scheduled or fallback path.
+        XCTAssertTrue(sent(transport, RemoteCmd.ScheduledCapture.self).isEmpty)
+        XCTAssertTrue(sent(transport, RemoteCmd.TakePic.self).isEmpty)
+        let capture = await controller.captureStateForTesting()
+        XCTAssertNil(capture)
+    }
+
+    func testShutterTapDuringRecordCountdownCancels() async {
+        let (controller, transport, _) = await makeController(peers: [camA])
+        await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)
+        await controller.setTimerTickInterval(1000)
+        controller.setRigTimer(3)
+        controller.startRecording()
+        await controller.waitForIdle()
+        transport.sentMessages.removeAll()
+
+        controller.startRecording() // second tap = cancel
+        await controller.waitForIdle()
+
+        let remaining = await controller.countdownRemainingForTesting()
+        XCTAssertNil(remaining)
+        XCTAssertTrue(sent(transport, RemoteCmd.ScheduledStartRecording.self).isEmpty)
+        XCTAssertTrue(sent(transport, RemoteCmd.StartRecordingVideo.self).isEmpty)
+        let recording = await controller.recordingStateForTesting()
+        XCTAssertNil(recording)
+    }
+
+    /// The fast-count-to-zero bug: a tick that was already in flight when its
+    /// countdown was cancelled must be inert — it can neither resurrect the old
+    /// countdown nor advance a newer one.
+    func testStaleTickCannotAdvanceANewerCountdown() async {
+        let (controller, transport, _) = await makeController(peers: [camA])
+        await controller.seedLaneForTesting(camA, supportsMulticam: true, offsetMillis: 0)
+        await controller.setTimerTickInterval(1000)
+        controller.setRigTimer(5)
+        controller.capturePhoto() // arm (generation 1)
+        await controller.waitForIdle()
+        controller.capturePhoto() // cancel (generation 2)
+        await controller.waitForIdle()
+        controller.capturePhoto() // re-arm (generation 3)
+        await controller.waitForIdle()
+
+        controller.tell(MCTimerAdvance(generation: 1)) // the late, stale tick
+        await controller.waitForIdle()
+
+        let remaining = await controller.countdownRemainingForTesting()
+        XCTAssertEqual(remaining, 5, "a stale tick must not advance the countdown")
+        XCTAssertTrue(sent(transport, RemoteCmd.ScheduledCapture.self).isEmpty)
     }
 
     func testSetPhotoQualityFansOut() async {

--- a/RemoteCamTests/MulticamViewModelTests.swift
+++ b/RemoteCamTests/MulticamViewModelTests.swift
@@ -17,6 +17,7 @@ final class MulticamViewModelTests: XCTestCase {
 
     private func info(_ peer: MCPeerID, status: CameraLink.Status = .linked,
                       focused: Bool = false, canFlipCamera: Bool = false,
+                      supportsFocusPoint: Bool = false,
                       zoomFactor: CGFloat = 1.0, maxZoomFactor: CGFloat = 10.0,
                       zoomStops: [CGFloat] = [1.0], wideAngleZoomFactor: CGFloat = 1.0,
                       torchOn: Bool = false, flashOn: Bool = false) -> MulticamLaneInfo {
@@ -24,6 +25,7 @@ final class MulticamViewModelTests: XCTestCase {
                          status: status, isFocused: focused, clockOffsetMillis: nil,
                          captureOutcome: nil, isRecording: false, needsQualityRematch: false,
                          collection: .idle, canFlipCamera: canFlipCamera,
+                         supportsFocusPoint: supportsFocusPoint,
                          zoomFactor: zoomFactor, maxZoomFactor: maxZoomFactor,
                          zoomStops: zoomStops, wideAngleZoomFactor: wideAngleZoomFactor,
                          torchOn: torchOn, flashOn: flashOn)

--- a/RemoteCamTests/RigQualityMenuTests.swift
+++ b/RemoteCamTests/RigQualityMenuTests.swift
@@ -61,6 +61,67 @@ final class RigQualityMenuTests: XCTestCase {
         XCTAssertTrue(menu.blockingLanes(resolution: .uhd4k, frameRate: .fps30).isEmpty)
     }
 
+    // MARK: - Set algebra (multicam settings = camA ∩ camB ∩ camC)
+
+    /// The video options a rig of `lanes` offers, as a set for algebra.
+    private func optionSet(_ lanes: [RigQualityMenu.Lane]) -> Set<String> {
+        Set(RigQualityMenu(lanes: lanes).videoOptions()
+            .map { "\($0.resolution.rawValue):\($0.frameRate.rawValue)" })
+    }
+
+    /// The defining property: a three-camera rig's options are exactly the
+    /// set intersection of each camera's own options.
+    func testRigOptionsAreTheSetIntersectionOfEachCamerasOptions() {
+        let camA = lane("A", full4K)
+        let camB = lane("B", [.uhd4k: [.fps24, .fps30], .hd1080p: [.fps24, .fps30, .fps60]])
+        let camC = lane("C", [.hd1080p: [.fps30, .fps60]])
+
+        XCTAssertEqual(
+            optionSet([camA, camB, camC]),
+            optionSet([camA]).intersection(optionSet([camB])).intersection(optionSet([camC])))
+        // Spelled out: only the 1080p rates every camera shares survive.
+        XCTAssertEqual(optionSet([camA, camB, camC]),
+                       optionSet([lane("solo", [.hd1080p: [.fps30, .fps60]])]))
+    }
+
+    /// Intersection is order-independent: the rig's options don't depend on
+    /// which camera joined first.
+    func testIntersectionIsCommutative() {
+        let camA = lane("A", full4K)
+        let camB = lane("B", only1080)
+        let camC = lane("C", [.uhd4k: [.fps30], .hd1080p: [.fps30]])
+        XCTAssertEqual(optionSet([camA, camB, camC]), optionSet([camC, camA, camB]))
+        XCTAssertEqual(optionSet([camA, camB, camC]), optionSet([camB, camC, camA]))
+    }
+
+    /// A camera dropping can only widen (or keep) the rig's options — never
+    /// shrink them. This is what the settings tray must reflect live.
+    func testRemovingACameraNeverShrinksTheOptionSet() {
+        let camA = lane("A", full4K)
+        let camB = lane("B", only1080)
+        let camC = lane("C", [.uhd4k: [.fps30], .hd1080p: [.fps30]])
+        XCTAssertTrue(optionSet([camA, camB, camC]).isSubset(of: optionSet([camA, camB])))
+        XCTAssertTrue(optionSet([camA, camB]).isSubset(of: optionSet([camA])))
+    }
+
+    /// HEIF/HDR are conjunctions: available iff every camera supports them —
+    /// checked over every combination of three cameras.
+    func testHEIFAndHDRAreANDedAcrossThreeCameras() {
+        for mask in 0..<8 {
+            let flags = [mask & 1 != 0, mask & 2 != 0, mask & 4 != 0]
+            let lanes = flags.enumerated().map { idx, flag in
+                lane("Cam \(idx + 1)", only1080, heif: flag, hdr: flag)
+            }
+            let menu = RigQualityMenu(lanes: lanes)
+            let allSupport = flags.allSatisfy { $0 }
+            XCTAssertEqual(menu.supportsHEIF(), allSupport, "HEIF for mask \(mask)")
+            XCTAssertEqual(menu.supportsHDR(), allSupport, "HDR for mask \(mask)")
+            // The blockers are exactly the cameras that can't.
+            XCTAssertEqual(Set(menu.lanesBlockingHEIF()),
+                           Set(flags.enumerated().filter { !$0.element }.map { "Cam \($0.offset + 1)" }))
+        }
+    }
+
     // MARK: - Automatic
 
     func testAutomaticPicksHighestResThenFps() {

--- a/RemoteShutter.xcodeproj/project.pbxproj
+++ b/RemoteShutter.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		06E965402535754800E5A8B3 /* Data+MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E9653D2535754800E5A8B3 /* Data+MD5.swift */; };
 		0A11B22C33D44E55F6070002 /* ZoomScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A11B22C33D44E55F6070001 /* ZoomScale.swift */; };
 		0A11B22C33D44E55F6070004 /* ZoomPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A11B22C33D44E55F6070003 /* ZoomPill.swift */; };
+		0A11B22C33D44E55F6071004 /* ViewfinderGestureLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A11B22C33D44E55F6071003 /* ViewfinderGestureLayer.swift */; };
 		0A11B22C33D44E55F6070006 /* ZoomScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A11B22C33D44E55F6070005 /* ZoomScaleTests.swift */; };
 		1ECFC14E17A9A47D5951E80B /* RemoteCam/WatchSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148A312CF1B445C71094EF0E /* RemoteCam/WatchSessionManager.swift */; };
 		28DAF89E6644742C1F1E47E6 /* FlatBuffers in Frameworks */ = {isa = PBXBuildFile; productRef = 8C0454249B071E09F8788E2E /* FlatBuffers */; };
@@ -345,6 +346,7 @@
 		06FA4AD71BC8B8E9005608E6 /* CocoaLumberjack.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaLumberjack.framework; path = "Pods/../build/Debug-iphoneos/CocoaLumberjack.framework"; sourceTree = "<group>"; };
 		0A11B22C33D44E55F6070001 /* ZoomScale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomScale.swift; sourceTree = "<group>"; };
 		0A11B22C33D44E55F6070003 /* ZoomPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomPill.swift; sourceTree = "<group>"; };
+		0A11B22C33D44E55F6071003 /* ViewfinderGestureLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewfinderGestureLayer.swift; sourceTree = "<group>"; };
 		0A11B22C33D44E55F6070005 /* ZoomScaleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ZoomScaleTests.swift; sourceTree = "<group>"; };
 		0ACB2DA94752BB4E9C4CE461 /* CountdownTimer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CountdownTimer.swift; sourceTree = "<group>"; };
 		0F7C7180B3B581F22EF07350 /* CaptureEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CaptureEngine.swift; sourceTree = "<group>"; };
@@ -671,6 +673,7 @@
 				068DF59A2E3544AD00A49279 /* MonitorView.swift */,
 				0A11B22C33D44E55F6070001 /* ZoomScale.swift */,
 				0A11B22C33D44E55F6070003 /* ZoomPill.swift */,
+				0A11B22C33D44E55F6071003 /* ViewfinderGestureLayer.swift */,
 				06BB79BB2E3884F00094E085 /* CameraProgressOverlayView.swift */,
 				06BB79BE2E3884FA0094E085 /* CameraViewModel.swift */,
 				CAFEBABE0013000000000001 /* CameraPreviewMode.swift */,
@@ -1205,6 +1208,7 @@
 				068DF59D2E3544AD00A49279 /* MonitorView.swift in Sources */,
 				0A11B22C33D44E55F6070002 /* ZoomScale.swift in Sources */,
 				0A11B22C33D44E55F6070004 /* ZoomPill.swift in Sources */,
+				0A11B22C33D44E55F6071004 /* ViewfinderGestureLayer.swift in Sources */,
 				068DF59E2E3544AD00A49279 /* MonitorViewController+SwiftUI.swift in Sources */,
 				068DF59F2E3544AD00A49279 /* MonitorViewModel.swift in Sources */,
 				06B1D80F2536C2330029CCB6 /* UIImage+gif.swift in Sources */,


### PR DESCRIPTION
Fixes Dario's two multicam repros. Stacked on #205 (base: `fix-scanner-reentry`); retarget to `master` when that merges.

## 1. Cancel made the countdown race to zero and take the picture anyway

The countdown tick task did `try? await Task.sleep(...)` and then **unconditionally** enqueued the next tick — so a *cancelled* tick task fired an immediate tick instead of dying. Tapping the shutter during a countdown restarted it, cancelling the sleeping task → instant tick → reschedule+cancel → instant tick… a self-feeding cascade that counted to zero at pump speed and fired the capture. There was also no cancel path at all in the director.

- The tick task now checks `Task.isCancelled` after sleeping.
- Ticks carry a **generation**; a tick from a cancelled/superseded countdown is inert even if it was already queued.
- Tapping the shutter during a countdown now **cancels** it — the same gesture the 1:1 monitor honors — and every camera gets `TimerCountdown(-1)`, which the camera side already renders as "cancelled" (overlay clears, torch restores). Nothing is captured.

## 2. Settings tray = camA ∩ camB ∩ camC, reactively

`RigQualityMenu` already computed the intersection, but publishing was driven by per-handler `lanesDirty`/`rigDirty` flags — and removal, disconnect, and version-refusal forgot to mark the rig dirty, so a dead camera kept constraining the menu.

The flags are deleted. After every pump message the controller **re-derives** each UI snapshot (lanes, shutter, rig settings, available peers) from actor state and publishes only the ones whose value changed (all Equatable). Publishing is a diff of derived state, not a per-handler call — nothing to forget, no settings copies stored anywhere. A camera joining, dropping, or being refused recomputes the tray on the same pump turn. The capture-ack timeout now routes through the inbox like every other event.

## Tests

- **Set algebra** (`RigQualityMenuTests`): rig options == options(A) ∩ options(B) ∩ options(C); commutativity; dropping a camera never shrinks the option set; HEIF/HDR are ANDs, verified over all 2³ support combinations with exact blocker lists.
- **Reactivity** (`MulticamControllerTests`): dropping the blocking camera unblocks 4K30/HEIF/HDR on the same pump turn, and the recomputed snapshot reaches the display; a version-refused camera leaves the intersection too.
- **Cancel**: shutter tap during photo/record countdown cancels (negative tick to every camera, no `ScheduledCapture`/`TakePic`); a stale tick can neither resurrect an old countdown nor advance a new one.

Full suite passes on iPhone 16 / iOS 18.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)