### PR TITLE
Fix QoS priority inversion in HEVC preview decode

### DIFF
--- a/RemoteCam/FrameStreamReceiver.swift
+++ b/RemoteCam/FrameStreamReceiver.swift
@@ -370,12 +370,17 @@ final class PeerHEVCPreviewDecoder {
             return recordFailure("could not wrap HEVC frame")
         }
 
+        // Synchronous decode, deliberately: without `.enableAsynchronousDecompression`
+        // VideoToolbox invokes the handler on this thread before the call returns,
+        // so no semaphore is needed — and none is allowed. `decodeQueue` runs at
+        // user-interactive QoS, and a semaphore wait on VT's unowned internal
+        // threads (where `._1xRealTimePlayback` pacing lands) is a priority
+        // inversion. Real-time is already requested per-session via
+        // `kVTDecompressionPropertyKey_RealTime`.
         var image: UIImage?
-        let done = DispatchSemaphore(value: 0)
         let status = VTDecompressionSessionDecodeFrame(
-            session, sampleBuffer: sampleBuffer, flags: [._1xRealTimePlayback], infoFlagsOut: nil
+            session, sampleBuffer: sampleBuffer, flags: [], infoFlagsOut: nil
         ) { [ciContext] decodeStatus, _, imageBuffer, _, _ in
-            defer { done.signal() }
             guard decodeStatus == noErr, let imageBuffer else { return }
             let ciImage = CIImage(cvPixelBuffer: imageBuffer)
             if let cgImage = ciContext.createCGImage(ciImage, from: ciImage.extent) {
@@ -383,7 +388,6 @@ final class PeerHEVCPreviewDecoder {
             }
         }
         guard status == noErr else { return recordFailure("VTDecompressionSessionDecodeFrame: \(status)") }
-        done.wait()
 
         guard let image else { return recordFailure("HEVC decode produced no image") }
         failureStreak = 0


### PR DESCRIPTION
## Summary

Fixes the runtime diagnostic **"Thread running at User-interactive quality-of-service class waiting on a thread without a QoS class specified"** at `done.wait()` in `PeerHEVCPreviewDecoder`.

**Root cause:** `FrameStreamReceiver.decodeQueue` runs at `.userInteractive` QoS, and the decoder passed `._1xRealTimePlayback` to `VTDecompressionSessionDecodeFrame`. That flag is only meaningful for *asynchronous* decompression — it paces decode on VideoToolbox's internal threads, which carry no QoS class. The semaphore then blocked the user-interactive thread on that anonymous thread, and semaphores can't donate priority.

**Fix:** decode synchronously. Per VideoToolbox's documented contract, without `.enableAsynchronousDecompression` the output handler is invoked on the calling thread *before the call returns* — so the pacing flag is dropped and the semaphore deleted outright rather than worked around. Real-time behavior is still requested the supported way, via `kVTDecompressionPropertyKey_RealTime` on the session.

The twin semaphore in `HEVCFrameEncoder.encode` is deliberately untouched: VT *compression* has no synchronous mode (that bridge is genuine), and its calling queue (`dataOutputQueue`) has no QoS class, so no inversion exists there.

## Test plan

- `FrameStreamReceiverTests` (7 tests) + `HEVCStreamingTests` pass on the iOS simulator.
- `testHEVCEncodeDecodeRoundTrip` passes on **Mac Catalyst with real hardware HEVC** — proving the synchronous contract holds: the decoded image is produced before `VTDecompressionSessionDecodeFrame` returns (a deferred callback would fail the test's unwrap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)