### PR TITLE
Multicam settings parity with the classic remote

### DIFF
--- a/RemoteCam/MultiCamChrome.swift
+++ b/RemoteCam/MultiCamChrome.swift
@@ -43,3 +43,34 @@ enum MultiCamChrome {
         cameraCount > 1
     }
 }
+
+// MARK: - Rig tray
+
+/// Which tiles the rig settings tray shows — the multicam mirror of
+/// `MonitorTray.items`, so the director offers the same settings per capture
+/// mode as the 1:1 monitor: photo settings never show in video mode and vice
+/// versa. Rig quality stays one tile (the intersection cycle carries both
+/// resolution and frame rate), so video mode has no separate frame-rate tile.
+enum RigTray {
+
+    /// `standbyAvailable` omits (not dims) the standby tile, as the 1:1 tray
+    /// does — a rig with no standby-capable camera has nothing to offer.
+    /// Format/HDR stay listed when blocked: the intersection model greys them
+    /// and names the blocking camera in the footnote instead. Aspect, like the
+    /// 1:1 tray's, shows in both modes — every camera can crop.
+    static func items(mode: MonitorMode, standbyAvailable: Bool) -> [MonitorTrayItem] {
+        var items: [MonitorTrayItem] = [.timer, .aspect]
+
+        switch mode {
+        case .video:
+            items.append(.resolution)
+        case .photo:
+            items.append(contentsOf: [.format, .hdr])
+        }
+
+        if standbyAvailable { items.append(.cameraStandby) }
+        items.append(.settings)
+        items.append(.help)
+        return items
+    }
+}

--- a/RemoteCam/MulticamController.swift
+++ b/RemoteCam/MulticamController.swift
@@ -218,6 +218,10 @@ public actor MulticamController {
     /// first-class; Automatic just recomputes best-in-intersection.
     private var activeVideoQuality: (resolution: VideoResolution, frameRate: VideoFrameRate)?
     private var activePhotoQuality: (format: PhotoFormat, hdr: HDRMode)?
+    /// The rig's aspect ratio — a crop every camera can do, so it needs no
+    /// intersection: it fans to every lane and is re-applied to late joiners.
+    /// 16:9 is the cameras' own default.
+    private var activeAspectRatio: AspectRatio = .sixteenNine
     /// The rig-wide camera-preview mode: standby blanks each camera's own
     /// on-screen preview (the director is the viewfinder; capture and the
     /// streamed frames are unaffected). Sent only to cameras that advertised
@@ -489,6 +493,9 @@ public actor MulticamController {
         case let q as MCSetPhotoQuality:
             logInfo("director: photo quality \(q.format)/\(q.hdr) → all")
             handleSetPhotoQuality(format: q.format, hdr: q.hdr)
+        case let a as MCSetAspectRatio:
+            logInfo("director: aspect \(a.ratio.displayName) → all")
+            handleSetAspectRatio(a.ratio)
         case let t as MCSetRigTimer:
             logInfo("director: timer preset \(t.seconds)s")
             handleSetRigTimer(t.seconds)
@@ -557,6 +564,11 @@ public actor MulticamController {
             // (or re-advertising) while the rig is in standby is put there too.
             if rigPreviewMode == .standby, caps.supportsPreviewMode {
                 sendTo(peer, RemoteCmd.SetCameraPreviewMode(mode: .standby))
+            }
+            // Aspect likewise: a camera arriving while the rig is off the 16:9
+            // camera default is cropped to match the rest of the shot.
+            if activeAspectRatio != .sixteenNine {
+                sendTo(peer, RemoteCmd.SetAspectRatio(aspectRatio: activeAspectRatio))
             }
 
         case let resp as RemoteCmd.ToggleCameraResp:
@@ -1123,6 +1135,17 @@ public actor MulticamController {
         }
     }
 
+    /// Rig aspect ratio — every camera crops the same way, so the shot cuts
+    /// together. No intersection needed (aspect is a crop, not a capability).
+    public nonisolated func setAspectRatio(_ ratio: AspectRatio) { tell(MCSetAspectRatio(ratio)) }
+
+    private func handleSetAspectRatio(_ ratio: AspectRatio) {
+        activeAspectRatio = ratio
+        for peer in order {
+            sendTo(peer, RemoteCmd.SetAspectRatio(aspectRatio: ratio))
+        }
+    }
+
     /// "Automatic" / re-match: recompute best-in-intersection and apply it.
     public nonisolated func applyAutomaticVideoQuality() { tell(MCAutomaticVideoQuality()) }
 
@@ -1242,6 +1265,7 @@ public actor MulticamController {
             hdrBlockedBy: menu.lanesBlockingHDR(),
             activePhotoFormat: activePhotoQuality?.format,
             activeHDR: activePhotoQuality?.hdr,
+            aspectRatio: activeAspectRatio,
             standbyAvailable: order.contains { peer in
                 guard let link = links[peer], link.status != .failed else { return false }
                 return link.capabilities?.supportsPreviewMode == true
@@ -1784,6 +1808,11 @@ final class MCSetPhotoQuality: Message, @unchecked Sendable {
     let format: PhotoFormat
     let hdr: HDRMode
     init(_ format: PhotoFormat, _ hdr: HDRMode) { self.format = format; self.hdr = hdr; super.init(sender: nil) }
+}
+
+final class MCSetAspectRatio: Message, @unchecked Sendable {
+    let ratio: AspectRatio
+    init(_ ratio: AspectRatio) { self.ratio = ratio; super.init(sender: nil) }
 }
 
 final class MCSetRigStandby: Message, @unchecked Sendable {

--- a/RemoteCam/MulticamView.swift
+++ b/RemoteCam/MulticamView.swift
@@ -34,10 +34,14 @@ struct MulticamView: View {
     /// Rig photo format / HDR picked.
     let onSetPhotoFormat: (PhotoFormat) -> Void
     let onSetHDR: (Bool) -> Void
+    /// Rig aspect ratio picked (one crop across every camera).
+    let onSetAspectRatio: (AspectRatio) -> Void
     /// Rig standby: blank (or wake) every supporting camera's own preview.
     let onSetStandby: (Bool) -> Void
     /// Open the app's Settings sheet (purchases, restore, preferences).
     let onOpenSettings: () -> Void
+    /// Open the help sheet (the shared one every screen presents).
+    let onOpenHelp: () -> Void
     /// Retry a lane's failed footage collection.
     let onRetryCollection: (CameraLane) -> Void
     /// Flip the focused camera front/back (per-camera framing).
@@ -114,17 +118,24 @@ struct MulticamView: View {
                 .ignoresSafeArea()
                 .onTapGesture { viewModel.showingRigTray = false }
             RigTrayPanel(settings: viewModel.rigSettings,
+                         mode: viewModel.mode,
+                         isRecording: viewModel.isRecording,
                          onSetTimer: onSetTimer,
                          onSelectVideoQuality: onSelectVideoQuality,
                          onAutomaticVideoQuality: onAutomaticVideoQuality,
                          onSetPhotoFormat: onSetPhotoFormat,
                          onSetHDR: onSetHDR,
+                         onSetAspectRatio: onSetAspectRatio,
                          onSetStandby: onSetStandby,
                          // Close the tray first, as the 1:1 tray does — the
                          // sheet returns to a clean viewfinder.
                          onOpenSettings: {
                              viewModel.showingRigTray = false
                              onOpenSettings()
+                         },
+                         onOpenHelp: {
+                             viewModel.showingRigTray = false
+                             onOpenHelp()
                          })
                 .transition(.move(edge: .bottom))
         }
@@ -411,7 +422,9 @@ struct MulticamView: View {
             count: MultiCamChrome.gridColumnCount(cameraCount: count))
         return LazyVGrid(columns: columns, spacing: spacing) {
             ForEach(viewModel.lanes) { lane in
-                CameraTileView(lane: lane, isThumbnail: true, onRetry: { onRetryCollection(lane) })
+                CameraTileView(lane: lane, isThumbnail: true,
+                               aspectRatio: viewModel.rigSettings.aspectRatio,
+                               onRetry: { onRetryCollection(lane) })
                     .frame(height: cellHeight)
                     .onTapGesture {
                         onFocusLane(lane)
@@ -438,7 +451,7 @@ struct MulticamView: View {
             // the 1:1 monitor's preview layer). Gestures address the focused
             // camera; in grid mode a tile tap focuses the lane instead.
             ZStack {
-                LiveFrameView(frames: focused.frames, aspectRatio: .sixteenNine)
+                LiveFrameView(frames: focused.frames, aspectRatio: viewModel.rigSettings.aspectRatio)
                 ViewfinderGestureLayer(
                     cameraImage: { focused.frames.cameraImage },
                     zoomScale: { focused.zoomScale },
@@ -482,7 +495,9 @@ struct MulticamView: View {
     @ViewBuilder
     private func stripTiles(_ others: [CameraLane], size: CGSize) -> some View {
         ForEach(others) { lane in
-            CameraTileView(lane: lane, isThumbnail: true, onRetry: { onRetryCollection(lane) })
+            CameraTileView(lane: lane, isThumbnail: true,
+                           aspectRatio: viewModel.rigSettings.aspectRatio,
+                           onRetry: { onRetryCollection(lane) })
                 .frame(width: size.width, height: size.height)
                 .onTapGesture { onFocusLane(lane) }
                 .contextMenu { disconnectButton(for: lane) }
@@ -598,6 +613,9 @@ struct TileStatusBadge: View {
 struct CameraTileView: View {
     @ObservedObject var lane: CameraLane
     var isThumbnail: Bool = false
+    /// The rig's aspect ratio — the tile draws the same crop bars as the
+    /// focused viewfinder, so every angle is judged against the real frame.
+    var aspectRatio: AspectRatio = .sixteenNine
     /// Retry a failed footage collection for this lane (nil = not offered).
     var onRetry: (() -> Void)? = nil
 
@@ -626,7 +644,7 @@ struct CameraTileView: View {
 
     var body: some View {
         ZStack {
-            LiveFrameView(frames: lane.frames, aspectRatio: .sixteenNine)
+            LiveFrameView(frames: lane.frames, aspectRatio: aspectRatio)
                 .clipShape(RoundedRectangle(cornerRadius: isThumbnail ? 10 : 0))
                 .saturation(lane.status == .linked ? 1 : 0)
 
@@ -741,42 +759,83 @@ struct AddCameraSheet: View {
 /// footnote names any camera that blocks an option.
 struct RigTrayPanel: View {
     let settings: RigSettingsSnapshot
+    /// Photo vs video — the tray lists only the tiles that matter to the mode,
+    /// exactly as `MonitorTray` does for the 1:1 monitor.
+    let mode: MonitorMode
+    /// Mid-recording the capture settings dim (standby and help stay live) —
+    /// the 1:1 monitor's `configureVideoRecording` rules.
+    let isRecording: Bool
     let onSetTimer: (Int) -> Void
     let onSelectVideoQuality: (VideoResolution, VideoFrameRate) -> Void
     let onAutomaticVideoQuality: () -> Void
     let onSetPhotoFormat: (PhotoFormat) -> Void
     let onSetHDR: (Bool) -> Void
+    /// Rig aspect ratio picked (one crop across every camera).
+    let onSetAspectRatio: (AspectRatio) -> Void
     /// Rig standby: blank (or wake) every supporting camera's own preview.
     let onSetStandby: (Bool) -> Void
     /// Open the app's Settings sheet (purchases, restore, preferences).
     let onOpenSettings: () -> Void
+    /// Open the help sheet (the same one every screen presents).
+    let onOpenHelp: () -> Void
 
     private let timerStops = [0, 3, 5, 10, 20]
 
     var body: some View {
-        TrayPanelShell(footnote: settings.blockerFootnote) {
+        TrayPanelShell(footnote: settings.blockerFootnote(for: mode)) {
+            ForEach(RigTray.items(mode: mode, standbyAvailable: settings.standbyAvailable),
+                    id: \.self) { item in
+                tile(for: item)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func tile(for item: MonitorTrayItem) -> some View {
+        switch item {
+        case .timer:
             MonitorTrayTile(item: .timer, value: settings.timerSeconds > 0 ? "\(settings.timerSeconds)" : nil,
-                            isActive: settings.timerSeconds > 0, isEnabled: true,
+                            isActive: settings.timerSeconds > 0, isEnabled: !isRecording,
                             action: cycleTimer)
+        case .aspect:
+            MonitorTrayTile(item: .aspect, value: settings.aspectRatio.displayName,
+                            isActive: false, isEnabled: !isRecording,
+                            action: {
+                                onSetAspectRatio(MonitorView.cycled(settings.aspectRatio,
+                                                                    in: AspectRatio.selectableCases))
+                            })
+        case .resolution:
             MonitorTrayTile(item: .resolution, value: settings.videoTileValue,
                             isActive: settings.activeVideo != nil,
-                            isEnabled: !settings.videoOptions.filter(\.enabled).isEmpty,
+                            isEnabled: !isRecording && !settings.videoOptions.filter(\.enabled).isEmpty,
                             action: cycleQuality)
+        case .format:
             MonitorTrayTile(item: .format, value: (settings.activePhotoFormat ?? .jpeg).displayName,
                             isActive: settings.activePhotoFormat == .heif,
-                            isEnabled: settings.heifAvailable,
+                            isEnabled: !isRecording && settings.heifAvailable,
                             action: { onSetPhotoFormat(settings.activePhotoFormat == .heif ? .jpeg : .heif) })
+        case .hdr:
             MonitorTrayTile(item: .hdr, value: nil,
                             isActive: settings.activeHDR == .on,
-                            isEnabled: settings.hdrAvailable,
+                            isEnabled: !isRecording && settings.hdrAvailable,
                             action: { onSetHDR(settings.activeHDR != .on) })
+        case .cameraStandby:
             MonitorTrayTile(item: .cameraStandby, value: nil,
                             isActive: settings.standbyOn,
-                            isEnabled: settings.standbyAvailable,
+                            isEnabled: true,
                             action: { onSetStandby(!settings.standbyOn) })
+        case .settings:
             MonitorTrayTile(item: .settings, value: nil,
-                            isActive: false, isEnabled: true,
+                            isActive: false, isEnabled: !isRecording,
                             action: onOpenSettings)
+        case .help:
+            MonitorTrayTile(item: .help, value: nil,
+                            isActive: false, isEnabled: true,
+                            action: onOpenHelp)
+        case .frameRate:
+            // Not offered by `RigTray.items` — frame rate rides the single
+            // quality tile's intersection cycle.
+            EmptyView()
         }
     }
 

--- a/RemoteCam/MulticamViewController.swift
+++ b/RemoteCam/MulticamViewController.swift
@@ -81,10 +81,15 @@ public final class MulticamViewController: UIViewController {
                     format: self?.viewModel.rigSettings.activePhotoFormat ?? .jpeg,
                     hdr: on ? .on : .off)
             },
+            onSetAspectRatio: { [weak self] ratio in self?.controller.setAspectRatio(ratio) },
             onSetStandby: { [weak self] on in self?.controller.setRigStandby(on) },
             onOpenSettings: { [weak self] in
                 logInfo("director: settings opened")
                 self?.showPaywall()
+            },
+            onOpenHelp: { [weak self] in
+                logInfo("director: help opened")
+                self?.presentHelpSheet()
             },
             onRetryCollection: { [weak self] lane in self?.controller.retryCollection(for: lane.peerID) },
             onFlipCamera: { [weak self] lane in self?.controller.flipCamera(lane.peerID) },

--- a/RemoteCam/RigQualityMenu.swift
+++ b/RemoteCam/RigQualityMenu.swift
@@ -175,6 +175,9 @@ struct RigSettingsSnapshot: Equatable {
     var hdrBlockedBy: [String] = []
     var activePhotoFormat: PhotoFormat?
     var activeHDR: HDRMode?
+    /// The rig's aspect ratio — one crop across every camera so the angles cut
+    /// together. 16:9 is the cameras' own default.
+    var aspectRatio: AspectRatio = .sixteenNine
     /// At least one camera in the rig can blank its own preview — offers the
     /// standby tile. Cameras that can't are simply not sent the command.
     var standbyAvailable: Bool = false
@@ -205,15 +208,24 @@ struct RigSettingsSnapshot: Equatable {
     }
 
     /// A compact footnote naming a camera that blocks an unavailable option, or
-    /// nil when every option is reachable. Video blockers first, then HDR.
-    var blockerFootnote: String? {
-        if let opt = videoOptions.first(where: { !$0.enabled }), let who = opt.blockedBy.first {
+    /// nil when everything the current mode's tray lists is reachable. Scoped to
+    /// the mode so the photo tray never explains a video limit and vice versa.
+    func blockerFootnote(for mode: MonitorMode) -> String? {
+        switch mode {
+        case .video:
+            guard let opt = videoOptions.first(where: { !$0.enabled }),
+                  let who = opt.blockedBy.first else { return nil }
             return String(format: NSLocalizedString("%@ can’t do %@", comment: "camera blocks a quality"),
                           who, opt.label)
+        case .photo:
+            if !heifAvailable, let who = heifBlockedBy.first {
+                return String(format: NSLocalizedString("%@ can’t do %@", comment: "camera blocks a quality"),
+                              who, PhotoFormat.heif.displayName)
+            }
+            if !hdrAvailable, let who = hdrBlockedBy.first {
+                return String(format: NSLocalizedString("%@ can’t do HDR", comment: "camera blocks HDR"), who)
+            }
+            return nil
         }
-        if !hdrAvailable, let who = hdrBlockedBy.first {
-            return String(format: NSLocalizedString("%@ can’t do HDR", comment: "camera blocks HDR"), who)
-        }
-        return nil
     }
 }

--- a/RemoteCamTests/MultiCamChromeTests.swift
+++ b/RemoteCamTests/MultiCamChromeTests.swift
@@ -39,6 +39,29 @@ final class MultiCamChromeTests: XCTestCase {
         XCTAssertTrue(MultiCamChrome.showsGridToggle(cameraCount: 4))
     }
 
+    // MARK: - Rig tray (mirrors MonitorTray's mode-conditioning)
+
+    /// Photo mode lists photo settings only — no video-quality tile, exactly
+    /// as the 1:1 monitor's tray behaves in photo mode.
+    func testRigTrayPhotoModeListsPhotoTilesOnly() {
+        XCTAssertEqual(RigTray.items(mode: .photo, standbyAvailable: true),
+                       [.timer, .aspect, .format, .hdr, .cameraStandby, .settings, .help])
+    }
+
+    /// Video mode lists the single rig-quality tile only — no photo format or
+    /// HDR tiles (frame rate rides the quality tile's intersection cycle).
+    func testRigTrayVideoModeListsQualityTileOnly() {
+        XCTAssertEqual(RigTray.items(mode: .video, standbyAvailable: true),
+                       [.timer, .aspect, .resolution, .cameraStandby, .settings, .help])
+    }
+
+    /// A rig with no standby-capable camera omits the tile (not dims it),
+    /// matching `MonitorTray`'s capability-driven omission.
+    func testRigTrayOmitsStandbyWhenUnavailable() {
+        XCTAssertFalse(RigTray.items(mode: .photo, standbyAvailable: false).contains(.cameraStandby))
+        XCTAssertFalse(RigTray.items(mode: .video, standbyAvailable: false).contains(.cameraStandby))
+    }
+
     func testStreamProfilePresets() {
         // The focused tier reproduces today's 1:1 peer preview.
         XCTAssertEqual(StreamProfile.focused.maxLongEdge, 1200)

--- a/RemoteCamTests/MulticamControllerTests.swift
+++ b/RemoteCamTests/MulticamControllerTests.swift
@@ -1525,6 +1525,42 @@ final class MulticamControllerTests: XCTestCase {
         XCTAssertEqual(q?.hdrMode, .on)
     }
 
+    /// Aspect is a rig setting, not an event: it fans to every lane, lands in
+    /// the tray snapshot, and a camera (re)advertising while the rig is off the
+    /// 16:9 camera default is cropped to match. At the default nothing is sent.
+    func testSetAspectRatioFansOutAndReappliesToLateJoiners() async {
+        let (controller, transport, _) = await makeController(peers: [camA, camB])
+
+        var rig = await controller.rigSettingsSnapshotForTesting()
+        XCTAssertEqual(rig.aspectRatio, .sixteenNine, "16:9 is the cameras' own default")
+
+        transport.sentMessages.removeAll()
+        controller.setAspectRatio(.fourThree)
+        await controller.waitForIdle()
+
+        let sends = sent(transport, RemoteCmd.SetAspectRatio.self)
+        XCTAssertEqual(Set(sends.flatMap(\.peers)), [camA, camB])
+        XCTAssertTrue(sends.allSatisfy { ($0.msg as? RemoteCmd.SetAspectRatio)?.aspectRatio == .fourThree })
+        rig = await controller.rigSettingsSnapshotForTesting()
+        XCTAssertEqual(rig.aspectRatio, .fourThree)
+
+        // camB re-advertises (device switch / rejoin) — it is re-cropped.
+        transport.sentMessages.removeAll()
+        controller.didReceiveMessage(capsWith(only1080), from: camB)
+        await controller.waitForIdle()
+        let lateSends = sent(transport, RemoteCmd.SetAspectRatio.self)
+        XCTAssertEqual(lateSends.flatMap(\.peers), [camB])
+        XCTAssertEqual((lateSends.first?.msg as? RemoteCmd.SetAspectRatio)?.aspectRatio, .fourThree)
+
+        // Back at the default, a re-advertising camera is not sent a no-op.
+        controller.setAspectRatio(.sixteenNine)
+        await controller.waitForIdle()
+        transport.sentMessages.removeAll()
+        controller.didReceiveMessage(capsWith(only1080), from: camB)
+        await controller.waitForIdle()
+        XCTAssertTrue(sent(transport, RemoteCmd.SetAspectRatio.self).isEmpty)
+    }
+
     // MARK: - Auto-collect
 
     func testVideoResourceTransferUpdatesLaneStateAndSaves() async {

--- a/RemoteCamTests/RigQualityMenuTests.swift
+++ b/RemoteCamTests/RigQualityMenuTests.swift
@@ -222,11 +222,39 @@ final class RigQualityMenuTests: XCTestCase {
             option(.hd1080p, .fps30),
             option(.uhd4k, .fps60, enabled: false, blockedBy: ["iPad"]),
         ])
-        XCTAssertNotNil(snap.blockerFootnote)
-        XCTAssertTrue(snap.blockerFootnote?.contains("iPad") == true)
+        XCTAssertNotNil(snap.blockerFootnote(for: .video))
+        XCTAssertTrue(snap.blockerFootnote(for: .video)?.contains("iPad") == true)
 
         // No blockers → no footnote.
         snap = RigSettingsSnapshot(videoOptions: [option(.hd1080p, .fps30)], hdrAvailable: true)
-        XCTAssertNil(snap.blockerFootnote)
+        XCTAssertNil(snap.blockerFootnote(for: .video))
+    }
+
+    /// The footnote is scoped to the tray's mode: the photo tray never explains
+    /// a video limit, and vice versa.
+    func testFootnoteIsModeScoped() {
+        var snap = RigSettingsSnapshot(videoOptions: [
+            option(.uhd4k, .fps60, enabled: false, blockedBy: ["iPad"]),
+        ])
+        snap.heifAvailable = true
+        snap.hdrAvailable = true
+        // A video blocker exists, but the photo tray doesn't list video quality.
+        XCTAssertNotNil(snap.blockerFootnote(for: .video))
+        XCTAssertNil(snap.blockerFootnote(for: .photo))
+
+        // A HEIF blocker outranks the HDR one; neither shows in video mode.
+        snap = RigSettingsSnapshot(videoOptions: [option(.hd1080p, .fps30)])
+        snap.heifAvailable = false
+        snap.heifBlockedBy = ["iPad"]
+        snap.hdrAvailable = false
+        snap.hdrBlockedBy = ["iPhone"]
+        XCTAssertTrue(snap.blockerFootnote(for: .photo)?.contains("iPad") == true)
+        XCTAssertTrue(snap.blockerFootnote(for: .photo)?.contains("HEIF") == true)
+        XCTAssertNil(snap.blockerFootnote(for: .video))
+
+        // HDR blocker alone.
+        snap.heifAvailable = true
+        snap.heifBlockedBy = []
+        XCTAssertTrue(snap.blockerFootnote(for: .photo)?.contains("iPhone") == true)
     }
 }


### PR DESCRIPTION
## Summary

The multicam director's settings tray now matches the classic 1:1 remote for both photo and video, closing the delta found in the QA comparison:

- **Mode-conditioned tiles** — a new pure `RigTray.items` policy (mirroring `MonitorTray.items`) shows format/HDR only in photo mode and the rig-quality tile only in video mode; previously all tiles showed in both modes.
- **Recording gates** — timer, quality, format/HDR, and settings dim while the rig records (standby and help stay live), matching the classic `configureVideoRecording` rules. Previously a mid-recording tap could fan `SetVideoQuality` to actively recording cameras.
- **Help tile** — wired to the shared help sheet.
- **Mode-scoped blocker footnote** — the photo tray explains HEIF/HDR blockers, the video tray explains quality blockers; the HEIF footnote reuses the already-translated `"%@ can’t do %@"` key (no new localization).
- **Rig aspect ratio** — the missing feature: the director stores an active rig aspect (16:9 camera default) and fans `RemoteCmd.SetAspectRatio` to every lane — a crop, not a capability, so no intersection. Late joiners are re-cropped to match (same "setting, not event" pattern as standby); at the default nothing is sent. The focused viewfinder, strip, and grid tiles all draw the classic crop-bar overlay for the selected ratio.

Deliberate differences kept: one merged AUTO/resolution·fps quality tile (the rig-intersection cycle), no SHORTS mode, torch only in focus mode.

## Test plan

- New: `RigTray` policy tests (tile lists per mode, standby omission), mode-scoped footnote tests, `testSetAspectRatioFansOutAndReappliesToLateJoiners` (fan-out, snapshot, late-joiner re-apply, no-op at default).
- `MulticamControllerTests` + `MultiCamChromeTests` + `RigQualityMenuTests`: 105 tests, 0 failures on iPhone 16 simulator (OS 18.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)