### PR TITLE
README: say what the app is and what it's for

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
   <img src="RemoteCam/Assets.xcassets/AppIcon.appiconset/1024.png" title="Remote Shutter" width="200" float=left>
 </p>
 
-# Remote shutter: camera connect
-## P2P Remote control camera
+# Remote Shutter — use a second iPhone, iPad, Apple Watch or Mac as a live-preview camera remote
+
+Remote Shutter is a free, open-source iOS app that turns any two Apple devices into a wireless camera system. One device (iPhone or iPad) is the **camera**; the other (iPhone, iPad, Apple Watch, or Apple-silicon Mac) is the **remote**, showing a full-screen live preview and controlling the shutter. The devices connect directly over peer-to-peer Wi-Fi — no internet, no Wi-Fi network, no account, no subscription. Photos and videos stay on the devices; nothing is uploaded anywhere.
 
 <p align="center" >
   <img src="fastlane/screenshots/en-US/0_APP_IPHONE_67_0.png" width="200" title="Screenshot 1" float=left>
@@ -22,28 +23,32 @@
 
 
 
-### Description
+### What it does
 ---
-Remote Shutter is an application that requires two devices. It works on both macOS and iOS. 
+- **Live preview on the remote** — see exactly what the camera sees before you shoot, not a postage-stamp thumbnail.
+- **Photo and video** — take photos or start/stop video recording from the remote.
+- **Full camera control** — switch lenses (wide / ultra-wide / telephoto), flip front/back, flash, torch, tap to focus, timer.
+- **Any pairing** — iPhone ↔ iPhone, iPhone ↔ iPad, iPhone ↔ Mac, iPhone ↔ Apple Watch.
+- **Range** — about 50 ft (15 m) line of sight over peer-to-peer Wi-Fi, or anywhere on the network when both devices share a Wi-Fi network.
+- **Private by design** — no accounts, no cloud, no tracking of photo content.
+- **Free** with optional one-time purchases (Pro unlocks everything). No subscription.
 
-With Remote Shutter one of your devices is the camera remote or camera monitor, and the other device would be set up wherever you would like to take a picture as the camera. Using the connected phone you can take pictures from up to 50 feet away.
-
-Remote Shutter makes it easy to take pictures of things at weird angles and that would put you in an uncomfortable position. Take Remote Shutter for a spin for free!
-
-### Features:
+### Common uses
 ---
-- Take pictures from up to 50ft away
-- Toggle the camera orientation
-- Use the camera flash
-- Adjustable camera timer
+- **Group photos with everyone in the shot** — hand a friend's iPhone or your Watch the remote instead of running back for a self-timer.
+- **Use an old iPhone as a remote camera** — the spare phone in a drawer becomes a wireless camera you can see through and trigger: wildlife at the feeder, pets, hard-to-reach angles, checking on a room.
+- **Overhead / product / workbench video** — mount the iPhone above the table and monitor the frame from an iPad or Mac in front of you.
+- **Vlogging and tutorials** — frame yourself from the rear camera with a live feed on the second device, and start/stop recording without touching the rig.
+- **Apple Watch as a trigger** — fire the shutter from your wrist.
 
-### HOW TO USE
+### How to use
 ---
-When you first open the app the phone will start searching for devices to connect with. The camera connects with a P2P connection to the other device. Once the devices are connected you will have to choose which device is the camera and which phone is the remote. 
-1. Connect your devices
-2. Choose which role the device has (camera or remote)
-3. Set up & take pictures!
----
+1. Install Remote Shutter on both devices from the [App Store](https://apps.apple.com/us/app/remote-shutter/id633274861).
+2. Open the app on both; they find each other automatically over peer-to-peer Wi-Fi (Bluetooth and Wi-Fi on, no network needed).
+3. Choose which device is the **camera** and which is the **remote**.
+4. Frame the shot on the remote's live preview and tap the shutter — or start recording.
+
+Guides and FAQ: [remoteshutter.app](https://remoteshutter.app) · Support: [GitHub Issues](https://github.com/security-union/remote-shutter/issues)
 
 ### Contributing, forks & the App Store
 ---


### PR DESCRIPTION
Rewrites the description/features/how-to sections of the README in plain language: what the app is, which device pairings work, what you can control, and the common use cases (group photos, old iPhone as remote camera, overhead video monitor, vlogging, Watch trigger). Mirrors remoteshutter.app/llms.txt so the App Store listing, the site and GitHub all describe the app identically. Contributing section untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR4DG4HhVZehnx88YPaf3q