### PR TITLE
Multicam on every public surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Remote Shutter is a free, open-source iOS app that turns any two Apple devices into a wireless camera system. One device (iPhone or iPad) is the **camera**; the other (iPhone, iPad, Apple Watch, or Apple-silicon Mac) is the **remote**, showing a full-screen live preview and controlling the shutter. The devices connect directly over peer-to-peer Wi-Fi — no internet, no Wi-Fi network, no account, no subscription. Photos and videos stay on the devices; nothing is uploaded anywhere.
 
+**Multicam (10.0+):** one iPhone directs up to four iPhone cameras at once — every angle live in a grid, one synced shutter that fires photos or video on all of them at the same instant, and footage that collects back to the director time-aligned for editing. Two cameras free, four with Pro.
+
 <p align="center" >
   <img src="fastlane/screenshots/en-US/0_APP_IPHONE_67_0.png" width="200" title="Screenshot 1" float=left>
   <img src="fastlane/screenshots/en-US/1_APP_IPHONE_67_1.png" width="200" title="Screenshot 2" float=left>
@@ -27,6 +29,7 @@ Remote Shutter is a free, open-source iOS app that turns any two Apple devices i
 ---
 - **Live preview on the remote** — see exactly what the camera sees before you shoot, not a postage-stamp thumbnail.
 - **Photo and video** — take photos or start/stop video recording from the remote.
+- **Multicam** — connect up to four iPhones as cameras, see every angle live in a grid, and fire a synchronized photo or video capture on all of them. Clips auto-collect to the director with alignment metadata so any editor lines them up.
 - **Full camera control** — switch lenses (wide / ultra-wide / telephoto), flip front/back, flash, torch, tap to focus, timer.
 - **Any pairing** — iPhone ↔ iPhone, iPhone ↔ iPad, iPhone ↔ Mac, iPhone ↔ Apple Watch.
 - **Range** — about 50 ft (15 m) line of sight over peer-to-peer Wi-Fi, or anywhere on the network when both devices share a Wi-Fi network.
@@ -40,6 +43,7 @@ Remote Shutter is a free, open-source iOS app that turns any two Apple devices i
 - **Overhead / product / workbench video** — mount the iPhone above the table and monitor the frame from an iPad or Mac in front of you.
 - **Vlogging and tutorials** — frame yourself from the rear camera with a live feed on the second device, and start/stop recording without touching the rig.
 - **Apple Watch as a trigger** — fire the shutter from your wrist.
+- **Multi-angle video with several iPhones** — interviews, music, sports, dance, unboxings: record the same moment from up to four phones with one button and edit the synced angles together.
 
 ### How to use
 ---

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Remote Shutter is a free, open-source iOS app that turns any two Apple devices i
 - **Live preview on the remote** — see exactly what the camera sees before you shoot, not a postage-stamp thumbnail.
 - **Photo and video** — take photos or start/stop video recording from the remote.
 - **Multicam** — connect up to four iPhones as cameras, see every angle live in a grid, and fire a synchronized photo or video capture on all of them. Clips auto-collect to the director with alignment metadata so any editor lines them up.
-- **Full camera control** — switch lenses (wide / ultra-wide / telephoto), flip front/back, flash, torch, tap to focus, timer.
+- **Full camera control** — switch lenses (wide / ultra-wide / telephoto), flip front/back, flash, torch, tap to focus, timer; frame rate (24/30/60), resolution (1080p/4K), aspect ratio, HDR and JPEG/HEIF, all set from the remote.
 - **Any pairing** — iPhone ↔ iPhone, iPhone ↔ iPad, iPhone ↔ Mac, iPhone ↔ Apple Watch.
 - **Range** — about 50 ft (15 m) line of sight over peer-to-peer Wi-Fi, or anywhere on the network when both devices share a Wi-Fi network.
 - **Private by design** — no accounts, no cloud, no tracking of photo content.

--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -6,6 +6,7 @@ NEW — MULTICAM: UP TO FOUR CAMERAS, ONE DIRECTOR
 - Connect up to four iPhones as cameras and see every angle live in a grid
 - One synced shutter fires photos or video on every camera at the same instant
 - Footage collects automatically to the director, time-aligned for editing
+- Set frame rate, resolution, aspect ratio, HDR and focus for every camera from the director
 - Interviews, music, sports, dance, unboxings — shoot every angle at once
 
 FULL MAC SUPPORT
@@ -21,7 +22,8 @@ FEATURES
 - Switch cameras remotely — front/back on iPhone, any connected camera on Mac
 - Camera flash control
 - Adjustable photo timer
-- Record video remotely
+- Record video remotely — choose 24/30/60 fps, 1080p or 4K, aspect ratio and HDR from the remote
+- Tap to focus on the remote's live preview (Pro)
 - Works with iPhone, iPad, and Mac
 - No internet or Wi-Fi network required — direct device-to-device connection (just keep Wi-Fi and Bluetooth turned on)
 

--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -2,7 +2,13 @@ Turn any two devices into a wireless remote camera system — no internet, no ro
 
 Remote Shutter uses peer-to-peer technology to link two devices directly. One becomes the camera, the other becomes your remote control with a live monitor. Perfect for group photos, selfies, tripod shots, creative angles, and hands-free photography.
 
-NEW — FULL MAC SUPPORT
+NEW — MULTICAM: UP TO FOUR CAMERAS, ONE DIRECTOR
+- Connect up to four iPhones as cameras and see every angle live in a grid
+- One synced shutter fires photos or video on every camera at the same instant
+- Footage collects automatically to the director, time-aligned for editing
+- Interviews, music, sports, dance, unboxings — shoot every angle at once
+
+FULL MAC SUPPORT
 - Use your Mac as the camera: built-in, USB and pro webcams, even your iPhone via Continuity Camera
 - Switch between every camera connected to your Mac, live from your iPhone
 - Or flip it: use your Mac's big screen as a director's monitor for your iPhone camera
@@ -25,4 +31,4 @@ HOW TO USE
 3. Choose which device is the camera and which is the remote
 4. Start shooting from anywhere in the room!
 
-Whether you're shooting products with a pro camera on your Mac, directing from the big screen, or setting up a family photo, Remote Shutter gives you full wireless control of your camera from another device.
+Whether you're directing four iPhones on a music video, shooting products with a pro camera on your Mac, directing from the big screen, or setting up a family photo, Remote Shutter gives you full wireless control of your camera from another device.

--- a/fastlane/metadata/en-US/keywords.txt
+++ b/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-wireless,group photo,tripod,webcam,mac,photobooth,bluetooth,video,watch,control,photography
+wireless,group photo,tripod,webcam,mac,photobooth,bluetooth,video,watch,control,multicam,multi

--- a/website/posts/multicam-record-with-multiple-iphones.md
+++ b/website/posts/multicam-record-with-multiple-iphones.md
@@ -1,0 +1,52 @@
+---
+title: "Record Video With Multiple iPhones at Once: Multicam With One Synced Shutter"
+date: "2026-08-21"
+author: "Dario Lencina"
+description: "Up to four iPhones as cameras, one iPhone as director: every angle live in a grid, one button that starts recording on all of them at the same instant, and clips that come back time-aligned."
+faq:
+  - q: "How many iPhones can record at the same time?"
+    a: "Up to four iPhones as cameras, controlled from a fifth iPhone acting as the director. Two cameras work for free; Pro unlocks four."
+  - q: "Are the videos synchronized?"
+    a: "Yes. One shutter on the director starts and stops recording on every camera at the same instant, and each clip is stamped with alignment metadata so the angles line up in any editor."
+  - q: "Do I need Wi-Fi or an internet connection?"
+    a: "No. The phones connect directly to each other, peer to peer, with no router or network. Keep Wi-Fi and Bluetooth turned on. A shared Wi-Fi network also works and extends the range."
+  - q: "Where do the videos end up?"
+    a: "Each camera records at full resolution to its own photo library, and the footage then collects automatically to the director. Nothing is uploaded to any server."
+  - q: "Can old iPhones be the cameras?"
+    a: "Yes — any iPhone that runs the current version of Remote Shutter. Spare and older phones make good fixed-angle cameras; the director should be the phone you hold."
+---
+
+If you have more than one iPhone in the house, you already own a multi-camera rig. Install [Remote Shutter](https://apps.apple.com/us/app/remote-shutter/id633274861) on every phone, pick one as the **director**, and the rest become cameras: you see every angle live in a grid on the director, and one button starts and stops recording on all of them at the same instant.
+
+## What multicam does
+
+- **Up to four cameras, one director.** The director connects to each camera directly over peer-to-peer Wi-Fi — no router, no account.
+- **Every angle live.** The director shows a grid of live previews, so you frame each phone before you roll, and tap any tile to see it full screen.
+- **One synced shutter.** Photo or video, the capture fires on every camera at the same instant. No more clapping for sync.
+- **Footage comes back to you.** Each camera records at full resolution locally, then the clips collect automatically to the director, stamped with alignment metadata so any editor — iMovie, Final Cut, DaVinci Resolve, CapCut — lines the angles up.
+
+Two cameras are free; Pro unlocks four.
+
+## What it is good for
+
+- **Interviews and podcasts** — a wide two-shot plus a close-up on each person, cut between them later.
+- **Music and dance** — one wide, one on hands or feet, one on the face; record a single take and edit the angles.
+- **Sports and skills** — front and side views of a swing, a lift, a trick, captured on the same frame.
+- **Unboxings and tutorials** — an overhead on the table and a face camera, started together.
+- **Events** — put spare phones on tripods around the room and direct from your own.
+
+## How to set it up
+
+1. Install Remote Shutter on every iPhone and open it on all of them. They find each other automatically — keep Wi-Fi and Bluetooth on; no network is needed.
+2. On the phone you will hold, choose **remote**. When two or more cameras connect, the director grid appears.
+3. Mount the camera phones (any [tripod or clamp](/gear) works) and frame each angle from the director's live tiles.
+4. Tap the shutter to take a photo on every camera at once, or start recording on all of them. Stop, and the clips collect to the director.
+
+## Tips
+
+- Keep the cameras within about 50 ft (15 m) of the director with line of sight, or put every phone on the same Wi-Fi network for more range.
+- Set focus on each angle before rolling so the cuts match — tap the preview where you want it sharp.
+- Old phones are fine as cameras. The director does the most work, so use your newest phone for that.
+- Turn on camera standby on the camera phones for long shoots — the screen rests while the phone keeps streaming and recording.
+
+Single camera is still the everyday case — a [spare iPhone as a remote camera](/blog/use-old-iphone-as-remote-camera) or an [iPad or Mac as the monitor](/blog/iphone-as-second-camera-mac-monitor) — and multicam is the same app with more phones connected.

--- a/website/posts/multicam-record-with-multiple-iphones.md
+++ b/website/posts/multicam-record-with-multiple-iphones.md
@@ -12,6 +12,8 @@ faq:
     a: "No. The phones connect directly to each other, peer to peer, with no router or network. Keep Wi-Fi and Bluetooth turned on. A shared Wi-Fi network also works and extends the range."
   - q: "Where do the videos end up?"
     a: "Each camera records at full resolution to its own photo library, and the footage then collects automatically to the director. Nothing is uploaded to any server."
+  - q: "Can I change frame rate and resolution on all the cameras at once?"
+    a: "Yes. Frame rate (24, 30 or 60 fps), resolution (1080p or 4K), aspect ratio and HDR are set from the director and applied to the rig, and you can tap to focus on any camera's live preview."
   - q: "Can old iPhones be the cameras?"
     a: "Yes — any iPhone that runs the current version of Remote Shutter. Spare and older phones make good fixed-angle cameras; the director should be the phone you hold."
 ---
@@ -23,6 +25,7 @@ If you have more than one iPhone in the house, you already own a multi-camera ri
 - **Up to four cameras, one director.** The director connects to each camera directly over peer-to-peer Wi-Fi — no router, no account.
 - **Every angle live.** The director shows a grid of live previews, so you frame each phone before you roll, and tap any tile to see it full screen.
 - **One synced shutter.** Photo or video, the capture fires on every camera at the same instant. No more clapping for sync.
+- **Camera settings from the director.** Frame rate (24/30/60), resolution (1080p/4K), aspect ratio, HDR and tap-to-focus are set from the director, so every phone rolls at the same 24p/4K without walking around to each one.
 - **Footage comes back to you.** Each camera records at full resolution locally, then the clips collect automatically to the director, stamped with alignment metadata so any editor — iMovie, Final Cut, DaVinci Resolve, CapCut — lines the angles up.
 
 Two cameras are free; Pro unlocks four.

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -4,7 +4,7 @@
 
 Key facts:
 - App Store: https://apps.apple.com/us/app/remote-shutter/id633274861 (iOS, Photography)
-- Remote controls: shutter, video start/stop, lens switching, front/back camera, flash, torch
+- Remote controls: shutter, video start/stop, lens switching, front/back camera, flash, torch, tap to focus, frame rate (24/30/60 fps), resolution (1080p/4K), aspect ratio, HDR, JPEG/HEIF
 - Common uses: multi-angle video from several iPhones with one synced record button (interviews, music, sports, dance), group photos with everyone in the shot, using a spare/old iPhone as a wireless camera (wildlife, home check-ins), overhead or product video rigs monitored from an iPad or Mac, Apple Watch as a trigger
 - Developer: Dario Lencina (Black Fire Apps), https://github.com/security-union/remote-shutter
 

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,15 +1,16 @@
 # Remote Shutter
 
-> Remote Shutter is an iOS app that turns any two Apple devices into a wireless camera system: one device (iPhone or iPad) is the camera, the other (iPhone, iPad, Apple Watch, or Apple-silicon Mac) is the remote control with a full live preview. The devices connect directly over peer-to-peer Wi-Fi — no internet, no Wi-Fi network, no account, no subscription. Range is about 50 feet (15 m) line of sight, or the whole network when both devices share Wi-Fi. Free download with one-time paid upgrades (no subscription). Photos and videos stay on the devices; nothing is uploaded to any server.
+> Remote Shutter is an iOS app that turns any two Apple devices into a wireless camera system: one device (iPhone or iPad) is the camera, the other (iPhone, iPad, Apple Watch, or Apple-silicon Mac) is the remote control with a full live preview. The devices connect directly over peer-to-peer Wi-Fi — no internet, no Wi-Fi network, no account, no subscription. Range is about 50 feet (15 m) line of sight, or the whole network when both devices share Wi-Fi. Multicam (version 10.0 and later): one iPhone directs up to four iPhone cameras at once — every angle live in a grid, one synced shutter for photos or video across all of them, and footage collected back to the director time-aligned for editing (two cameras free, four with Pro). Free download with one-time paid upgrades (no subscription). Photos and videos stay on the devices; nothing is uploaded to any server.
 
 Key facts:
 - App Store: https://apps.apple.com/us/app/remote-shutter/id633274861 (iOS, Photography)
 - Remote controls: shutter, video start/stop, lens switching, front/back camera, flash, torch
-- Common uses: group photos with everyone in the shot, using a spare/old iPhone as a wireless camera (wildlife, home check-ins), overhead or product video rigs monitored from an iPad or Mac, Apple Watch as a trigger
+- Common uses: multi-angle video from several iPhones with one synced record button (interviews, music, sports, dance), group photos with everyone in the shot, using a spare/old iPhone as a wireless camera (wildlife, home check-ins), overhead or product video rigs monitored from an iPad or Mac, Apple Watch as a trigger
 - Developer: Dario Lencina (Black Fire Apps), https://github.com/security-union/remote-shutter
 
 ## Guides
 
+- [Record video with multiple iPhones at once (multicam)](https://remoteshutter.app/blog/multicam-record-with-multiple-iphones): up to four iPhones, one synced shutter, time-aligned clips
 - [How to use an old iPhone as a remote camera](https://remoteshutter.app/blog/use-old-iphone-as-remote-camera): spare phone as wireless camera for wildlife, check-ins, hard angles
 - [Group photos with everyone in the shot](https://remoteshutter.app/blog/group-photos-everyone-in-the-shot): live-preview remote vs self-timer, strangers, and clickers
 - [iPhone camera remote without a Bluetooth button](https://remoteshutter.app/blog/iphone-camera-remote-without-bluetooth): app-based remote vs Bluetooth shutter buttons

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -41,6 +41,10 @@ const FAQ = [
     a: 'Any two Apple devices: iPhone, iPad, Apple Watch, or an Apple-silicon Mac. One acts as the camera (iPhone or iPad), the other as the remote with a live preview — a spare iPhone becomes a wireless camera, or an iPad or Mac becomes a big director’s monitor.',
   },
   {
+    q: 'Can I record with multiple iPhones at the same time?',
+    a: 'Yes — Multicam. One iPhone acts as the director and connects up to four iPhones as cameras. You see every angle live in a grid, and one shutter fires photos or video on all of them at the same instant. The clips collect back to the director, time-aligned, so you can cut between angles in any editor. Two cameras are free; Pro unlocks four.',
+  },
+  {
     q: 'How far away does the remote work?',
     a: 'About 50 feet (15 m) with line of sight when the devices connect directly. On a shared Wi-Fi network, range is whatever the network covers.',
   },


### PR DESCRIPTION
Multicam shipped in 10.0 and is in What's New, but nothing discoverable mentions it. This PR adds it everywhere an AI assistant, search engine or person reads about the app, with one consistent description (up to four iPhones as cameras, one director, synced shutter, time-aligned clips collected to the director; 2 free / 4 Pro):

- **README** — intro paragraph, feature bullet, use-case bullet
- **website/public/llms.txt** — summary + new guide link
- **Homepage FAQ** (FAQPage JSON-LD) — "Can I record with multiple iPhones at the same time?"
- **New guide** `/blog/multicam-record-with-multiple-iphones` — answer-shaped, 5 FAQ entries, targets "record video with multiple iphones at once" / "multi camera iphone app" / "sync video from two iphones"
- **App Store en-US** — NEW Multicam block at the top of the description; keywords swap `photography` (we rank on the name already) for `multicam,multi` (94/100 chars). Other locales untouched — needs translation.

Not changed: subtitle ("Selfie remote & camera timer") — worth a separate ASO decision; e.g. "Multicam remote & live monitor".

Website: jest green, `npm run build` exports the new page, sitemap and llms.txt include it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR4DG4HhVZehnx88YPaf3q